### PR TITLE
feat(web): public views with mock data

### DIFF
--- a/src/web/src/components/common/ArticleCard.vue
+++ b/src/web/src/components/common/ArticleCard.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import type { Article } from '@/types/content'
+
+defineProps<{ article: Article }>()
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+</script>
+
+<template>
+  <article class="flex flex-col rounded-xl border border-slypn-100 bg-white p-6 shadow-sm transition-shadow hover:shadow-md">
+    <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+      {{ article.category }}
+    </p>
+    <h3 class="mt-2 text-xl font-bold text-slypn-700">
+      <RouterLink :to="`/articles/${article.slug}`" class="hover:text-slypn-600">
+        {{ article.title }}
+      </RouterLink>
+    </h3>
+    <p class="mt-3 flex-1 text-sm text-slypn-900/75">{{ article.summary }}</p>
+    <div class="mt-4 flex items-center justify-between text-xs text-slypn-900/60">
+      <span>{{ article.author }}</span>
+      <span>{{ formatDate(article.publishedAt) }} &middot; {{ article.readingMinutes }} min read</span>
+    </div>
+  </article>
+</template>

--- a/src/web/src/components/common/EventCalendar.vue
+++ b/src/web/src/components/common/EventCalendar.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { CommunityEvent } from '@/types/content'
+
+const props = defineProps<{ events: CommunityEvent[] }>()
+
+const today = new Date()
+const cursor = ref(new Date(today.getFullYear(), today.getMonth(), 1))
+
+const monthLabel = computed(() =>
+  cursor.value.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }),
+)
+
+const weeks = computed(() => {
+  const first = new Date(cursor.value)
+  const start = new Date(first)
+  const dayOfWeek = (first.getDay() + 6) % 7 // Monday-first
+  start.setDate(first.getDate() - dayOfWeek)
+
+  const cells: Array<{ date: Date; inMonth: boolean; events: CommunityEvent[] }> = []
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    const dayEvents = props.events.filter(e => {
+      const ed = new Date(e.startsAt)
+      return ed.getFullYear() === d.getFullYear()
+        && ed.getMonth() === d.getMonth()
+        && ed.getDate() === d.getDate()
+    })
+    cells.push({ date: d, inMonth: d.getMonth() === first.getMonth(), events: dayEvents })
+  }
+  const rows = []
+  for (let i = 0; i < 6; i++) rows.push(cells.slice(i * 7, i * 7 + 7))
+  return rows
+})
+
+const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const isToday = (d: Date) =>
+  d.getFullYear() === today.getFullYear()
+  && d.getMonth() === today.getMonth()
+  && d.getDate() === today.getDate()
+
+const shift = (months: number) => {
+  cursor.value = new Date(cursor.value.getFullYear(), cursor.value.getMonth() + months, 1)
+}
+</script>
+
+<template>
+  <div class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
+    <div class="flex items-center justify-between">
+      <h3 class="font-display text-xl font-bold text-slypn-700">{{ monthLabel }}</h3>
+      <div class="flex gap-1">
+        <button
+          type="button"
+          class="rounded-md border border-slypn-200 px-3 py-1 text-sm text-slypn-700 hover:bg-slypn-50"
+          aria-label="Previous month"
+          @click="shift(-1)"
+        >
+          &larr;
+        </button>
+        <button
+          type="button"
+          class="rounded-md border border-slypn-200 px-3 py-1 text-sm text-slypn-700 hover:bg-slypn-50"
+          aria-label="Next month"
+          @click="shift(1)"
+        >
+          &rarr;
+        </button>
+      </div>
+    </div>
+
+    <div class="mt-4 grid grid-cols-7 gap-1 text-center text-xs font-semibold uppercase tracking-wider text-slypn-500">
+      <div v-for="d in weekDays" :key="d">{{ d }}</div>
+    </div>
+
+    <div class="mt-1 grid grid-cols-7 gap-1">
+      <template v-for="(row, ri) in weeks" :key="ri">
+        <div
+          v-for="cell in row"
+          :key="cell.date.toISOString()"
+          :class="[
+            'min-h-[88px] rounded-md border p-1.5 text-left text-xs',
+            cell.inMonth ? 'border-slypn-100 bg-white' : 'border-slypn-50 bg-slypn-50/40 text-slypn-900/40',
+            isToday(cell.date) ? 'ring-2 ring-slypn-500' : '',
+          ]"
+        >
+          <div class="font-semibold">{{ cell.date.getDate() }}</div>
+          <div v-for="e in cell.events" :key="e.id" class="mt-1 truncate rounded bg-slypn-100 px-1.5 py-0.5 text-[11px] text-slypn-800" :title="e.title">
+            {{ e.title }}
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/src/web/src/components/common/EventCard.vue
+++ b/src/web/src/components/common/EventCard.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { CommunityEvent } from '@/types/content'
+
+defineProps<{ event: CommunityEvent }>()
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })
+
+const formatTime = (iso: string) =>
+  new Date(iso).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false })
+</script>
+
+<template>
+  <article class="flex gap-5 rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
+    <div class="flex w-20 flex-shrink-0 flex-col items-center justify-center rounded-lg bg-slypn-50 text-center">
+      <span class="font-display text-2xl font-extrabold text-slypn-700">
+        {{ new Date(event.startsAt).getDate() }}
+      </span>
+      <span class="text-xs font-semibold uppercase tracking-wider text-slypn-500">
+        {{ new Date(event.startsAt).toLocaleDateString('en-GB', { month: 'short' }) }}
+      </span>
+    </div>
+
+    <div class="min-w-0 flex-1">
+      <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+        {{ event.type }}
+      </p>
+      <h3 class="mt-1 truncate text-lg font-bold text-slypn-700">{{ event.title }}</h3>
+      <p class="mt-1 text-sm text-slypn-900/75">{{ event.description }}</p>
+      <div class="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slypn-900/60">
+        <span>{{ formatDate(event.startsAt) }}, {{ formatTime(event.startsAt) }}&ndash;{{ formatTime(event.endsAt) }}</span>
+        <span>{{ event.location }}</span>
+        <a
+          v-if="event.signupUrl"
+          :href="event.signupUrl"
+          target="_blank"
+          rel="noopener"
+          class="text-slypn-600 underline underline-offset-2 hover:text-slypn-700"
+        >Sign up</a>
+      </div>
+    </div>
+  </article>
+</template>

--- a/src/web/src/components/common/NewsletterCard.vue
+++ b/src/web/src/components/common/NewsletterCard.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { Newsletter } from '@/types/content'
+
+defineProps<{ newsletter: Newsletter }>()
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+</script>
+
+<template>
+  <article class="rounded-xl border border-slypn-100 bg-white p-6 shadow-sm">
+    <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+      {{ formatDate(newsletter.issueDate) }}
+    </p>
+    <h3 class="mt-2 text-xl font-bold text-slypn-700">{{ newsletter.title }}</h3>
+    <p class="mt-3 text-sm text-slypn-900/75">{{ newsletter.summary }}</p>
+    <ul class="mt-4 flex flex-wrap gap-2">
+      <li
+        v-for="topic in newsletter.topics"
+        :key="topic"
+        class="rounded-full bg-slypn-50 px-3 py-1 text-xs font-medium text-slypn-700"
+      >
+        {{ topic }}
+      </li>
+    </ul>
+  </article>
+</template>

--- a/src/web/src/components/common/ResourceCard.vue
+++ b/src/web/src/components/common/ResourceCard.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import type { Resource } from '@/types/content'
+
+defineProps<{ resource: Resource }>()
+</script>
+
+<template>
+  <a
+    :href="resource.url"
+    target="_blank"
+    rel="noopener"
+    class="block rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+  >
+    <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+      {{ resource.category }}
+    </p>
+    <h3 class="mt-2 text-lg font-bold text-slypn-700">{{ resource.title }}</h3>
+    <p class="mt-2 text-sm text-slypn-900/75">{{ resource.description }}</p>
+    <p class="mt-3 text-xs text-slypn-600">{{ resource.url.replace(/^https?:\/\//, '') }} &rarr;</p>
+  </a>
+</template>

--- a/src/web/src/mock/articles.ts
+++ b/src/web/src/mock/articles.ts
@@ -1,0 +1,74 @@
+import type { Article } from '@/types/content'
+
+export const mockArticles: Article[] = [
+  {
+    id: 'a1',
+    slug: 'working-with-parkinsons',
+    title: "Living well at work with Parkinson's",
+    summary:
+      "Practical thinking on workplace adjustments, when to disclose, and how to keep doing the job you love after a Parkinson's diagnosis.",
+    body:
+      "A Parkinson's diagnosis at working age often comes with a stack of practical questions about the job. There's no single right answer — much depends on your role, your employer, and your symptoms — but a few things consistently help.\n\nStart by reading the rights you already have. In the UK, Parkinson's is covered by the Equality Act 2010, meaning employers must make reasonable adjustments. That might be flexible hours, voice-to-text software, a quieter workspace, or breaks for medication timing.\n\nWhen to disclose is personal. Many SLYPN members tell us they wished they'd waited — and just as many wish they'd told their manager sooner. There's no universally right moment. What helps is having a clear ask ready when you do.\n\nFinally, the small daily things compound. Lay out clothes the night before. Tackle the hardest task in your best-medication window. Build in recovery. Working with Parkinson's is not the same as working without it; pretending otherwise wears you down.",
+    author: 'Helen Stoinanov',
+    publishedAt: '2026-05-12T09:00:00Z',
+    readingMinutes: 6,
+    category: "Living with Parkinson's",
+    tags: ['work', 'rights', 'adjustments'],
+  },
+  {
+    id: 'a2',
+    slug: 'medication-side-effects',
+    title: 'Understanding the medication side effects no one warned you about',
+    summary:
+      'A frank look at the common (and less common) side effects of the medications most often prescribed for Parkinson’s — and what to do when they show up.',
+    body:
+      "Levodopa is still the most effective treatment for Parkinson's, but the body's relationship with it is messy. Many people experience nausea in the first few weeks, which usually settles. Some find their sleep changes — vivid dreams, sudden tiredness, or difficulty getting off in the first place.\n\nDopamine agonists carry their own profile. Impulse-control issues — sudden cravings to gamble, shop, or eat — are well documented but under-discussed. If you or someone close to you notices new behaviours, it's worth raising with your neurologist; a dose tweak often helps.\n\nWhat we hear most often in our meet-ups is that people would have liked clearer warnings up front. This article is not medical advice — talk to your specialist nurse — but it's the conversation we wish we'd had earlier.",
+    author: 'Kate Wellington',
+    publishedAt: '2026-04-28T09:00:00Z',
+    readingMinutes: 8,
+    category: 'Treatment',
+    tags: ['medication', 'side-effects', 'levodopa'],
+  },
+  {
+    id: 'a3',
+    slug: 'support-network-at-any-age',
+    title: 'Building a support network at any age',
+    summary:
+      'Why peer support matters more than people expect, and how SLYPN works to provide it for the South London under-50s.',
+    body:
+      "We started SLYPN in 2011 because the support that existed at the time wasn't built around working-age people. Daytime groups didn't fit around jobs or school runs. Helen, Kate, and Sarah wanted somewhere informal, in the evenings, where you could talk frankly without having to explain Parkinson's from scratch every time.\n\nFifteen years on, the format has barely changed: coffee meet-ups across South London, occasional drinks, a few activities a year, and the odd fundraiser. What's grown is the membership. We've watched people arrive newly diagnosed and stay long enough to support the next person walking in.\n\nThe best advice we can offer anyone newly diagnosed: don't wait until things feel hard to ask for support. Find your people early.",
+    author: 'Sarah Webb',
+    publishedAt: '2026-04-10T09:00:00Z',
+    readingMinutes: 5,
+    category: 'Community',
+    tags: ['peer-support', 'history', 'founders'],
+  },
+  {
+    id: 'a4',
+    slug: 'sleep-exercise-parkinsons',
+    title: 'Sleep, exercise, and Parkinson’s — what the evidence actually says',
+    summary:
+      'Cutting through the noise on lifestyle interventions: what helps, what doesn’t, and what to try first.',
+    body:
+      "There is no shortage of advice online about lifestyle changes for Parkinson's. Some of it is genuinely useful. Some of it is wishful thinking. A few practical things have decent evidence behind them.\n\nExercise — particularly aerobic and resistance training — has the strongest evidence for slowing symptom progression. The Parkinson's UK Cycle to Beat Parkinson's research and several US studies point in the same direction. The key word is regular: little and often beats heroic but sporadic.\n\nSleep is harder. REM sleep behaviour disorder is common, and so is daytime fatigue. Sleep hygiene basics (consistent times, cool dark room, no screens late) help everyone, but if you suspect a sleep disorder, ask for a referral.\n\nWhat doesn't have evidence: most supplements, most diets marketed as 'Parkinson's diets', most heavily-promoted gadgets. Save the money for things you actually enjoy.",
+    author: 'Helen Stoinanov',
+    publishedAt: '2026-03-22T09:00:00Z',
+    readingMinutes: 7,
+    category: 'Lifestyle',
+    tags: ['sleep', 'exercise', 'evidence'],
+  },
+  {
+    id: 'a5',
+    slug: 'what-to-bring-to-your-first-meetup',
+    title: 'What to bring (and expect) at your first SLYPN meet-up',
+    summary:
+      'A short, practical note for anyone thinking about coming to a meet-up for the first time.',
+    body:
+      "Just yourself. That's the honest answer.\n\nWe meet in coffee shops or pubs around South London, usually for a couple of hours in the evening. There's no introductions round, no name badges, no pressure to talk about Parkinson's if you don't want to. People come along, order whatever they fancy, and end up chatting. Partners and carers are welcome.\n\nIf it would help to know who'll be there, send us a message before — we'll point you toward someone to look out for.",
+    author: 'Kate Wellington',
+    publishedAt: '2026-03-04T09:00:00Z',
+    readingMinutes: 3,
+    category: 'Community',
+    tags: ['newcomers', 'meet-ups'],
+  },
+]

--- a/src/web/src/mock/blog.ts
+++ b/src/web/src/mock/blog.ts
@@ -1,0 +1,37 @@
+import type { BlogPost } from '@/types/content'
+
+export const mockBlogPosts: BlogPost[] = [
+  {
+    id: 'b1',
+    slug: 'brixton-meetup-may-2026',
+    title: 'Brixton coffee meet-up — May recap',
+    excerpt:
+      'Eleven of us, two new faces, far too much cake. A short recap from Tuesday night.',
+    body:
+      "We had eleven members at Federation Coffee in Brixton on Tuesday — two new, both newly diagnosed and brave enough to walk in without knowing anyone. (Thank you both.) Conversation drifted, as it always does, between very serious (medication changes) and completely silly (someone's dog had eaten a passport).\n\nNext South London meet-up is in Clapham on the 28th. See the Events page.",
+    author: 'Sarah Webb',
+    publishedAt: '2026-05-15T20:30:00Z',
+  },
+  {
+    id: 'b2',
+    slug: 'welcome-new-members-q2',
+    title: 'Welcome to our new members',
+    excerpt:
+      'A short hello to the eight people who have joined the network since the start of April.',
+    body:
+      "We've had a busy spring. Eight new people have joined SLYPN since the start of April, taking total membership past 220. If you've signed up recently — welcome. Come to a meet-up, drop a note in the newsletter, or just say hello.",
+    author: 'Helen Stoinanov',
+    publishedAt: '2026-05-02T09:00:00Z',
+  },
+  {
+    id: 'b3',
+    slug: 'thank-you-5k-runners',
+    title: 'Thank you to our 5k runners',
+    excerpt:
+      'Our spring fundraiser raised £4,820 for Parkinson’s UK. Thank you to everyone who ran, walked, or cheered.',
+    body:
+      "Forty of us turned out in Hyde Park on a damp Sunday morning. Between sponsorship and matched donations we raised £4,820 for Parkinson's UK research. Particular thanks to David's team for the post-race coffee run, and to anyone whose knees are still recovering.",
+    author: 'Kate Wellington',
+    publishedAt: '2026-04-21T09:00:00Z',
+  },
+]

--- a/src/web/src/mock/events.ts
+++ b/src/web/src/mock/events.ts
@@ -1,0 +1,74 @@
+import type { CommunityEvent } from '@/types/content'
+
+export const mockEvents: CommunityEvent[] = [
+  {
+    id: 'e1',
+    title: 'Coffee meet-up — Clapham',
+    type: 'Coffee meet-up',
+    startsAt: '2026-05-28T18:30:00+01:00',
+    endsAt: '2026-05-28T20:30:00+01:00',
+    location: 'WatchHouse, Clapham Common SW4',
+    description:
+      'Our regular monthly meet-up. Drop in any time between 6:30 and 8:30. New members very welcome — message us if it helps to know who to look out for.',
+  },
+  {
+    id: 'e2',
+    title: 'Q&A with a movement-disorder neurologist',
+    type: 'Q&A',
+    startsAt: '2026-06-04T19:00:00+01:00',
+    endsAt: '2026-06-04T20:30:00+01:00',
+    location: 'Online (Zoom)',
+    description:
+      "An hour-and-a-half with Dr Priya Iyer (King's College Hospital) covering medication windows, when to consider DBS, and questions submitted in advance.",
+    signupUrl: 'https://example.com/slypn/qa-june',
+  },
+  {
+    id: 'e3',
+    title: 'Summer drinks — Greenwich',
+    type: 'Drinks',
+    startsAt: '2026-06-13T19:00:00+01:00',
+    endsAt: '2026-06-13T22:00:00+01:00',
+    location: 'The Trafalgar Tavern, Greenwich SE10',
+    description:
+      'Our summer social. Partners and carers welcome. Booked the back room, so there will be seats.',
+  },
+  {
+    id: 'e4',
+    title: 'Carer-only catch-up',
+    type: 'Carer session',
+    startsAt: '2026-06-18T19:30:00+01:00',
+    endsAt: '2026-06-18T21:00:00+01:00',
+    location: 'Online (Zoom)',
+    description:
+      'A small group for partners and carers of SLYPN members. Quiet, confidential, hosted by Sarah.',
+  },
+  {
+    id: 'e5',
+    title: 'Coffee meet-up — Dulwich',
+    type: 'Coffee meet-up',
+    startsAt: '2026-06-25T18:30:00+01:00',
+    endsAt: '2026-06-25T20:30:00+01:00',
+    location: 'Romeo Jones, Dulwich Village SE21',
+    description: 'June meet-up. Same format as Clapham — drop in any time.',
+  },
+  {
+    id: 'e6',
+    title: 'Beat Parkinson’s 5k — autumn',
+    type: 'Fundraising',
+    startsAt: '2026-09-20T09:30:00+01:00',
+    endsAt: '2026-09-20T12:00:00+01:00',
+    location: 'Hyde Park, London W2',
+    description:
+      'Our autumn fundraiser for Parkinson’s UK. Run, walk, or cheer — same as the spring event. Sign up via the Parkinson’s UK page.',
+    signupUrl: 'https://example.com/slypn/5k-autumn',
+  },
+  {
+    id: 'e7',
+    title: 'Coffee meet-up — Tooting',
+    type: 'Coffee meet-up',
+    startsAt: '2026-07-23T18:30:00+01:00',
+    endsAt: '2026-07-23T20:30:00+01:00',
+    location: 'Brick House, Tooting SW17',
+    description: 'July meet-up.',
+  },
+]

--- a/src/web/src/mock/newsletters.ts
+++ b/src/web/src/mock/newsletters.ts
@@ -1,0 +1,36 @@
+import type { Newsletter } from '@/types/content'
+
+export const mockNewsletters: Newsletter[] = [
+  {
+    id: 'n1',
+    title: 'May 2026',
+    issueDate: '2026-05-01',
+    summary:
+      'Spring fundraiser write-up, eight new members welcomed, and a heads-up about the autumn 5k.',
+    topics: ['Spring fundraiser', 'New members', 'Autumn 5k', 'Q&A with neurologist'],
+  },
+  {
+    id: 'n2',
+    title: 'April 2026',
+    issueDate: '2026-04-01',
+    summary:
+      'A short feature on medication windows, the spring meet-up schedule, and an introduction from a new member volunteer.',
+    topics: ['Medication windows', 'Meet-up schedule', 'Member feature'],
+  },
+  {
+    id: 'n3',
+    title: 'March 2026',
+    issueDate: '2026-03-01',
+    summary:
+      'Sleep, exercise, and Parkinson’s — a long-form piece — plus the dates for the spring fundraiser.',
+    topics: ['Sleep and exercise', 'Fundraiser dates', 'Carer session announcement'],
+  },
+  {
+    id: 'n4',
+    title: 'February 2026',
+    issueDate: '2026-02-01',
+    summary:
+      'A new year retrospective from the founders, plus thoughts on disclosure at work from members.',
+    topics: ['Founders retrospective', 'Work and disclosure'],
+  },
+]

--- a/src/web/src/mock/resources.ts
+++ b/src/web/src/mock/resources.ts
@@ -1,0 +1,76 @@
+import type { Resource } from '@/types/content'
+
+export const mockResources: Resource[] = [
+  {
+    id: 'r1',
+    title: 'Parkinson’s UK helpline',
+    description:
+      'Free, confidential support from trained advisers. Mon–Fri 9am–7pm, Sat 10am–2pm.',
+    url: 'https://www.parkinsons.org.uk/information-and-support/helpline-and-local-advisers',
+    category: "Parkinson's UK",
+  },
+  {
+    id: 'r2',
+    title: 'Parkinson’s UK — for the newly diagnosed',
+    description:
+      'The single best starting point if you’ve been diagnosed in the last few months.',
+    url: 'https://www.parkinsons.org.uk/information-and-support/newly-diagnosed',
+    category: "Parkinson's UK",
+  },
+  {
+    id: 'r3',
+    title: 'NHS — Parkinson’s disease overview',
+    description:
+      'Plain-English summary of symptoms, treatment, and what to expect from NHS care.',
+    url: 'https://www.nhs.uk/conditions/parkinsons-disease/',
+    category: 'NHS',
+  },
+  {
+    id: 'r4',
+    title: 'King’s College Hospital movement disorders clinic',
+    description:
+      'The specialist movement-disorders unit at King’s College Hospital, Denmark Hill. GP referral required.',
+    url: 'https://www.kch.nhs.uk/services/neurology',
+    category: 'Local',
+  },
+  {
+    id: 'r5',
+    title: 'Deep brain stimulation (DBS) — Parkinson’s UK',
+    description:
+      'What DBS is, who it might suit, and how to be referred for an assessment.',
+    url: 'https://www.parkinsons.org.uk/information-and-support/deep-brain-stimulation',
+    category: "Parkinson's UK",
+  },
+  {
+    id: 'r6',
+    title: 'Personal Independence Payment (PIP)',
+    description:
+      'The main UK benefit you may be entitled to as a working-age adult with Parkinson’s.',
+    url: 'https://www.gov.uk/pip',
+    category: 'Benefits',
+  },
+  {
+    id: 'r7',
+    title: 'Access to Work — disability employment support',
+    description:
+      'A government grant scheme to pay for workplace adjustments your employer cannot reasonably cover.',
+    url: 'https://www.gov.uk/access-to-work',
+    category: 'Benefits',
+  },
+  {
+    id: 'r8',
+    title: 'Carers UK',
+    description:
+      'Advice, peer support, and a helpline specifically for unpaid carers.',
+    url: 'https://www.carersuk.org/',
+    category: 'Carers',
+  },
+  {
+    id: 'r9',
+    title: 'Parkinson’s UK — current research',
+    description:
+      'The charity’s research overview, including ways to take part in clinical studies.',
+    url: 'https://www.parkinsons.org.uk/research',
+    category: 'Research',
+  },
+]

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -1,11 +1,28 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '@/views/HomeView.vue'
+import AboutView from '@/views/AboutView.vue'
+import ArticlesView from '@/views/ArticlesView.vue'
+import ArticleDetailView from '@/views/ArticleDetailView.vue'
+import BlogView from '@/views/BlogView.vue'
+import EventsView from '@/views/EventsView.vue'
+import ResourcesView from '@/views/ResourcesView.vue'
+import NewsletterView from '@/views/NewsletterView.vue'
+import LoginView from '@/views/LoginView.vue'
 import NotFoundView from '@/views/NotFoundView.vue'
 
 export default createRouter({
   history: createWebHistory(),
+  scrollBehavior: () => ({ top: 0 }),
   routes: [
-    { path: '/', name: 'home', component: HomeView },
-    { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFoundView },
+    { path: '/',                  name: 'home',            component: HomeView },
+    { path: '/about',             name: 'about',           component: AboutView },
+    { path: '/articles',          name: 'articles',        component: ArticlesView },
+    { path: '/articles/:slug',    name: 'article-detail',  component: ArticleDetailView },
+    { path: '/blog',              name: 'blog',            component: BlogView },
+    { path: '/events',            name: 'events',          component: EventsView },
+    { path: '/resources',         name: 'resources',       component: ResourcesView },
+    { path: '/newsletter',        name: 'newsletter',      component: NewsletterView },
+    { path: '/login',             name: 'login',           component: LoginView },
+    { path: '/:pathMatch(.*)*',   name: 'not-found',       component: NotFoundView },
   ],
 })

--- a/src/web/src/types/content.ts
+++ b/src/web/src/types/content.ts
@@ -1,0 +1,71 @@
+export type ArticleCategory =
+  | "Living with Parkinson's"
+  | 'Treatment'
+  | 'Community'
+  | 'Lifestyle'
+
+export interface Article {
+  id: string
+  slug: string
+  title: string
+  summary: string
+  body: string
+  author: string
+  publishedAt: string
+  readingMinutes: number
+  category: ArticleCategory
+  tags: string[]
+}
+
+export interface BlogPost {
+  id: string
+  slug: string
+  title: string
+  excerpt: string
+  body: string
+  author: string
+  publishedAt: string
+}
+
+export type EventType =
+  | 'Coffee meet-up'
+  | 'Drinks'
+  | 'Fundraising'
+  | 'Q&A'
+  | 'Carer session'
+  | 'Activity'
+
+export interface CommunityEvent {
+  id: string
+  title: string
+  type: EventType
+  startsAt: string
+  endsAt: string
+  location: string
+  description: string
+  signupUrl?: string
+}
+
+export type ResourceCategory =
+  | "Parkinson's UK"
+  | 'NHS'
+  | 'Local'
+  | 'Benefits'
+  | 'Carers'
+  | 'Research'
+
+export interface Resource {
+  id: string
+  title: string
+  description: string
+  url: string
+  category: ResourceCategory
+}
+
+export interface Newsletter {
+  id: string
+  title: string
+  issueDate: string
+  summary: string
+  topics: string[]
+}

--- a/src/web/src/views/AboutView.vue
+++ b/src/web/src/views/AboutView.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import HeroBanner from '@/components/common/HeroBanner.vue'
+
+const founders = [
+  { name: 'Helen Stoinanov', role: 'Co-founder, 2011' },
+  { name: 'Kate Wellington', role: 'Co-founder, 2011' },
+  { name: 'Sarah Webb',      role: 'Co-founder, 2011' },
+]
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="About"
+    title="A community for working-age South Londoners with Parkinson's"
+    subtitle="Founded in 2011 because the daytime support that existed back then didn't fit around jobs, family, or school runs. Fifteen years on, SLYPN still meets in the evenings — and is now a couple of hundred members strong."
+  />
+
+  <section class="mx-auto max-w-3xl px-6 py-16">
+    <h2 class="font-display text-2xl font-bold text-slypn-700">Who we are</h2>
+    <p class="mt-4 text-slypn-900/85">
+      Around 1 in 20 people diagnosed with Parkinson&rsquo;s is under 40. South London Younger
+      Parkinson&rsquo;s Network (SLYPN) is a support group for the demographic that often
+      can&rsquo;t make daytime meetings: people in work, with young families, with school runs.
+      We&rsquo;re affiliated with
+      <a href="https://www.parkinsons.org.uk/" class="text-slypn-600 underline underline-offset-4 hover:text-slypn-700" rel="noopener" target="_blank">Parkinson&rsquo;s UK</a>.
+    </p>
+
+    <h2 class="mt-12 font-display text-2xl font-bold text-slypn-700">What we do</h2>
+    <ul class="mt-4 space-y-3 text-slypn-900/85">
+      <li>Regular coffee meet-ups across South London &mdash; Brixton, Clapham, Dulwich, Greenwich, Tooting.</li>
+      <li>Occasional drinks evenings and activities.</li>
+      <li>Q&amp;As with neurologists, specialist nurses, and physios.</li>
+      <li>A quieter carer-only session each quarter.</li>
+      <li>Fundraising for Parkinson&rsquo;s UK research.</li>
+    </ul>
+
+    <h2 class="mt-12 font-display text-2xl font-bold text-slypn-700">Founders</h2>
+    <p class="mt-4 text-slypn-900/85">
+      SLYPN was started in 2011 by Helen Stoinanov, Kate Wellington, and Sarah Webb &mdash; three
+      South Londoners who wanted somewhere to talk about Parkinson&rsquo;s frankly, in the evening,
+      without having to explain the basics each time.
+    </p>
+    <ul class="mt-4 grid gap-4 sm:grid-cols-3">
+      <li
+        v-for="f in founders"
+        :key="f.name"
+        class="rounded-xl border border-slypn-100 bg-white p-4"
+      >
+        <p class="font-display font-bold text-slypn-700">{{ f.name }}</p>
+        <p class="mt-1 text-xs text-slypn-900/60">{{ f.role }}</p>
+      </li>
+    </ul>
+
+    <h2 class="mt-12 font-display text-2xl font-bold text-slypn-700">How to join</h2>
+    <p class="mt-4 text-slypn-900/85">
+      Come to a meet-up. Bring whoever you&rsquo;d like with you. There&rsquo;s no membership
+      form to fill in &mdash; just show up. If it would help to know who to look out for, send us
+      a message first.
+    </p>
+  </section>
+</template>

--- a/src/web/src/views/ArticleDetailView.vue
+++ b/src/web/src/views/ArticleDetailView.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import { mockArticles } from '@/mock/articles'
+
+const route = useRoute()
+const article = computed(() =>
+  mockArticles.find(a => a.slug === route.params.slug),
+)
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
+</script>
+
+<template>
+  <article v-if="article" class="mx-auto max-w-3xl px-6 py-16">
+    <RouterLink to="/articles" class="text-sm text-slypn-600 hover:text-slypn-700">
+      &larr; All articles
+    </RouterLink>
+    <p class="mt-6 font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+      {{ article.category }}
+    </p>
+    <h1 class="mt-2 text-4xl font-extrabold text-slypn-700 sm:text-5xl">
+      {{ article.title }}
+    </h1>
+    <p class="mt-4 text-slypn-900/65">
+      {{ article.author }} &middot; {{ formatDate(article.publishedAt) }} &middot; {{ article.readingMinutes }} min read
+    </p>
+    <p class="mt-6 text-xl text-slypn-900/85">{{ article.summary }}</p>
+
+    <div class="prose mt-8 max-w-none text-slypn-900/85">
+      <p v-for="(para, i) in article.body.split('\n\n')" :key="i" class="mt-5 leading-relaxed">
+        {{ para }}
+      </p>
+    </div>
+
+    <ul class="mt-12 flex flex-wrap gap-2">
+      <li
+        v-for="tag in article.tags"
+        :key="tag"
+        class="rounded-full bg-slypn-50 px-3 py-1 text-xs font-medium text-slypn-700"
+      >
+        #{{ tag }}
+      </li>
+    </ul>
+  </article>
+
+  <section v-else class="mx-auto max-w-3xl px-6 py-20 text-center">
+    <h1 class="font-display text-3xl font-bold text-slypn-700">Article not found</h1>
+    <RouterLink to="/articles" class="mt-6 inline-block text-slypn-600 underline underline-offset-4 hover:text-slypn-700">
+      Back to articles
+    </RouterLink>
+  </section>
+</template>

--- a/src/web/src/views/ArticlesView.vue
+++ b/src/web/src/views/ArticlesView.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import ArticleCard from '@/components/common/ArticleCard.vue'
+import { mockArticles } from '@/mock/articles'
+import type { ArticleCategory } from '@/types/content'
+
+const categories: Array<'All' | ArticleCategory> = [
+  'All',
+  "Living with Parkinson's",
+  'Treatment',
+  'Community',
+  'Lifestyle',
+]
+const selected = ref<typeof categories[number]>('All')
+
+const visible = computed(() => {
+  const sorted = [...mockArticles].sort(
+    (a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt),
+  )
+  return selected.value === 'All'
+    ? sorted
+    : sorted.filter(a => a.category === selected.value)
+})
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Articles"
+    title="Considered pieces, written by members"
+    subtitle="Longer-form writing from the SLYPN community on living with Parkinson's, navigating treatment, and the small daily things that make a difference."
+  />
+
+  <section class="mx-auto max-w-6xl px-6 py-16">
+    <div class="flex flex-wrap gap-2">
+      <button
+        v-for="cat in categories"
+        :key="cat"
+        type="button"
+        :class="[
+          'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
+          selected === cat
+            ? 'border-slypn-600 bg-slypn-600 text-white'
+            : 'border-slypn-200 bg-white text-slypn-700 hover:bg-slypn-50',
+        ]"
+        @click="selected = cat"
+      >
+        {{ cat }}
+      </button>
+    </div>
+
+    <div class="mt-8 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <ArticleCard v-for="article in visible" :key="article.id" :article="article" />
+    </div>
+
+    <p v-if="!visible.length" class="mt-12 text-center text-slypn-900/70">
+      No articles in this category yet.
+    </p>
+  </section>
+</template>

--- a/src/web/src/views/BlogView.vue
+++ b/src/web/src/views/BlogView.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import { mockBlogPosts } from '@/mock/blog'
+
+const sorted = [...mockBlogPosts].sort(
+  (a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt),
+)
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Blog"
+    title="Shorter, more frequent updates"
+    subtitle="Meet-up recaps, thank-yous, member news. If you want to write something for the blog, mention it at the next meet-up."
+  />
+
+  <section class="mx-auto max-w-3xl px-6 py-16">
+    <ol class="space-y-12">
+      <li v-for="post in sorted" :key="post.id" class="border-b border-slypn-100 pb-12 last:border-b-0">
+        <p class="text-xs text-slypn-900/60">{{ formatDate(post.publishedAt) }} &middot; {{ post.author }}</p>
+        <h2 class="mt-2 text-2xl font-bold text-slypn-700">{{ post.title }}</h2>
+        <p class="mt-3 text-slypn-900/85">{{ post.excerpt }}</p>
+        <p class="mt-4 whitespace-pre-line text-slypn-900/80">{{ post.body }}</p>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/src/web/src/views/EventsView.vue
+++ b/src/web/src/views/EventsView.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import EventCard from '@/components/common/EventCard.vue'
+import EventCalendar from '@/components/common/EventCalendar.vue'
+import { mockEvents } from '@/mock/events'
+
+const view = ref<'list' | 'calendar'>('list')
+
+const upcoming = computed(() => {
+  const now = Date.now()
+  return [...mockEvents]
+    .filter(e => +new Date(e.startsAt) >= now)
+    .sort((a, b) => +new Date(a.startsAt) - +new Date(b.startsAt))
+})
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Events"
+    title="Coffee meet-ups, drinks, Q&amp;As, and fundraisers"
+    subtitle="Most of our events are evening coffee meet-ups around South London. Drop-in, no booking — just turn up. Partners and carers welcome."
+  >
+    <template #actions>
+      <div class="inline-flex rounded-md border border-slypn-200 bg-white p-1">
+        <button
+          type="button"
+          :class="[
+            'rounded-md px-4 py-1.5 text-sm font-semibold',
+            view === 'list' ? 'bg-slypn-600 text-white' : 'text-slypn-700 hover:bg-slypn-50',
+          ]"
+          @click="view = 'list'"
+        >
+          List
+        </button>
+        <button
+          type="button"
+          :class="[
+            'rounded-md px-4 py-1.5 text-sm font-semibold',
+            view === 'calendar' ? 'bg-slypn-600 text-white' : 'text-slypn-700 hover:bg-slypn-50',
+          ]"
+          @click="view = 'calendar'"
+        >
+          Calendar
+        </button>
+      </div>
+    </template>
+  </HeroBanner>
+
+  <section class="mx-auto max-w-4xl px-6 py-16">
+    <div v-if="view === 'list'" class="space-y-4">
+      <EventCard v-for="event in upcoming" :key="event.id" :event="event" />
+      <p v-if="!upcoming.length" class="text-center text-slypn-900/70">
+        No upcoming events listed.
+      </p>
+    </div>
+
+    <EventCalendar v-else :events="mockEvents" />
+  </section>
+</template>

--- a/src/web/src/views/HomeView.vue
+++ b/src/web/src/views/HomeView.vue
@@ -1,6 +1,25 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
 import HeroBanner from '@/components/common/HeroBanner.vue'
+import ArticleCard from '@/components/common/ArticleCard.vue'
+import EventCard from '@/components/common/EventCard.vue'
+import { mockArticles } from '@/mock/articles'
+import { mockEvents } from '@/mock/events'
+
+const featuredArticles = computed(() =>
+  [...mockArticles]
+    .sort((a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt))
+    .slice(0, 3),
+)
+
+const upcomingEvents = computed(() => {
+  const now = Date.now()
+  return [...mockEvents]
+    .filter(e => +new Date(e.startsAt) >= now)
+    .sort((a, b) => +new Date(a.startsAt) - +new Date(b.startsAt))
+    .slice(0, 3)
+})
 </script>
 
 <template>
@@ -26,21 +45,47 @@ import HeroBanner from '@/components/common/HeroBanner.vue'
   </HeroBanner>
 
   <section class="mx-auto max-w-6xl px-6 py-16">
-    <p class="font-display text-sm font-semibold uppercase tracking-[0.2em] text-slypn-500">
-      Site under construction
-    </p>
-    <h2 class="mt-3 max-w-2xl text-3xl font-extrabold text-slypn-700">
-      We're building this in the open
-    </h2>
-    <p class="mt-4 max-w-2xl text-slypn-900/80">
-      The site is in early development. Track each phase &mdash; scaffold, persistence,
-      auth, authoring, observability, deployment &mdash; on the
-      <a
-        href="https://github.com/users/sinclapa/projects/2"
-        class="text-slypn-600 underline underline-offset-4 hover:text-slypn-700"
-        rel="noopener"
-        target="_blank"
-      >GitHub project board</a>.
-    </p>
+    <div class="flex items-end justify-between gap-4">
+      <div>
+        <p class="font-display text-sm font-semibold uppercase tracking-[0.2em] text-slypn-500">Latest</p>
+        <h2 class="mt-2 text-3xl font-bold text-slypn-700">From our members</h2>
+      </div>
+      <RouterLink to="/articles" class="text-sm font-medium text-slypn-600 hover:text-slypn-700">
+        All articles &rarr;
+      </RouterLink>
+    </div>
+    <div class="mt-8 grid gap-6 md:grid-cols-3">
+      <ArticleCard v-for="a in featuredArticles" :key="a.id" :article="a" />
+    </div>
+  </section>
+
+  <section class="mx-auto max-w-4xl px-6 py-16">
+    <div class="flex items-end justify-between gap-4">
+      <div>
+        <p class="font-display text-sm font-semibold uppercase tracking-[0.2em] text-slypn-500">Coming up</p>
+        <h2 class="mt-2 text-3xl font-bold text-slypn-700">Upcoming events</h2>
+      </div>
+      <RouterLink to="/events" class="text-sm font-medium text-slypn-600 hover:text-slypn-700">
+        All events &rarr;
+      </RouterLink>
+    </div>
+    <div class="mt-8 space-y-4">
+      <EventCard v-for="e in upcomingEvents" :key="e.id" :event="e" />
+    </div>
+  </section>
+
+  <section class="border-t border-slypn-100 bg-white">
+    <div class="mx-auto max-w-3xl px-6 py-16 text-center">
+      <h2 class="font-display text-3xl font-bold text-slypn-700">Get the monthly newsletter</h2>
+      <p class="mt-3 text-slypn-900/80">
+        Meet-up dates, a featured article, fundraising progress, and the odd member story. About five minutes to read.
+      </p>
+      <RouterLink
+        to="/newsletter"
+        class="mt-6 inline-block rounded-md bg-slypn-600 px-6 py-3 text-sm font-semibold text-white hover:bg-slypn-700"
+      >
+        Subscribe
+      </RouterLink>
+    </div>
   </section>
 </template>

--- a/src/web/src/views/LoginView.vue
+++ b/src/web/src/views/LoginView.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import HeroBanner from '@/components/common/HeroBanner.vue'
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Sign in"
+    title="Member sign-in is coming soon"
+    subtitle="We're wiring up sign-in via Entra External ID — with Google and Facebook as social options — as part of Phase 3 of the build. Until then, all public content is available without signing in."
+  />
+
+  <section class="mx-auto max-w-3xl px-6 py-16">
+    <h2 class="font-display text-2xl font-bold text-slypn-700">What sign-in will unlock</h2>
+    <ul class="mt-4 space-y-3 text-slypn-900/85">
+      <li><strong>Members</strong> — a private dashboard, RSVP for events, comment on articles.</li>
+      <li><strong>Contributors</strong> — write articles and blog posts in the browser with autosave; admin approves before publication.</li>
+      <li><strong>Admins</strong> — manage members, articles, events, resources, and the newsletter.</li>
+    </ul>
+
+    <p class="mt-8 text-sm text-slypn-900/70">
+      The detailed plan is on
+      <a
+        href="https://github.com/sinclapa/slypn/issues/18"
+        class="text-slypn-600 underline underline-offset-4 hover:text-slypn-700"
+        rel="noopener"
+        target="_blank"
+      >issue #18 (Phase 3 &mdash; Auth + RBAC)</a>.
+    </p>
+  </section>
+</template>

--- a/src/web/src/views/NewsletterView.vue
+++ b/src/web/src/views/NewsletterView.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import NewsletterCard from '@/components/common/NewsletterCard.vue'
+import { mockNewsletters } from '@/mock/newsletters'
+
+const email = ref('')
+const submitted = ref(false)
+
+function subscribe() {
+  if (!email.value) return
+  submitted.value = true
+  email.value = ''
+}
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Newsletter"
+    title="A monthly note from the SLYPN team"
+    subtitle="Meet-up dates, a featured article, fundraising progress, and the odd member story. About five minutes to read. Free, no tracking."
+  >
+    <template #actions>
+      <form
+        class="flex w-full max-w-md flex-col gap-2 sm:flex-row"
+        @submit.prevent="subscribe"
+      >
+        <input
+          v-model="email"
+          type="email"
+          required
+          placeholder="you@example.com"
+          aria-label="Email address"
+          class="flex-1 rounded-md border border-slypn-200 bg-white px-4 py-2.5 text-sm text-slypn-900 shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+        />
+        <button
+          type="submit"
+          class="rounded-md bg-slypn-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-slypn-700"
+        >
+          Subscribe
+        </button>
+      </form>
+      <p v-if="submitted" class="mt-3 text-sm text-slypn-600">
+        Thank you &mdash; we&rsquo;ll add you to the next issue. (This is a mock form for now.)
+      </p>
+    </template>
+  </HeroBanner>
+
+  <section class="mx-auto max-w-4xl px-6 py-16">
+    <h2 class="font-display text-2xl font-bold text-slypn-700">Past issues</h2>
+    <div class="mt-6 grid gap-5 sm:grid-cols-2">
+      <NewsletterCard
+        v-for="n in mockNewsletters"
+        :key="n.id"
+        :newsletter="n"
+      />
+    </div>
+  </section>
+</template>

--- a/src/web/src/views/ResourcesView.vue
+++ b/src/web/src/views/ResourcesView.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import ResourceCard from '@/components/common/ResourceCard.vue'
+import { mockResources } from '@/mock/resources'
+import type { ResourceCategory } from '@/types/content'
+
+const categories: Array<'All' | ResourceCategory> = [
+  'All',
+  "Parkinson's UK",
+  'NHS',
+  'Local',
+  'Benefits',
+  'Carers',
+  'Research',
+]
+const selected = ref<typeof categories[number]>('All')
+
+const visible = computed(() =>
+  selected.value === 'All'
+    ? mockResources
+    : mockResources.filter(r => r.category === selected.value),
+)
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Resources"
+    title="Where to read more &mdash; or get help today"
+    subtitle="A curated list of links our members come back to most often: the Parkinson's UK helpline and information pages, NHS overviews, local clinics, benefits, and research."
+  />
+
+  <section class="mx-auto max-w-6xl px-6 py-16">
+    <div class="flex flex-wrap gap-2">
+      <button
+        v-for="cat in categories"
+        :key="cat"
+        type="button"
+        :class="[
+          'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
+          selected === cat
+            ? 'border-slypn-600 bg-slypn-600 text-white'
+            : 'border-slypn-200 bg-white text-slypn-700 hover:bg-slypn-50',
+        ]"
+        @click="selected = cat"
+      >
+        {{ cat }}
+      </button>
+    </div>
+
+    <div class="mt-8 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+      <ResourceCard v-for="resource in visible" :key="resource.id" :resource="resource" />
+    </div>
+  </section>
+</template>


### PR DESCRIPTION
## Summary
Implements all the planned public views, sourcing realistic mock content from `src/web/src/mock/`. The full IA from the nav now renders properly — no more "coming soon" placeholders for the main pages.

### New types
`src/web/src/types/content.ts` — shared TS shapes for `Article`, `BlogPost`, `CommunityEvent`, `Resource`, `Newsletter`.

### Mock data
- **5 articles** across "Living with Parkinson's" / Treatment / Community / Lifestyle, written in a SLYPN voice.
- **3 blog posts** — Brixton meet-up recap, welcoming new members, 5k thank-you.
- **7 events** spread across May–Sep 2026 (coffee meet-ups, Q&A, drinks, carer session, fundraiser).
- **9 resources** across Parkinson's UK / NHS / Local / Benefits / Carers / Research.
- **4 newsletter issues** with topic tags.

### New components
`ArticleCard`, `EventCard`, `ResourceCard`, `NewsletterCard`, and a from-scratch `EventCalendar` (Monday-first month grid with prev/next nav and a today highlight).

### Views
| Route | View | Notes |
|---|---|---|
| `/` | HomeView | Hero + 3 latest articles + 3 upcoming events + newsletter CTA. |
| `/about` | AboutView | Origin story, what SLYPN does, the three founders, how to join. |
| `/articles` | ArticlesView | Category filter chips. |
| `/articles/:slug` | ArticleDetailView | Prose layout with tags. |
| `/blog` | BlogView | Chronological list. |
| `/events` | EventsView | List / Calendar toggle. |
| `/resources` | ResourcesView | Category filter chips. |
| `/newsletter` | NewsletterView | Mock subscribe form + past issues grid. |
| `/login` | LoginView | Placeholder pointing at #18 (Phase 3). |

Router also gains `scrollBehavior: () => ({ top: 0 })` so navigation resets scroll.

### Test plan
- [x] `npm run build` clean — 75 modules (up from 44), 139 KB JS / 17 KB CSS gzipped 51 KB / 4 KB.
- [x] All routes render locally with HTTP 200.
- [x] Article detail (`/articles/working-with-parkinsons`) resolves; unknown slug shows the not-found branch.
- [x] Events calendar paginates between months and badges events on the right days.
- [x] Category filters narrow Articles and Resources lists.
- [ ] No real persistence — Cosmos integration lands in Phase 2 (#14).
- [ ] CI not yet wired up (lands in #8).

Closes #5