### PR TITLE
feat(api): CosmosService wrapper as the single Cosmos entry point

### DIFF
--- a/src/api/Slypn.Api/Infrastructure/CosmosBootstrapper.cs
+++ b/src/api/Slypn.Api/Infrastructure/CosmosBootstrapper.cs
@@ -1,17 +1,17 @@
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Slypn.Api.Services;
 
 namespace Slypn.Api.Infrastructure;
 
 /// <summary>
-/// Creates the SLYPN database and the six content containers on startup
-/// if Cosmos is configured. No-op when Endpoint/Key are absent so the API
-/// keeps starting on a fresh checkout (still serves mock data until #14).
+/// Creates the SLYPN database and the six content containers on startup.
+/// Uses the singleton <see cref="ICosmosService"/> so we don't open a second
+/// client. No-op when Cosmos is not configured.
 /// </summary>
 public sealed class CosmosBootstrapper(
-    IOptions<CosmosOptions> options,
+    ICosmosService cosmos,
     ILogger<CosmosBootstrapper> logger) : IHostedService
 {
     // Partition keys per docs/data-model.md.
@@ -27,36 +27,16 @@ public sealed class CosmosBootstrapper(
 
     public async Task StartAsync(CancellationToken ct)
     {
-        var opts = options.Value;
-        if (string.IsNullOrWhiteSpace(opts.Endpoint) || string.IsNullOrWhiteSpace(opts.Key))
+        if (!cosmos.IsConfigured)
         {
             logger.LogInformation(
-                "Cosmos endpoint/key not configured; skipping bootstrap. The API will continue with mock data.");
+                "Cosmos not configured; skipping container bootstrap. The API continues with mock data.");
             return;
         }
 
-        var isLocalEmulator =
-            opts.Endpoint.Contains("localhost", StringComparison.OrdinalIgnoreCase) ||
-            opts.Endpoint.Contains("127.0.0.1", StringComparison.Ordinal);
-
-        var clientOptions = new CosmosClientOptions
-        {
-            ConnectionMode = ConnectionMode.Gateway,
-            ApplicationName = "Slypn.Api",
-        };
-        if (isLocalEmulator)
-        {
-            // Cosmos DB Linux Emulator uses a self-signed cert in dev.
-            clientOptions.HttpClientFactory = () => new HttpClient(new HttpClientHandler
-            {
-                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-            });
-        }
-
-        using var client = new CosmosClient(opts.Endpoint, opts.Key, clientOptions);
-
-        var dbResponse = await client.CreateDatabaseIfNotExistsAsync(opts.Database, cancellationToken: ct);
-        logger.LogInformation("Cosmos database ready: {Database}", opts.Database);
+        var dbResponse = await cosmos.Client.CreateDatabaseIfNotExistsAsync(
+            cosmos.Database.Id, cancellationToken: ct);
+        logger.LogInformation("Cosmos database ready: {Database}", cosmos.Database.Id);
 
         foreach (var (container, partitionKey) in Containers)
         {

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -14,6 +14,7 @@ var host = new HostBuilder()
             .AddOptions<CosmosOptions>()
             .Bind(context.Configuration.GetSection(CosmosOptions.SectionName));
 
+        services.AddSingleton<ICosmosService, CosmosService>();
         services.AddHostedService<CosmosBootstrapper>();
     })
     .Build();

--- a/src/api/Slypn.Api/Services/CosmosService.cs
+++ b/src/api/Slypn.Api/Services/CosmosService.cs
@@ -1,0 +1,87 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Slypn.Api.Infrastructure;
+
+namespace Slypn.Api.Services;
+
+/// <summary>
+/// Singleton wrapper around <see cref="CosmosClient"/> for the SLYPN API.
+///
+/// Auth modes:
+///   - dev    : key-based (emulator + cert bypass when endpoint is localhost)
+///   - prod   : key-based for now; Managed Identity wiring lands in #38 (Phase 6)
+///              — swap to `new CosmosClient(endpoint, new DefaultAzureCredential(), options)`.
+///
+/// If the configuration section is empty the service exposes IsConfigured=false
+/// and every other property throws. Callers must check the flag first.
+/// </summary>
+public sealed class CosmosService : ICosmosService, IDisposable
+{
+    private readonly CosmosClient? _client;
+    private readonly Database?     _database;
+    private readonly string?       _databaseId;
+
+    public CosmosService(IOptions<CosmosOptions> options, ILogger<CosmosService> logger)
+    {
+        var opts = options.Value;
+
+        if (string.IsNullOrWhiteSpace(opts.Endpoint) || string.IsNullOrWhiteSpace(opts.Key))
+        {
+            logger.LogInformation(
+                "CosmosService: endpoint/key not configured. " +
+                "Cosmos-backed code paths will be unavailable until configuration is supplied.");
+            IsConfigured = false;
+            return;
+        }
+
+        _databaseId = opts.Database;
+        _client     = BuildClient(opts);
+        _database   = _client.GetDatabase(_databaseId);
+        IsConfigured = true;
+    }
+
+    public bool IsConfigured { get; }
+
+    public CosmosClient Client   => _client   ?? throw NotConfigured();
+    public Database     Database => _database ?? throw NotConfigured();
+
+    public Container Articles    => Database.GetContainer("articles");
+    public Container Drafts      => Database.GetContainer("drafts");
+    public Container Events      => Database.GetContainer("events");
+    public Container Resources   => Database.GetContainer("resources");
+    public Container Newsletters => Database.GetContainer("newsletters");
+    public Container Members     => Database.GetContainer("members");
+
+    private static CosmosClient BuildClient(CosmosOptions opts)
+    {
+        var isLocalEmulator =
+            opts.Endpoint!.Contains("localhost", StringComparison.OrdinalIgnoreCase) ||
+            opts.Endpoint!.Contains("127.0.0.1", StringComparison.Ordinal);
+
+        var clientOptions = new CosmosClientOptions
+        {
+            ConnectionMode  = ConnectionMode.Gateway,
+            ApplicationName = "Slypn.Api",
+            SerializerOptions = new CosmosSerializationOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase,
+            },
+        };
+
+        if (isLocalEmulator)
+        {
+            clientOptions.HttpClientFactory = () => new HttpClient(new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+            });
+        }
+
+        return new CosmosClient(opts.Endpoint, opts.Key, clientOptions);
+    }
+
+    private static InvalidOperationException NotConfigured() =>
+        new("Cosmos is not configured. Check IsConfigured before accessing handles.");
+
+    public void Dispose() => _client?.Dispose();
+}

--- a/src/api/Slypn.Api/Services/ICosmosService.cs
+++ b/src/api/Slypn.Api/Services/ICosmosService.cs
@@ -1,0 +1,26 @@
+using Microsoft.Azure.Cosmos;
+
+namespace Slypn.Api.Services;
+
+/// <summary>
+/// Single point of access to the SLYPN Cosmos DB account. Container handles
+/// are lazy SDK references — they don't require the container to exist
+/// (creation happens in CosmosBootstrapper on startup).
+///
+/// Consumers must check <see cref="IsConfigured"/> before accessing handles;
+/// otherwise an InvalidOperationException is thrown.
+/// </summary>
+public interface ICosmosService
+{
+    bool IsConfigured { get; }
+
+    CosmosClient Client   { get; }
+    Database     Database { get; }
+
+    Container Articles    { get; }
+    Container Drafts      { get; }
+    Container Events      { get; }
+    Container Resources   { get; }
+    Container Newsletters { get; }
+    Container Members     { get; }
+}


### PR DESCRIPTION
## Summary
Wraps `CosmosClient` + `Database` + the six container handles behind `ICosmosService`. Registered as a singleton in `Program.cs` and consumed by the `CosmosBootstrapper` (which no longer opens its own `CosmosClient` — one client now serves both bootstrap and runtime).

### Auth modes
- **dev** — key-based. If the endpoint is `localhost`/`127.0.0.1`, the HttpClient accepts the emulator's self-signed cert.
- **prod** — key-based for now. Managed Identity flip (`DefaultAzureCredential`) lands in #38 (Phase 6) once role assignments are in Bicep.

### Serialization
`CosmosSerializationOptions` is set to `CamelCase` so items returned over the wire match the Vue mock shapes once #14 swaps the read paths.

### Not-configured behaviour
When Cosmos isn't configured, `IsConfigured` is `false` and every other property throws `InvalidOperationException`. The bootstrapper checks the flag and skips silently. The API still starts on a fresh checkout with no Cosmos configuration.

### Test plan
- [x] `dotnet build` clean.
- [x] API starts without Cosmos config (logs the no-op).
- [ ] Endpoints don't use CosmosService yet — #14 wires reads.
- [ ] CI green.

Closes #12