### PR TITLE
feat(api): BlobService + POST /api/media upload endpoint

### DIFF
--- a/src/api/Slypn.Api/Functions/MediaFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MediaFunctions.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using HttpMultipartParser;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Slypn.Api.Services;
+
+namespace Slypn.Api.Functions;
+
+public sealed class MediaFunctions(IBlobService blob)
+{
+    /// <summary>
+    /// POST /api/media — multipart/form-data with a single "file" part.
+    /// Returns { name, url } where `url` is a 15-minute read SAS.
+    /// </summary>
+    [Function("UploadMedia")]
+    public async Task<HttpResponseData> Upload(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "media")] HttpRequestData req)
+    {
+        if (!blob.IsConfigured)
+        {
+            var unavailable = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
+            await unavailable.WriteStringAsync("BlobService is not configured.");
+            return unavailable;
+        }
+
+        var contentType = req.Headers.TryGetValues("Content-Type", out var ct)
+            ? ct.FirstOrDefault()
+            : null;
+        if (contentType is null || !contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
+        {
+            return await Reject(req, HttpStatusCode.UnsupportedMediaType,
+                "Expected multipart/form-data with a 'file' part.");
+        }
+
+        MultipartFormDataParser parsed;
+        try
+        {
+            parsed = await MultipartFormDataParser.ParseAsync(req.Body);
+        }
+        catch (Exception ex)
+        {
+            return await Reject(req, HttpStatusCode.BadRequest, $"Could not parse multipart body: {ex.Message}");
+        }
+
+        var file = parsed.Files.FirstOrDefault(f => f.Name == "file") ?? parsed.Files.FirstOrDefault();
+        if (file is null)
+        {
+            return await Reject(req, HttpStatusCode.BadRequest, "No file part in the upload.");
+        }
+
+        if (!blob.AllowedContentTypes.Contains(file.ContentType))
+        {
+            return await Reject(req, HttpStatusCode.UnsupportedMediaType,
+                $"Content type '{file.ContentType}' not allowed. Allowed: {string.Join(", ", blob.AllowedContentTypes)}.");
+        }
+
+        var blobName = await blob.UploadMediaAsync(file.Data, file.ContentType, default);
+        var readUrl  = blob.GetMediaReadUrl(blobName);
+
+        var response = req.CreateResponse(HttpStatusCode.Created);
+        await response.WriteAsJsonAsync(new
+        {
+            name = blobName,
+            url  = readUrl.ToString(),
+        });
+        return response;
+    }
+
+    private static async Task<HttpResponseData> Reject(HttpRequestData req, HttpStatusCode code, string message)
+    {
+        var resp = req.CreateResponse(code);
+        await resp.WriteStringAsync(message);
+        return resp;
+    }
+}

--- a/src/api/Slypn.Api/Infrastructure/StorageOptions.cs
+++ b/src/api/Slypn.Api/Infrastructure/StorageOptions.cs
@@ -1,0 +1,15 @@
+namespace Slypn.Api.Infrastructure;
+
+public sealed class StorageOptions
+{
+    public const string SectionName = "Storage";
+
+    /// <summary>Connection string for dev (Azurite emulator) and key-based prod.</summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>Container that holds article/media uploads.</summary>
+    public string MediaContainer { get; set; } = "media";
+
+    /// <summary>How long a generated read SAS URL is valid for.</summary>
+    public TimeSpan ReadSasLifetime { get; set; } = TimeSpan.FromMinutes(15);
+}

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -13,9 +13,13 @@ var host = new HostBuilder()
         services
             .AddOptions<CosmosOptions>()
             .Bind(context.Configuration.GetSection(CosmosOptions.SectionName));
-
         services.AddSingleton<ICosmosService, CosmosService>();
         services.AddHostedService<CosmosBootstrapper>();
+
+        services
+            .AddOptions<StorageOptions>()
+            .Bind(context.Configuration.GetSection(StorageOptions.SectionName));
+        services.AddSingleton<IBlobService, BlobService>();
     })
     .Build();
 

--- a/src/api/Slypn.Api/Services/BlobService.cs
+++ b/src/api/Slypn.Api/Services/BlobService.cs
@@ -1,0 +1,99 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Slypn.Api.Infrastructure;
+
+namespace Slypn.Api.Services;
+
+public sealed class BlobService : IBlobService
+{
+    private readonly BlobContainerClient? _container;
+    private readonly StorageOptions _opts;
+
+    private static readonly HashSet<string> Allowed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+    };
+
+    public BlobService(IOptions<StorageOptions> options, ILogger<BlobService> logger)
+    {
+        _opts = options.Value;
+
+        if (string.IsNullOrWhiteSpace(_opts.ConnectionString))
+        {
+            logger.LogInformation(
+                "BlobService: connection string not configured. Media upload endpoints will return 503 until configured.");
+            IsConfigured = false;
+            return;
+        }
+
+        var serviceClient = new BlobServiceClient(_opts.ConnectionString);
+        _container = serviceClient.GetBlobContainerClient(_opts.MediaContainer);
+        _container.CreateIfNotExists(PublicAccessType.None);
+        IsConfigured = true;
+    }
+
+    public bool IsConfigured { get; }
+    public IReadOnlySet<string> AllowedContentTypes => Allowed;
+
+    public async Task<string> UploadMediaAsync(Stream content, string contentType, CancellationToken ct)
+    {
+        if (!IsConfigured || _container is null)
+        {
+            throw new InvalidOperationException("BlobService is not configured.");
+        }
+        if (!Allowed.Contains(contentType))
+        {
+            throw new ArgumentException($"Content type '{contentType}' is not allowed.", nameof(contentType));
+        }
+
+        var ext = contentType.ToLowerInvariant() switch
+        {
+            "image/png"  => ".png",
+            "image/jpeg" => ".jpg",
+            "image/webp" => ".webp",
+            _ => throw new InvalidOperationException("unreachable"),
+        };
+        var blobName = $"{Guid.NewGuid():N}{ext}";
+
+        var blob = _container.GetBlobClient(blobName);
+        await blob.UploadAsync(content,
+            new BlobHttpHeaders { ContentType = contentType },
+            cancellationToken: ct);
+
+        return blobName;
+    }
+
+    public Uri GetMediaReadUrl(string blobName, TimeSpan? validFor = null)
+    {
+        if (!IsConfigured || _container is null)
+        {
+            throw new InvalidOperationException("BlobService is not configured.");
+        }
+
+        var blob = _container.GetBlobClient(blobName);
+        if (!blob.CanGenerateSasUri)
+        {
+            // Will be the case once we switch to managed identity in Phase 6;
+            // a user-delegation SAS will be generated via the service client instead.
+            throw new InvalidOperationException(
+                "Cannot generate shared-key SAS. Switch to user-delegation SAS once managed identity is wired (see #41).");
+        }
+
+        var lifetime = validFor ?? _opts.ReadSasLifetime;
+        var sas = new BlobSasBuilder
+        {
+            BlobContainerName = _container.Name,
+            BlobName          = blobName,
+            Resource          = "b",
+            ExpiresOn         = DateTimeOffset.UtcNow.Add(lifetime),
+        };
+        sas.SetPermissions(BlobSasPermissions.Read);
+
+        return blob.GenerateSasUri(sas);
+    }
+}

--- a/src/api/Slypn.Api/Services/IBlobService.cs
+++ b/src/api/Slypn.Api/Services/IBlobService.cs
@@ -1,0 +1,23 @@
+namespace Slypn.Api.Services;
+
+public interface IBlobService
+{
+    bool IsConfigured { get; }
+
+    /// <summary>Allowed media MIME types (lowercase).</summary>
+    IReadOnlySet<string> AllowedContentTypes { get; }
+
+    /// <summary>
+    /// Uploads a media blob. Caller is responsible for MIME validation
+    /// (this method also validates as a safety net). Returns the blob name
+    /// (a Guid-based identifier with an appropriate extension).
+    /// </summary>
+    Task<string> UploadMediaAsync(Stream content, string contentType, CancellationToken ct);
+
+    /// <summary>
+    /// Returns a short-lived (default 15 min) read URL for the given blob name.
+    /// Currently shared-key SAS; user-delegation SAS via managed identity in
+    /// <c>#41</c> (Phase 6) once SWA managed identity has Blob Data Contributor.
+    /// </summary>
+    Uri GetMediaReadUrl(string blobName, TimeSpan? validFor = null);
+}

--- a/src/api/Slypn.Api/Slypn.Api.csproj
+++ b/src/api/Slypn.Api/Slypn.Api.csproj
@@ -9,6 +9,8 @@
     <UserSecretsId>slypn-api-dev</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
+    <PackageReference Include="HttpMultipartParser" Version="8.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />

--- a/src/api/Slypn.Api/local.settings.sample.json
+++ b/src/api/Slypn.Api/local.settings.sample.json
@@ -6,7 +6,9 @@
     "ASPNETCORE_URLS": "http://localhost:7071",
     "Cosmos__Endpoint": "https://localhost:8081/",
     "Cosmos__Key": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-    "Cosmos__Database": "slypn"
+    "Cosmos__Database": "slypn",
+    "Storage__ConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;",
+    "Storage__MediaContainer": "media"
   },
   "Host": {
     "CORS": "http://localhost:5173",


### PR DESCRIPTION
## Summary
Media uploads for article images and (eventually) editor attachments. `POST /api/media` accepts multipart/form-data, validates MIME, writes to the `media` container in Azure Storage, and returns a short-lived (15-minute) read URL.

### Components
- **`StorageOptions`** — `ConnectionString`, `MediaContainer` (default `media`), `ReadSasLifetime` (default 15 min).
- **`IBlobService` / `BlobService`** — wraps `BlobContainerClient`; creates the container if missing; enforces MIME allowlist (`image/png`, `image/jpeg`, `image/webp`); generates SAS read URLs.
- **`MediaFunctions.Upload`** — `POST /api/media` (anonymous for now; auth lands in Phase 3). Multipart with a `file` part. Returns `201 { name, url }` on success, `415` for bad MIME, `400` for bad multipart, `503` if the service isn't configured.

### SAS strategy
Shared-key SAS for now (works with the Azurite emulator and key-based prod). User-delegation SAS via managed identity is targeted for **#41** (Phase 6) once SWA has Blob Data Contributor — `BlobService` already throws a hint in that case so the switch is obvious.

### Local dev wiring
`local.settings.sample.json` now ships the well-known Azurite connection string. The real `local.settings.json` will pick this up via **#17** (Phase 2.7) once Azurite is launched by `start.ps1`.

### Test plan
- [x] `dotnet build` clean.
- [x] API starts without Storage config — endpoint returns 503 cleanly.
- [ ] End-to-end upload against Azurite: #17 wires the emulator.
- [ ] UI integration (TipTap image upload): #26.
- [ ] CI green.

Closes #13