### PR TITLE
feat(web): add core layout components (nav, footer, hero, cookie banner)

### DIFF
--- a/src/web/src/App.vue
+++ b/src/web/src/App.vue
@@ -1,5 +1,14 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import AppNav from '@/components/layout/AppNav.vue'
+import AppFooter from '@/components/layout/AppFooter.vue'
+import CookieBanner from '@/components/common/CookieBanner.vue'
+</script>
 
 <template>
-  <RouterView />
+  <div class="flex min-h-screen flex-col bg-slypn-50">
+    <AppNav />
+    <RouterView class="flex-1" />
+    <AppFooter />
+    <CookieBanner />
+  </div>
 </template>

--- a/src/web/src/components/common/CookieBanner.vue
+++ b/src/web/src/components/common/CookieBanner.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { useCookieConsent } from '@/composables/useCookieConsent'
+
+const { choice, accept, decline } = useCookieConsent()
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="choice === null"
+      role="dialog"
+      aria-labelledby="cookie-title"
+      aria-describedby="cookie-desc"
+      class="fixed inset-x-0 bottom-0 z-50 border-t border-slypn-100 bg-white/95 shadow-lg backdrop-blur"
+    >
+      <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-5 md:flex-row md:items-center md:justify-between">
+        <div class="text-sm text-slypn-900/85">
+          <p id="cookie-title" class="font-display font-semibold text-slypn-700">
+            We&rsquo;d like to use cookies
+          </p>
+          <p id="cookie-desc" class="mt-1 max-w-2xl">
+            We use a small number of cookies to understand how the site is used and to improve it.
+            No tracking is loaded until you accept. You can change your mind at any time.
+          </p>
+        </div>
+        <div class="flex shrink-0 gap-2">
+          <button
+            type="button"
+            class="rounded-md border border-slypn-200 bg-white px-4 py-2 text-sm font-semibold text-slypn-700 hover:bg-slypn-50"
+            @click="decline"
+          >
+            Decline
+          </button>
+          <button
+            type="button"
+            class="rounded-md bg-slypn-600 px-4 py-2 text-sm font-semibold text-white hover:bg-slypn-700"
+            @click="accept"
+          >
+            Accept all
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/web/src/components/common/HeroBanner.vue
+++ b/src/web/src/components/common/HeroBanner.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+defineProps<{
+  eyebrow?: string
+  title: string
+  subtitle?: string
+}>()
+</script>
+
+<template>
+  <section class="relative isolate overflow-hidden bg-gradient-to-br from-slypn-50 via-white to-slypn-100">
+    <div class="absolute inset-y-0 right-0 -z-10 hidden w-1/2 bg-[radial-gradient(circle_at_top_right,_var(--tw-gradient-stops))] from-slypn-200/60 to-transparent md:block" />
+
+    <div class="mx-auto max-w-6xl px-6 py-20 sm:py-28">
+      <p
+        v-if="eyebrow"
+        class="font-display text-sm font-semibold uppercase tracking-[0.25em] text-slypn-500"
+      >
+        {{ eyebrow }}
+      </p>
+      <h1 class="mt-3 max-w-3xl text-4xl font-extrabold text-slypn-700 sm:text-5xl md:text-6xl">
+        {{ title }}
+      </h1>
+      <p
+        v-if="subtitle"
+        class="mt-6 max-w-2xl text-lg text-slypn-900/80"
+      >
+        {{ subtitle }}
+      </p>
+
+      <div v-if="$slots.actions" class="mt-10 flex flex-wrap gap-3">
+        <slot name="actions" />
+      </div>
+
+      <div v-if="$slots.default" class="mt-10">
+        <slot />
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/web/src/components/common/TulipIcon.vue
+++ b/src/web/src/components/common/TulipIcon.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+defineProps<{ class?: string }>()
+</script>
+
+<template>
+  <svg
+    viewBox="0 0 32 32"
+    aria-hidden="true"
+    fill="currentColor"
+    :class="$attrs.class as string"
+  >
+    <path d="M16 4c-3.2 2.4-5 5.4-5 8.5 0 1.6.6 3 1.7 4H10c-.7 0-1 .5-.6 1.1l5.7 7.6c.4.5 1.1.5 1.5 0l5.8-7.6c.4-.6.1-1.1-.6-1.1h-2.7c1-1 1.7-2.4 1.7-4 0-3-1.8-6.1-5-8.5z" />
+  </svg>
+</template>

--- a/src/web/src/components/layout/AppFooter.vue
+++ b/src/web/src/components/layout/AppFooter.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import TulipIcon from '@/components/common/TulipIcon.vue'
+
+const year = new Date().getFullYear()
+</script>
+
+<template>
+  <footer class="mt-24 border-t border-slypn-100 bg-slypn-700 text-slypn-50">
+    <div class="mx-auto grid max-w-6xl gap-10 px-6 py-12 md:grid-cols-3">
+      <div>
+        <div class="flex items-center gap-2 font-display text-xl font-extrabold">
+          <TulipIcon class="h-7 w-7 text-tulip" />
+          <span>SLYPN</span>
+        </div>
+        <p class="mt-3 text-sm text-slypn-100/85">
+          South London Younger Parkinson&rsquo;s Network &mdash; a community for
+          working-age people living with Parkinson&rsquo;s in South London.
+        </p>
+      </div>
+
+      <div>
+        <h2 class="font-display text-sm font-semibold uppercase tracking-widest text-tulip">
+          Explore
+        </h2>
+        <ul class="mt-4 space-y-2 text-sm">
+          <li><RouterLink to="/about" class="hover:text-tulip">About</RouterLink></li>
+          <li><RouterLink to="/articles" class="hover:text-tulip">Articles</RouterLink></li>
+          <li><RouterLink to="/events" class="hover:text-tulip">Events</RouterLink></li>
+          <li><RouterLink to="/resources" class="hover:text-tulip">Resources</RouterLink></li>
+          <li><RouterLink to="/newsletter" class="hover:text-tulip">Newsletter</RouterLink></li>
+        </ul>
+      </div>
+
+      <div>
+        <h2 class="font-display text-sm font-semibold uppercase tracking-widest text-tulip">
+          Affiliated with
+        </h2>
+        <p class="mt-4 text-sm text-slypn-100/90">
+          SLYPN is affiliated with
+          <a
+            href="https://www.parkinsons.org.uk/"
+            class="underline underline-offset-4 hover:text-tulip"
+            rel="noopener"
+            target="_blank"
+          >Parkinson&rsquo;s UK</a>,
+          the UK&rsquo;s leading Parkinson&rsquo;s charity.
+        </p>
+        <p class="mt-4 text-xs text-slypn-100/70">
+          For people diagnosed with Parkinson&rsquo;s and in immediate need of support,
+          please contact the
+          <a
+            href="https://www.parkinsons.org.uk/information-and-support/helpline-and-local-advisers"
+            class="underline underline-offset-4 hover:text-tulip"
+            rel="noopener"
+            target="_blank"
+          >Parkinson&rsquo;s UK helpline</a>.
+        </p>
+      </div>
+    </div>
+
+    <div class="border-t border-slypn-600/60">
+      <div class="mx-auto flex max-w-6xl flex-col items-start justify-between gap-3 px-6 py-5 text-xs text-slypn-100/70 sm:flex-row sm:items-center">
+        <p>&copy; {{ year }} South London Younger Parkinson&rsquo;s Network.</p>
+        <p>
+          Built with care &mdash;
+          <a
+            href="https://github.com/sinclapa/slypn"
+            class="underline underline-offset-2 hover:text-tulip"
+            rel="noopener"
+            target="_blank"
+          >source on GitHub</a>.
+        </p>
+      </div>
+    </div>
+  </footer>
+</template>

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import TulipIcon from '@/components/common/TulipIcon.vue'
+
+const navItems = [
+  { to: '/',           label: 'Home' },
+  { to: '/about',      label: 'About' },
+  { to: '/articles',   label: 'Articles' },
+  { to: '/blog',       label: 'Blog' },
+  { to: '/events',     label: 'Events' },
+  { to: '/resources',  label: 'Resources' },
+  { to: '/newsletter', label: 'Newsletter' },
+]
+
+const mobileOpen = ref(false)
+</script>
+
+<template>
+  <header class="sticky top-0 z-40 border-b border-slypn-100 bg-white/85 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between gap-6 px-6 py-4">
+      <RouterLink
+        to="/"
+        class="flex items-center gap-2 font-display text-lg font-extrabold text-slypn-700"
+        @click="mobileOpen = false"
+      >
+        <TulipIcon class="h-7 w-7 text-slypn-500" />
+        <span>SLYPN</span>
+      </RouterLink>
+
+      <nav class="hidden items-center gap-1 md:flex" aria-label="Primary">
+        <RouterLink
+          v-for="item in navItems"
+          :key="item.to"
+          :to="item.to"
+          class="rounded-md px-3 py-2 text-sm font-medium text-slypn-700 transition-colors hover:bg-slypn-50 hover:text-slypn-900"
+          active-class="bg-slypn-50 text-slypn-900"
+          exact-active-class="bg-slypn-100 text-slypn-900"
+        >
+          {{ item.label }}
+        </RouterLink>
+      </nav>
+
+      <div class="hidden md:block">
+        <RouterLink
+          to="/login"
+          class="rounded-md bg-slypn-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-slypn-700"
+        >
+          Sign in
+        </RouterLink>
+      </div>
+
+      <button
+        type="button"
+        class="inline-flex items-center justify-center rounded-md p-2 text-slypn-700 hover:bg-slypn-50 md:hidden"
+        :aria-expanded="mobileOpen"
+        aria-controls="mobile-nav"
+        aria-label="Toggle navigation menu"
+        @click="mobileOpen = !mobileOpen"
+      >
+        <svg v-if="!mobileOpen" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        <svg v-else class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M6 18L18 6" />
+        </svg>
+      </button>
+    </div>
+
+    <nav
+      v-show="mobileOpen"
+      id="mobile-nav"
+      class="border-t border-slypn-100 bg-white md:hidden"
+      aria-label="Mobile primary"
+    >
+      <div class="mx-auto flex max-w-6xl flex-col gap-1 px-4 py-3">
+        <RouterLink
+          v-for="item in navItems"
+          :key="item.to"
+          :to="item.to"
+          class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+          active-class="bg-slypn-50"
+          @click="mobileOpen = false"
+        >
+          {{ item.label }}
+        </RouterLink>
+        <RouterLink
+          to="/login"
+          class="mt-1 rounded-md bg-slypn-600 px-3 py-2 text-center text-base font-semibold text-white hover:bg-slypn-700"
+          @click="mobileOpen = false"
+        >
+          Sign in
+        </RouterLink>
+      </div>
+    </nav>
+  </header>
+</template>

--- a/src/web/src/composables/useCookieConsent.ts
+++ b/src/web/src/composables/useCookieConsent.ts
@@ -1,0 +1,32 @@
+import { ref } from 'vue'
+
+export type ConsentChoice = 'accepted' | 'declined'
+const STORAGE_KEY = 'slypn:cookie-consent'
+
+const stored = (() => {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    return v === 'accepted' || v === 'declined' ? (v as ConsentChoice) : null
+  } catch {
+    return null
+  }
+})()
+
+const choice = ref<ConsentChoice | null>(stored)
+
+function persist(next: ConsentChoice) {
+  choice.value = next
+  try {
+    localStorage.setItem(STORAGE_KEY, next)
+  } catch {
+    /* storage blocked — keep in-memory state only */
+  }
+}
+
+export function useCookieConsent() {
+  return {
+    choice,
+    accept: () => persist('accepted'),
+    decline: () => persist('declined'),
+  }
+}

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -1,9 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '@/views/HomeView.vue'
+import NotFoundView from '@/views/NotFoundView.vue'
 
 export default createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/', name: 'home', component: HomeView },
+    { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFoundView },
   ],
 })

--- a/src/web/src/views/HomeView.vue
+++ b/src/web/src/views/HomeView.vue
@@ -1,27 +1,46 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+</script>
 
 <template>
-  <main class="min-h-screen px-6 py-20">
-    <div class="mx-auto max-w-3xl">
-      <p class="font-display text-sm font-semibold uppercase tracking-[0.2em] text-slypn-500">
-        South London
-      </p>
-      <h1 class="mt-2 text-5xl font-extrabold text-slypn-700 sm:text-6xl">
-        Younger Parkinson&rsquo;s Network
-      </h1>
-      <p class="mt-6 max-w-xl text-lg text-slypn-900/80">
-        A community for working-age people living with Parkinson&rsquo;s in South London.
-        Affiliated with
-        <a href="https://www.parkinsons.org.uk/" class="font-medium text-slypn-600 underline underline-offset-4 hover:text-slypn-700">
-          Parkinson&rsquo;s UK
-        </a>.
-      </p>
-      <p class="mt-12 text-sm text-slypn-900/60">
-        Site under construction &mdash; track progress on
-        <a href="https://github.com/users/sinclapa/projects/2" class="text-slypn-500 underline underline-offset-2 hover:text-slypn-700">
-          GitHub Project #2
-        </a>.
-      </p>
-    </div>
-  </main>
+  <HeroBanner
+    eyebrow="South London"
+    title="Younger Parkinson's Network"
+    subtitle="A community for working-age people living with Parkinson's in South London — coffee meet-ups, drinks, activities, and fundraising events. Affiliated with Parkinson's UK."
+  >
+    <template #actions>
+      <RouterLink
+        to="/about"
+        class="rounded-md bg-slypn-600 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700"
+      >
+        About SLYPN
+      </RouterLink>
+      <RouterLink
+        to="/events"
+        class="rounded-md border border-slypn-200 bg-white px-5 py-3 text-sm font-semibold text-slypn-700 hover:bg-slypn-50"
+      >
+        Upcoming events
+      </RouterLink>
+    </template>
+  </HeroBanner>
+
+  <section class="mx-auto max-w-6xl px-6 py-16">
+    <p class="font-display text-sm font-semibold uppercase tracking-[0.2em] text-slypn-500">
+      Site under construction
+    </p>
+    <h2 class="mt-3 max-w-2xl text-3xl font-extrabold text-slypn-700">
+      We're building this in the open
+    </h2>
+    <p class="mt-4 max-w-2xl text-slypn-900/80">
+      The site is in early development. Track each phase &mdash; scaffold, persistence,
+      auth, authoring, observability, deployment &mdash; on the
+      <a
+        href="https://github.com/users/sinclapa/projects/2"
+        class="text-slypn-600 underline underline-offset-4 hover:text-slypn-700"
+        rel="noopener"
+        target="_blank"
+      >GitHub project board</a>.
+    </p>
+  </section>
 </template>

--- a/src/web/src/views/NotFoundView.vue
+++ b/src/web/src/views/NotFoundView.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { RouterLink, useRoute } from 'vue-router'
+const route = useRoute()
+</script>
+
+<template>
+  <main class="min-h-[60vh] px-6 py-20">
+    <div class="mx-auto max-w-3xl text-center">
+      <p class="font-display text-sm font-semibold uppercase tracking-[0.2em] text-slypn-500">
+        Coming soon
+      </p>
+      <h1 class="mt-3 text-4xl font-extrabold text-slypn-700">
+        We&rsquo;re still building this page
+      </h1>
+      <p class="mt-4 text-slypn-900/80">
+        The page at <code class="rounded bg-slypn-100 px-2 py-0.5 text-slypn-800">{{ route.fullPath }}</code>
+        isn&rsquo;t live yet. Progress is tracked on the
+        <a
+          href="https://github.com/users/sinclapa/projects/2"
+          class="text-slypn-600 underline underline-offset-4 hover:text-slypn-700"
+          rel="noopener"
+          target="_blank"
+        >project board</a>.
+      </p>
+      <RouterLink
+        to="/"
+        class="mt-8 inline-block rounded-md bg-slypn-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-slypn-700"
+      >
+        Back to home
+      </RouterLink>
+    </div>
+  </main>
+</template>


### PR DESCRIPTION
**Stacked on #44** — base is `feat/1.2-vue-scaffold`. After #44 merges, GitHub will auto-retarget this to `main`.

## Summary
- **AppNav** — sticky branded nav with logo + tulip icon, primary RouterLinks for Home/About/Articles/Blog/Events/Resources/Newsletter, a Sign in CTA, and a responsive mobile drawer.
- **AppFooter** — dark navy footer with three columns (intro, explore links, Parkinson's UK affiliation + helpline pointer), plus a thin copyright bar.
- **HeroBanner** — reusable hero with `eyebrow` / `title` / `subtitle` props and named `#actions` + default slots. Subtle radial brand-blue gradient.
- **CookieBanner** — bottom-pinned dialog with Accept/Decline actions; choice persisted to `localStorage` via the new `useCookieConsent` composable. **No telemetry is loaded** — Faro wiring lands in #34.
- **TulipIcon** — small inline-SVG tulip motif used by nav + footer (white-on-navy in the footer, brand-blue in the nav).
- **NotFoundView + catch-all route** — so the nav items that don't yet have a view (Articles/Blog/Events/Resources/Newsletter/Login — land in #5) show a friendly "coming soon" placeholder pointing at the project board, instead of Vue Router warnings.
- **HomeView** now uses HeroBanner with the SLYPN strapline and two CTAs.

## Test plan
- [x] `npm run build` clean — 44 modules (up from 30), 105 KB JS / 13 KB CSS gzipped 40 KB / 3.3 KB.
- [x] Dev server boots; mobile nav toggles open/close; outside paths render NotFoundView.
- [x] Cookie banner appears on first visit; Accept/Decline persists across reloads (`localStorage.slypn:cookie-consent`).
- [x] Keyboard nav works on the mobile toggle (`aria-expanded` / `aria-controls`).
- [ ] CI not yet wired up (lands in #8).

Closes #4