### PR TITLE
feat(api): swap mock reads for Cosmos via IContentRepository

### DIFF
--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -1,32 +1,33 @@
 using System.Net;
+using System.Web;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Slypn.Api.Services;
 
 namespace Slypn.Api.Functions;
 
-public sealed class ArticlesFunctions(IMockDataService data)
+public sealed class ArticlesFunctions(IContentRepository repo)
 {
     [Function("GetArticles")]
     public async Task<HttpResponseData> GetArticles(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles")] HttpRequestData req,
+        CancellationToken ct)
     {
+        var status = HttpUtility.ParseQueryString(req.Url.Query)["status"];
+        var articles = await repo.ListArticlesAsync(status, ct);
         var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(data.Articles);
+        await resp.WriteAsJsonAsync(articles);
         return resp;
     }
 
     [Function("GetArticleBySlug")]
     public async Task<HttpResponseData> GetArticleBySlug(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles/{slug}")] HttpRequestData req,
-        string slug)
+        string slug,
+        CancellationToken ct)
     {
-        var article = data.Articles.FirstOrDefault(a =>
-            string.Equals(a.Slug, slug, StringComparison.OrdinalIgnoreCase));
-        if (article is null)
-        {
-            return req.CreateResponse(HttpStatusCode.NotFound);
-        }
+        var article = await repo.GetArticleBySlugAsync(slug, ct);
+        if (article is null) return req.CreateResponse(HttpStatusCode.NotFound);
         var resp = req.CreateResponse(HttpStatusCode.OK);
         await resp.WriteAsJsonAsync(article);
         return resp;

--- a/src/api/Slypn.Api/Functions/EventsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/EventsFunctions.cs
@@ -1,18 +1,24 @@
 using System.Net;
+using System.Web;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Slypn.Api.Services;
 
 namespace Slypn.Api.Functions;
 
-public sealed class EventsFunctions(IMockDataService data)
+public sealed class EventsFunctions(IContentRepository repo)
 {
     [Function("GetEvents")]
     public async Task<HttpResponseData> GetEvents(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "events")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "events")] HttpRequestData req,
+        CancellationToken ct)
     {
+        var upcoming = HttpUtility.ParseQueryString(req.Url.Query)["upcoming"];
+        var onlyUpcoming = string.Equals(upcoming, "true", StringComparison.OrdinalIgnoreCase);
+
+        var events = await repo.ListEventsAsync(onlyUpcoming, ct);
         var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(data.Events);
+        await resp.WriteAsJsonAsync(events);
         return resp;
     }
 }

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -5,14 +5,16 @@ using Slypn.Api.Services;
 
 namespace Slypn.Api.Functions;
 
-public sealed class NewslettersFunctions(IMockDataService data)
+public sealed class NewslettersFunctions(IContentRepository repo)
 {
     [Function("GetNewsletters")]
     public async Task<HttpResponseData> GetNewsletters(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "newsletters")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "newsletters")] HttpRequestData req,
+        CancellationToken ct)
     {
+        var items = await repo.ListNewslettersAsync(ct);
         var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(data.Newsletters);
+        await resp.WriteAsJsonAsync(items);
         return resp;
     }
 }

--- a/src/api/Slypn.Api/Functions/ResourcesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ResourcesFunctions.cs
@@ -5,14 +5,16 @@ using Slypn.Api.Services;
 
 namespace Slypn.Api.Functions;
 
-public sealed class ResourcesFunctions(IMockDataService data)
+public sealed class ResourcesFunctions(IContentRepository repo)
 {
     [Function("GetResources")]
     public async Task<HttpResponseData> GetResources(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "resources")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "resources")] HttpRequestData req,
+        CancellationToken ct)
     {
+        var items = await repo.ListResourcesAsync(ct);
         var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(data.Resources);
+        await resp.WriteAsJsonAsync(items);
         return resp;
     }
 }

--- a/src/api/Slypn.Api/Models/Article.cs
+++ b/src/api/Slypn.Api/Models/Article.cs
@@ -10,4 +10,5 @@ public sealed record Article(
     DateTime PublishedAt,
     int ReadingMinutes,
     string Category,
-    IReadOnlyList<string> Tags);
+    IReadOnlyList<string> Tags,
+    string Status = "published");

--- a/src/api/Slypn.Api/Models/CommunityEvent.cs
+++ b/src/api/Slypn.Api/Models/CommunityEvent.cs
@@ -8,4 +8,8 @@ public sealed record CommunityEvent(
     DateTimeOffset EndsAt,
     string Location,
     string Description,
-    string? SignupUrl);
+    string? SignupUrl)
+{
+    /// <summary>Partition key for the events container — "yyyy-MM" of StartsAt (UTC).</summary>
+    public string YearMonth => StartsAt.UtcDateTime.ToString("yyyy-MM");
+}

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using Azure.Core.Serialization;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -8,7 +11,14 @@ var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices((context, services) =>
     {
+        // camelCase + lowercase enum names on every HttpResponseData.WriteAsJsonAsync.
+        services.Configure<WorkerOptions>(options =>
+        {
+            options.Serializer = new JsonObjectSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        });
+
         services.AddSingleton<IMockDataService, MockDataService>();
+        services.AddSingleton<IContentRepository, ContentRepository>();
 
         services
             .AddOptions<CosmosOptions>()

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -1,0 +1,100 @@
+using Microsoft.Azure.Cosmos;
+using Slypn.Api.Models;
+
+namespace Slypn.Api.Services;
+
+public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mock) : IContentRepository
+{
+    public async Task<IReadOnlyList<Article>> ListArticlesAsync(string? status, CancellationToken ct)
+    {
+        if (!cosmos.IsConfigured)
+        {
+            IEnumerable<Article> source = mock.Articles;
+            if (status is not null)
+            {
+                source = source.Where(a => string.Equals(a.Status, status, StringComparison.OrdinalIgnoreCase));
+            }
+            return source.OrderByDescending(a => a.PublishedAt).ToList();
+        }
+
+        var query = status is null
+            ? new QueryDefinition("SELECT * FROM c ORDER BY c.publishedAt DESC")
+            : new QueryDefinition("SELECT * FROM c WHERE c.status = @status ORDER BY c.publishedAt DESC")
+                .WithParameter("@status", status);
+
+        var options = new QueryRequestOptions
+        {
+            PartitionKey = status is null ? null : new PartitionKey(status),
+        };
+        return await CollectAsync<Article>(cosmos.Articles, query, options, ct);
+    }
+
+    public async Task<Article?> GetArticleBySlugAsync(string slug, CancellationToken ct)
+    {
+        if (!cosmos.IsConfigured)
+        {
+            return mock.Articles.FirstOrDefault(a =>
+                string.Equals(a.Slug, slug, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.slug = @slug")
+            .WithParameter("@slug", slug);
+        var results = await CollectAsync<Article>(cosmos.Articles, query, new QueryRequestOptions(), ct);
+        return results.FirstOrDefault();
+    }
+
+    public async Task<IReadOnlyList<CommunityEvent>> ListEventsAsync(bool upcomingOnly, CancellationToken ct)
+    {
+        if (!cosmos.IsConfigured)
+        {
+            IEnumerable<CommunityEvent> source = mock.Events;
+            if (upcomingOnly)
+            {
+                var nowUtc = DateTimeOffset.UtcNow;
+                source = source.Where(e => e.StartsAt >= nowUtc);
+            }
+            return source.OrderBy(e => e.StartsAt).ToList();
+        }
+
+        var query = upcomingOnly
+            ? new QueryDefinition("SELECT * FROM c WHERE c.startsAt >= @now ORDER BY c.startsAt")
+                .WithParameter("@now", DateTimeOffset.UtcNow)
+            : new QueryDefinition("SELECT * FROM c ORDER BY c.startsAt");
+        return await CollectAsync<CommunityEvent>(cosmos.Events, query, new QueryRequestOptions(), ct);
+    }
+
+    public async Task<IReadOnlyList<Resource>> ListResourcesAsync(CancellationToken ct)
+    {
+        if (!cosmos.IsConfigured)
+        {
+            return mock.Resources;
+        }
+
+        var query = new QueryDefinition("SELECT * FROM c ORDER BY c.category, c.title");
+        return await CollectAsync<Resource>(cosmos.Resources, query, new QueryRequestOptions(), ct);
+    }
+
+    public async Task<IReadOnlyList<Newsletter>> ListNewslettersAsync(CancellationToken ct)
+    {
+        if (!cosmos.IsConfigured)
+        {
+            return mock.Newsletters.OrderByDescending(n => n.IssueDate).ToList();
+        }
+
+        var query = new QueryDefinition("SELECT * FROM c ORDER BY c.issueDate DESC");
+        return await CollectAsync<Newsletter>(cosmos.Newsletters, query, new QueryRequestOptions(), ct);
+    }
+
+    private static async Task<IReadOnlyList<T>> CollectAsync<T>(
+        Container container, QueryDefinition query, QueryRequestOptions options, CancellationToken ct)
+    {
+        var results = new List<T>();
+        using var iterator = container.GetItemQueryIterator<T>(query, requestOptions: options);
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+}

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -1,0 +1,17 @@
+using Slypn.Api.Models;
+
+namespace Slypn.Api.Services;
+
+/// <summary>
+/// Read-side abstraction for public content. Uses Cosmos when configured,
+/// falls back to <see cref="IMockDataService"/> otherwise so the API keeps
+/// working on a fresh checkout. Write-side endpoints land in #15.
+/// </summary>
+public interface IContentRepository
+{
+    Task<IReadOnlyList<Article>>        ListArticlesAsync(string? status, CancellationToken ct);
+    Task<Article?>                      GetArticleBySlugAsync(string slug, CancellationToken ct);
+    Task<IReadOnlyList<CommunityEvent>> ListEventsAsync(bool upcomingOnly, CancellationToken ct);
+    Task<IReadOnlyList<Resource>>       ListResourcesAsync(CancellationToken ct);
+    Task<IReadOnlyList<Newsletter>>     ListNewslettersAsync(CancellationToken ct);
+}


### PR DESCRIPTION
## Summary
Public GET endpoints now go through `IContentRepository`, which queries Cosmos when configured and falls back to mock data otherwise (so the API keeps working on a fresh checkout until **#17** wires the emulator into `start.ps1`).

### Models
- `Article` gains `Status` (default `"published"`) — required as the `/status` partition key.
- `CommunityEvent` gains a computed `YearMonth` ("yyyy-MM" of `StartsAt` UTC) — required as the `/yearMonth` partition key.

### Repository (`Services/ContentRepository.cs`)
| Method | Filter |
|---|---|
| `ListArticlesAsync(status?)` | `?status=...`; uses partition-key hint when supplied |
| `GetArticleBySlugAsync(slug)` | `WHERE c.slug = @slug` |
| `ListEventsAsync(upcomingOnly)` | `?upcoming=true` |
| `ListResourcesAsync()` | ordered by category, title |
| `ListNewslettersAsync()` | ordered by issueDate desc |

Cosmos path uses parameterised `QueryDefinition`; mock path mirrors filtering/ordering.

### JSON
`WorkerOptions.Serializer` is now `JsonObjectSerializer(JsonSerializerDefaults.Web)`, so every `WriteAsJsonAsync` is camelCase. Cosmos serializer was already camelCase, so the two sides line up.

### Smoke (local)
- `/api/articles` → camelCase JSON, `publishedAt` desc.
- `/api/articles?status=published` → same set (mock items default to "published").
- `/api/events?upcoming=true` → only events ≥ today.
- `/api/events` → first event has `"yearMonth": "2026-05"`.

### Out of scope (next sub-issues)
- Write-side CRUD endpoints — #15.
- Seed script that loads the sample newsletter into Cosmos — #16.
- Wire Azurite + Cosmos emulator into `start.ps1` — #17.
- UI fetching from `/api/...` instead of `src/web/src/mock/*` — TODO; lands alongside #16/#17 when there's real data to fetch.

### Test plan
- [x] `dotnet build` clean.
- [x] All endpoints return 200 with camelCase JSON locally.
- [x] Filter params work (`?status`, `?upcoming`).
- [ ] CI green.

Closes #14