### PR TITLE
feat(scripts): PowerShell setup/start/stop for the local dev stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ secrets.*
 logs/
 tmp/
 .cache/
+
+# ---- dev scripts ----
+scripts/.runtime/

--- a/scripts/_lib.ps1
+++ b/scripts/_lib.ps1
@@ -1,0 +1,39 @@
+# Shared helpers for setup/start/stop. Dot-source from each script:
+#   . (Join-Path $PSScriptRoot '_lib.ps1')
+
+# Resolve repo root one level up from scripts/.
+$script:RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$script:WebDir   = Join-Path $RepoRoot 'src/web'
+$script:ApiDir   = Join-Path $RepoRoot 'src/api/Slypn.Api'
+
+# Ports we standardise on (Vite default, Functions Core Tools default).
+$script:WebPort = 5173
+$script:ApiPort = 7071
+
+function Write-Step($msg) {
+    Write-Host "==> $msg" -ForegroundColor Cyan
+}
+function Write-Ok($msg) {
+    Write-Host "    $msg" -ForegroundColor Green
+}
+function Write-Warn($msg) {
+    Write-Host "    $msg" -ForegroundColor Yellow
+}
+function Write-Err($msg) {
+    Write-Host "    $msg" -ForegroundColor Red
+}
+
+function Test-Port($port) {
+    return [bool](Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue)
+}
+
+function Stop-Port($port) {
+    $procIds = (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).OwningProcess
+    foreach ($procId in ($procIds | Sort-Object -Unique)) {
+        if ($procId) {
+            $name = (Get-Process -Id $procId -ErrorAction SilentlyContinue).ProcessName
+            Write-Host "    killing PID $procId ($name) on port $port" -ForegroundColor DarkGray
+            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,133 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Verifies prereqs and prepares the SLYPN dev environment.
+
+.DESCRIPTION
+  Checks for Node 20+, the .NET 8 SDK, and Azure Functions Core Tools v4.
+  Installs Functions Core Tools globally via npm if missing. Restores web
+  (npm) and API (dotnet) dependencies, and copies local.settings.sample.json
+  to local.settings.json if not already present.
+
+.EXAMPLE
+  .\scripts\setup.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_lib.ps1')
+
+# --- Node 20+ ---------------------------------------------------------------
+Write-Step 'Checking Node.js'
+$nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+if (-not $nodeCmd) {
+    Write-Err 'Node is not on PATH. Install Node 20+ from https://nodejs.org/.'
+    exit 1
+}
+$nodeVersion = & node --version
+$major = [int]($nodeVersion -replace '^v(\d+)\..*$', '$1')
+if ($major -lt 20) {
+    Write-Err "Node $nodeVersion is too old. Install Node 20+."
+    exit 1
+}
+Write-Ok "Node $nodeVersion"
+
+# --- .NET 8 SDK -------------------------------------------------------------
+Write-Step 'Checking .NET SDK'
+$dotnetCmd = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnetCmd) {
+    Write-Err 'dotnet is not on PATH. Install the .NET 8 SDK from https://dotnet.microsoft.com/.'
+    exit 1
+}
+$sdks = & dotnet --list-sdks
+$hasNet8 = $sdks | Where-Object { $_ -match '^8\.' -or $_ -match '^9\.' }
+if (-not $hasNet8) {
+    Write-Err 'Need a .NET 8 SDK (or 9, which can target net8.0). Install from https://dotnet.microsoft.com/.'
+    exit 1
+}
+Write-Ok "Found a compatible SDK ($(& dotnet --version))"
+
+# --- Azure Functions Core Tools v4 -----------------------------------------
+Write-Step 'Checking Azure Functions Core Tools'
+$funcCmd  = Get-Command func -ErrorAction SilentlyContinue
+$funcHome = Join-Path $env:LOCALAPPDATA 'AzureFunctionsCoreTools'
+
+# If our standard install dir already has func.exe, just ensure it's on PATH.
+if (-not $funcCmd -and (Test-Path (Join-Path $funcHome 'func.exe'))) {
+    $env:PATH = "$funcHome;$env:PATH"
+    $funcCmd = Get-Command func -ErrorAction SilentlyContinue
+}
+
+if (-not $funcCmd) {
+    Write-Warn 'func not found. Downloading the standalone CLI from the Azure releases...'
+    # Pin to a known-good min build (smaller, ~65 MB; uses system .NET). Override
+    # via $env:SLYPN_FUNC_VERSION if you want a specific release.
+    $funcVersionPin = if ($env:SLYPN_FUNC_VERSION) { $env:SLYPN_FUNC_VERSION } else { '4.12.0' }
+    $zipUrl = "https://github.com/Azure/azure-functions-core-tools/releases/download/$funcVersionPin/Azure.Functions.Cli.min.win-x64.$funcVersionPin.zip"
+    $zipPath = Join-Path $env:TEMP "func-cli-$funcVersionPin.zip"
+    try {
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath
+        if (Test-Path $funcHome) { Remove-Item $funcHome -Recurse -Force }
+        Expand-Archive -Path $zipPath -DestinationPath $funcHome -Force
+        Remove-Item $zipPath -ErrorAction SilentlyContinue
+        $env:PATH = "$funcHome;$env:PATH"
+        # Persist for future shells.
+        $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+        if ($userPath -notmatch [regex]::Escape($funcHome)) {
+            $userPathNew = if ($userPath) { "$funcHome;$userPath" } else { $funcHome }
+            [Environment]::SetEnvironmentVariable('PATH', $userPathNew, 'User')
+            Write-Warn "Added $funcHome to User PATH (effective in new shells)."
+        }
+        $funcCmd = Get-Command func -ErrorAction SilentlyContinue
+    } catch {
+        Write-Err "Failed to download/extract Functions Core Tools: $_"
+        Write-Err 'Install manually from https://learn.microsoft.com/azure/azure-functions/functions-run-local.'
+        exit 1
+    }
+}
+
+if ($funcCmd) {
+    $funcVersion = (& func --version) 2>&1 | Select-Object -First 1
+    Write-Ok "func $funcVersion"
+} else {
+    Write-Err 'func installation appeared to succeed but the command is still missing on PATH.'
+    exit 1
+}
+
+# --- web deps ---------------------------------------------------------------
+Write-Step "npm ci in $WebDir"
+Push-Location $WebDir
+try {
+    npm ci --no-fund --no-audit
+    if ($LASTEXITCODE -ne 0) { throw 'npm ci failed' }
+    Write-Ok 'web dependencies installed'
+}
+finally { Pop-Location }
+
+# --- API deps ---------------------------------------------------------------
+Write-Step "dotnet restore in $ApiDir"
+Push-Location $ApiDir
+try {
+    dotnet restore
+    if ($LASTEXITCODE -ne 0) { throw 'dotnet restore failed' }
+    Write-Ok 'API dependencies restored'
+}
+finally { Pop-Location }
+
+# --- local.settings.json ----------------------------------------------------
+Write-Step 'Local Functions settings'
+$localSettings  = Join-Path $ApiDir 'local.settings.json'
+$sampleSettings = Join-Path $ApiDir 'local.settings.sample.json'
+if (Test-Path $localSettings) {
+    Write-Ok 'local.settings.json already exists'
+} else {
+    Copy-Item $sampleSettings $localSettings
+    Write-Ok 'Created local.settings.json from local.settings.sample.json'
+}
+
+Write-Host ''
+Write-Host 'Setup complete.' -ForegroundColor Green
+Write-Host "Next: .\scripts\start.ps1" -ForegroundColor Green

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -1,0 +1,126 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Boots the Vue dev server and the .NET Functions host side-by-side.
+
+.DESCRIPTION
+  Starts:
+    - vite (web)        on http://localhost:5173/
+    - func (API)        on http://localhost:7071/
+  Both are launched as background jobs whose logs stream to
+  scripts/.runtime/<web|api>.log. PIDs are written to scripts/.runtime/pids.json
+  so stop.ps1 can shut them down cleanly. The script waits until both ports
+  respond, then prints URLs and returns control. Ctrl+C does NOT stop the
+  servers — use stop.ps1.
+
+.EXAMPLE
+  .\scripts\start.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_lib.ps1')
+
+$runtimeDir = Join-Path $PSScriptRoot '.runtime'
+if (-not (Test-Path $runtimeDir)) { New-Item -ItemType Directory -Path $runtimeDir | Out-Null }
+$webLog  = Join-Path $runtimeDir 'web.log'
+$apiLog  = Join-Path $runtimeDir 'api.log'
+$pidFile = Join-Path $runtimeDir 'pids.json'
+
+# Refuse to start if anything is already on the ports.
+foreach ($p in @($WebPort, $ApiPort)) {
+    if (Test-Port $p) {
+        Write-Err "Port $p is already in use. Run .\scripts\stop.ps1 first."
+        exit 1
+    }
+}
+
+# Ensure local.settings.json exists (don't fail noisily — setup.ps1 covers this).
+$localSettings = Join-Path $ApiDir 'local.settings.json'
+if (-not (Test-Path $localSettings)) {
+    $sample = Join-Path $ApiDir 'local.settings.sample.json'
+    if (Test-Path $sample) {
+        Copy-Item $sample $localSettings
+        Write-Warn 'Created local.settings.json from sample (run setup.ps1 if anything else looks off).'
+    }
+}
+
+# Resolve a real Win32 executable (Start-Process can't launch .ps1 shims).
+function Resolve-WinExe($name) {
+    # Prefer .cmd / .exe forms over PowerShell .ps1 shims that npm/Functions install.
+    foreach ($suffix in @('.exe', '.cmd', '.bat', '')) {
+        $cmd = Get-Command "$name$suffix" -ErrorAction SilentlyContinue |
+               Where-Object { $_.Source -match '\.(exe|cmd|bat)$' } |
+               Select-Object -First 1
+        if ($cmd) { return $cmd.Source }
+    }
+    return $null
+}
+
+# --- web --------------------------------------------------------------------
+Write-Step 'Starting Vite (web)'
+$npmExe = Resolve-WinExe 'npm'
+if (-not $npmExe) { Write-Err 'npm.cmd not on PATH'; exit 1 }
+$webProc = Start-Process -FilePath $npmExe -ArgumentList 'run', 'dev' `
+    -WorkingDirectory $WebDir `
+    -RedirectStandardOutput $webLog `
+    -RedirectStandardError  "$webLog.err" `
+    -WindowStyle Hidden -PassThru
+Write-Ok "vite PID $($webProc.Id), logging to $webLog"
+
+# --- API --------------------------------------------------------------------
+Write-Step 'Starting Functions host (API)'
+$funcExe = Resolve-WinExe 'func'
+if (-not $funcExe) {
+    # Fall back to our standard install location used by setup.ps1.
+    $funcHome = Join-Path $env:LOCALAPPDATA 'AzureFunctionsCoreTools'
+    $candidate = Join-Path $funcHome 'func.exe'
+    if (Test-Path $candidate) { $funcExe = $candidate }
+}
+if (-not $funcExe) {
+    Write-Err 'func not on PATH. Run setup.ps1 first.'
+    Stop-Process -Id $webProc.Id -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+$apiProc = Start-Process -FilePath $funcExe -ArgumentList 'start' `
+    -WorkingDirectory $ApiDir `
+    -RedirectStandardOutput $apiLog `
+    -RedirectStandardError  "$apiLog.err" `
+    -WindowStyle Hidden -PassThru
+Write-Ok "func PID $($apiProc.Id), logging to $apiLog"
+
+# Persist PIDs so stop.ps1 has something to kill.
+@{ web = $webProc.Id; api = $apiProc.Id } | ConvertTo-Json | Out-File -FilePath $pidFile -Encoding UTF8
+
+# --- wait until both ports respond -----------------------------------------
+function Wait-Port($port, $timeoutSec) {
+    $start = Get-Date
+    while (((Get-Date) - $start).TotalSeconds -lt $timeoutSec) {
+        if (Test-Port $port) { return $true }
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
+}
+
+Write-Step 'Waiting for ports to come up'
+if (-not (Wait-Port $WebPort 30)) {
+    Write-Err "vite did not start on $WebPort within 30s. See $webLog."
+    exit 1
+}
+Write-Ok "vite ready on http://localhost:$WebPort/"
+
+if (-not (Wait-Port $ApiPort 90)) {
+    Write-Err "func did not start on $ApiPort within 90s. See $apiLog."
+    exit 1
+}
+Write-Ok "func ready on http://localhost:$ApiPort/"
+
+Write-Host ''
+Write-Host 'Both servers are up.' -ForegroundColor Green
+Write-Host "  Web:  http://localhost:$WebPort/" -ForegroundColor Green
+Write-Host "  API:  http://localhost:$ApiPort/api/articles" -ForegroundColor Green
+Write-Host ''
+Write-Host "Logs:  $runtimeDir" -ForegroundColor DarkGray
+Write-Host "Stop:  .\scripts\stop.ps1" -ForegroundColor DarkGray

--- a/scripts/stop.ps1
+++ b/scripts/stop.ps1
@@ -1,0 +1,56 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Stops the local Vue + Functions dev stack started by start.ps1.
+
+.DESCRIPTION
+  First tries the PIDs persisted by start.ps1 in scripts/.runtime/pids.json.
+  Falls back to killing whatever is listening on ports 5173 and 7071. Safe
+  to run repeatedly.
+
+.EXAMPLE
+  .\scripts\stop.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_lib.ps1')
+
+$runtimeDir = Join-Path $PSScriptRoot '.runtime'
+$pidFile    = Join-Path $runtimeDir 'pids.json'
+
+if (Test-Path $pidFile) {
+    Write-Step 'Stopping by recorded PIDs'
+    $procIds = Get-Content $pidFile -Raw | ConvertFrom-Json
+    foreach ($key in @('web', 'api')) {
+        $procId = $procIds.$key
+        if ($procId) {
+            $name = (Get-Process -Id $procId -ErrorAction SilentlyContinue).ProcessName
+            if ($name) {
+                Write-Host "    killing PID $procId ($name) [$key]" -ForegroundColor DarkGray
+                # Kill the whole process tree (Start-Process spawns npm.cmd which spawns node).
+                Get-CimInstance Win32_Process |
+                    Where-Object { $_.ParentProcessId -eq $procId } |
+                    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+                Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+    Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+}
+
+# Sweep ports as a safety net (catches orphaned children).
+Write-Step "Sweeping ports $WebPort and $ApiPort"
+Stop-Port $WebPort
+Stop-Port $ApiPort
+
+Start-Sleep -Milliseconds 500
+foreach ($p in @($WebPort, $ApiPort)) {
+    if (Test-Port $p) {
+        Write-Warn "Port $p still in use."
+    } else {
+        Write-Ok "Port $p free"
+    }
+}


### PR DESCRIPTION
## Summary
Three PowerShell scripts that take the dev experience from "follow a README" to "one command per phase".

### `scripts/setup.ps1`
- Checks Node 20+ and a .NET 8-compatible SDK (.NET 9 SDK targeting net8.0 is accepted).
- If Azure Functions Core Tools is missing: downloads the official **standalone min build** (~65 MB) from the `Azure/azure-functions-core-tools` GitHub release, extracts to `%LOCALAPPDATA%\AzureFunctionsCoreTools`, and adds it to the user PATH. (The npm path is gone: `npm install -g azure-functions-core-tools@4` currently fails on Node 22 with `ERR_REQUIRE_ESM`.)
- Runs `npm ci` in `src/web` and `dotnet restore` in `src/api/Slypn.Api`.
- Copies `local.settings.sample.json` → `local.settings.json` if absent.

### `scripts/start.ps1`
- Launches Vite (`npm.cmd run dev`) and the Functions host (`func.exe start`) as background processes.
- stdout/stderr go to `scripts/.runtime/{web,api}.log` (gitignored).
- Persists both PIDs to `scripts/.runtime/pids.json` so stop.ps1 can clean up reliably.
- Refuses to start if either `:5173` or `:7071` is already occupied — points at stop.ps1.
- Waits for both ports to listen before printing URLs.

### `scripts/stop.ps1`
- Reads `pids.json`, kills the child trees of those PIDs.
- Sweeps anything still on `:5173` and `:7071` as a safety net (handles orphaned children when scripts/.runtime is missing).

### `scripts/_lib.ps1`
Shared helpers (`Write-Step/Ok/Warn/Err`, `Test-Port`, `Stop-Port`, repo-rooted paths).

### Test plan
- [x] `.\scripts\setup.ps1` — completes clean on a fresh checkout.
- [x] `.\scripts\start.ps1` — both servers up; URLs printed.
- [x] `curl http://localhost:7071/api/articles` → 200, returns 5 articles.
- [x] `curl http://localhost:7071/api/articles/working-with-parkinsons` → 200.
- [x] `curl http://localhost:7071/api/articles/nope` → 404.
- [x] `curl http://localhost:7071/api/events|/api/resources|/api/newsletters` → 200.
- [x] `.\scripts\stop.ps1` — both ports free, PIDs cleared.
- [ ] CI not yet wired up (lands in #8).

Closes #7