### PR TITLE
feat(api): Cosmos data-model doc + bootstrap on startup

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,46 @@
+# SLYPN data model
+
+This document describes the Cosmos DB schema for SLYPN — containers, partition keys, and the rationale for each choice. Bootstrapping logic lives in `src/api/Slypn.Api/Infrastructure/CosmosBootstrapper.cs`.
+
+## Why Cosmos free tier
+
+All data lives in a single Cosmos DB account on the **free tier** (one per Azure subscription, free forever): 1000 RU/s shared across all containers, 25 GB storage. To stay inside it we keep:
+
+- Documents small. Article bodies are bounded at ~10 KB; everything else is well under 1 KB.
+- Containers few (one per content type).
+- Write rate low. This is a small community site with a few writes per day.
+
+## Containers and partition keys
+
+| Container | Partition key | Why |
+|---|---|---|
+| `articles` | `/status` | Public reads are heavily biased to `status = "published"`. Partitioning on status makes the most common query a single-partition lookup. Trade-off: cross-partition list when an admin wants "everything by author X, any status" — rare and acceptable. |
+| `drafts` | `/authorId` | Drafts are private. Every query either starts with "show me my drafts" (contributor view) or "drafts pending review by X" (admin). Partitioning on `authorId` keeps those single-partition. |
+| `events` | `/yearMonth` (e.g. `2026-05`) | Listing events is almost always by date range, and the home page + Events page need "this month + next month". A year-month partition keeps that to one or two partition reads. The API derives `yearMonth` from `startsAt` on write. |
+| `resources` | `/category` | The Resources page filters by category (chips). Partitioning matches the access pattern. Small partitions (9 entries today) — fine forever. |
+| `newsletters` | `/year` (four digits) | Archive views are by year; ~12 issues per partition per year. Cheap. |
+| `members` | `/id` | Single-row reads by member id dominate (auth flows + admin lookup). One row per partition is unusual but correct for this access pattern — we never list "all members in partition X". |
+
+## Trade-offs explicitly accepted
+
+- **`articles` partition on `/status`** creates a hot partition for `published` (the vast majority of reads). For a community site at our scale (hundreds of articles, light traffic) this is fine; if write throughput on `published` ever becomes a problem we'd shard by `yearPublished` or move to a composite key.
+- **`events` requires `yearMonth` on write**. Computed in the API, not user-provided. If a write skips it, validation rejects.
+- **`members /id` is one row per partition**. Unusual, but it matches every access we need.
+- **Shared throughput across containers** (free tier is database-level). Means a hot container can starve quiet ones. With our traffic profile, no risk.
+
+## Bootstrap
+
+`CosmosBootstrapper` is an `IHostedService` registered in `Program.cs`. On startup it:
+
+1. Reads `Cosmos:Endpoint`, `Cosmos:Key`, `Cosmos:Database` from configuration (`local.settings.json` for dev, app settings for prod).
+2. If the endpoint/key are missing, **skips silently** and logs a hint — the API still starts with mock data, which is the current state before #14 wires reads to Cosmos.
+3. Calls `CreateDatabaseIfNotExistsAsync` and `CreateContainerIfNotExistsAsync` for each entry in the table above.
+4. When the endpoint is `localhost`/`127.0.0.1`, accepts the emulator's self-signed certificate.
+
+The bootstrapper is idempotent — safe to call on every startup, in dev or prod.
+
+## Next
+
+- **#12** — a `CosmosService` wrapper exposing typed container handles via DI.
+- **#13** — Blob Storage for media (article images).
+- **#14** — replace the mock read endpoints with Cosmos reads.

--- a/src/api/Slypn.Api/Infrastructure/CosmosBootstrapper.cs
+++ b/src/api/Slypn.Api/Infrastructure/CosmosBootstrapper.cs
@@ -1,0 +1,71 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Slypn.Api.Infrastructure;
+
+/// <summary>
+/// Creates the SLYPN database and the six content containers on startup
+/// if Cosmos is configured. No-op when Endpoint/Key are absent so the API
+/// keeps starting on a fresh checkout (still serves mock data until #14).
+/// </summary>
+public sealed class CosmosBootstrapper(
+    IOptions<CosmosOptions> options,
+    ILogger<CosmosBootstrapper> logger) : IHostedService
+{
+    // Partition keys per docs/data-model.md.
+    private static readonly (string Container, string PartitionKey)[] Containers =
+    [
+        ("articles",    "/status"),
+        ("drafts",      "/authorId"),
+        ("events",      "/yearMonth"),
+        ("resources",   "/category"),
+        ("newsletters", "/year"),
+        ("members",     "/id"),
+    ];
+
+    public async Task StartAsync(CancellationToken ct)
+    {
+        var opts = options.Value;
+        if (string.IsNullOrWhiteSpace(opts.Endpoint) || string.IsNullOrWhiteSpace(opts.Key))
+        {
+            logger.LogInformation(
+                "Cosmos endpoint/key not configured; skipping bootstrap. The API will continue with mock data.");
+            return;
+        }
+
+        var isLocalEmulator =
+            opts.Endpoint.Contains("localhost", StringComparison.OrdinalIgnoreCase) ||
+            opts.Endpoint.Contains("127.0.0.1", StringComparison.Ordinal);
+
+        var clientOptions = new CosmosClientOptions
+        {
+            ConnectionMode = ConnectionMode.Gateway,
+            ApplicationName = "Slypn.Api",
+        };
+        if (isLocalEmulator)
+        {
+            // Cosmos DB Linux Emulator uses a self-signed cert in dev.
+            clientOptions.HttpClientFactory = () => new HttpClient(new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+            });
+        }
+
+        using var client = new CosmosClient(opts.Endpoint, opts.Key, clientOptions);
+
+        var dbResponse = await client.CreateDatabaseIfNotExistsAsync(opts.Database, cancellationToken: ct);
+        logger.LogInformation("Cosmos database ready: {Database}", opts.Database);
+
+        foreach (var (container, partitionKey) in Containers)
+        {
+            await dbResponse.Database.CreateContainerIfNotExistsAsync(
+                new ContainerProperties(container, partitionKey),
+                cancellationToken: ct);
+            logger.LogInformation("Cosmos container ready: {Container} ({PartitionKey})", container, partitionKey);
+        }
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/src/api/Slypn.Api/Infrastructure/CosmosOptions.cs
+++ b/src/api/Slypn.Api/Infrastructure/CosmosOptions.cs
@@ -1,0 +1,10 @@
+namespace Slypn.Api.Infrastructure;
+
+public sealed class CosmosOptions
+{
+    public const string SectionName = "Cosmos";
+
+    public string? Endpoint { get; set; }
+    public string? Key      { get; set; }
+    public string  Database { get; set; } = "slypn";
+}

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -1,12 +1,20 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Slypn.Api.Infrastructure;
 using Slypn.Api.Services;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
-    .ConfigureServices(services =>
+    .ConfigureServices((context, services) =>
     {
         services.AddSingleton<IMockDataService, MockDataService>();
+
+        services
+            .AddOptions<CosmosOptions>()
+            .Bind(context.Configuration.GetSection(CosmosOptions.SectionName));
+
+        services.AddHostedService<CosmosBootstrapper>();
     })
     .Build();
 

--- a/src/api/Slypn.Api/Slypn.Api.csproj
+++ b/src/api/Slypn.Api/Slypn.Api.csproj
@@ -9,9 +9,12 @@
     <UserSecretsId>slypn-api-dev</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/api/Slypn.Api/local.settings.sample.json
+++ b/src/api/Slypn.Api/local.settings.sample.json
@@ -3,7 +3,10 @@
   "Values": {
     "AzureWebJobsStorage": "",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "ASPNETCORE_URLS": "http://localhost:7071"
+    "ASPNETCORE_URLS": "http://localhost:7071",
+    "Cosmos__Endpoint": "https://localhost:8081/",
+    "Cosmos__Key": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+    "Cosmos__Database": "slypn"
   },
   "Host": {
     "CORS": "http://localhost:5173",


### PR DESCRIPTION
## Summary
First step of Phase 2 — design the data layer and lay the bootstrap rails. Endpoints still return mock data; #14 swaps in real Cosmos reads.

### `docs/data-model.md`
Defines six containers with explicit partition-key rationale:
- `articles` `/status`
- `drafts` `/authorId`
- `events` `/yearMonth` (derived from `startsAt` on write)
- `resources` `/category`
- `newsletters` `/year`
- `members` `/id`

Each row documents the access pattern that motivates the choice; trade-offs accepted (hot `published` articles partition, single-row member partitions) are called out so future-us doesn't second-guess.

### `Infrastructure/CosmosBootstrapper.cs`
`IHostedService` that, on startup:
1. Reads `Cosmos:Endpoint`, `Cosmos:Key`, `Cosmos:Database`.
2. **Skips silently** with a hint log if endpoint/key are absent — the API still starts and serves mock data, which is the current state until #14.
3. `CreateDatabaseIfNotExistsAsync` + `CreateContainerIfNotExistsAsync` for each container.
4. Accepts the emulator's self-signed cert when the endpoint is `localhost`/`127.0.0.1`.

Idempotent — safe on every startup, dev or prod.

### Other changes
- `CosmosOptions.cs` — config-bound POCO.
- `Program.cs` — registers options + hosted service.
- `local.settings.sample.json` — ships the well-known emulator endpoint + key + database `slypn` for #17's emulator wiring.
- `Slypn.Api.csproj` — adds `Microsoft.Azure.Cosmos 3.46.0` and the explicit `Newtonsoft.Json 13.0.3` reference Cosmos 3.x requires.

### Test plan
- [x] `dotnet build` clean.
- [x] API still starts without Cosmos config (the no-op path) — bootstrapper logs the skip and the existing mock endpoints continue serving.
- [ ] End-to-end emulator wiring + container creation: #17.
- [ ] Real reads against Cosmos: #14.
- [ ] CI green.

Closes #11