### PR TITLE
feat(api): CRUD endpoints with ETag-based optimistic concurrency

### DIFF
--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -1,35 +1,81 @@
 using System.Net;
-using System.Web;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
+using static Slypn.Api.Functions.FunctionHelpers;
 
 namespace Slypn.Api.Functions;
 
-public sealed class ArticlesFunctions(IContentRepository repo)
+public sealed class ArticlesFunctions(IContentRepository repo, ILogger<ArticlesFunctions> log)
 {
     [Function("GetArticles")]
     public async Task<HttpResponseData> GetArticles(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles")] HttpRequestData req,
         CancellationToken ct)
     {
-        var status = HttpUtility.ParseQueryString(req.Url.Query)["status"];
-        var articles = await repo.ListArticlesAsync(status, ct);
-        var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(articles);
-        return resp;
+        var articles = await repo.ListArticlesAsync(QueryParam(req, "status"), ct);
+        return await Ok(req, articles);
     }
 
     [Function("GetArticleBySlug")]
     public async Task<HttpResponseData> GetArticleBySlug(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles/{slug}")] HttpRequestData req,
-        string slug,
-        CancellationToken ct)
+        string slug, CancellationToken ct)
     {
         var article = await repo.GetArticleBySlugAsync(slug, ct);
         if (article is null) return req.CreateResponse(HttpStatusCode.NotFound);
-        var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(article);
-        return resp;
+        return await Ok(req, article, article.Etag);
+    }
+
+    [Function("CreateArticle")]
+    public async Task<HttpResponseData> Create(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles")] HttpRequestData req,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var (input, err) = await ReadValidatedAsync<ArticleInput>(req, ct);
+        if (err is not null) return err;
+        try
+        {
+            var article = await repo.CreateArticleAsync(input!, ct);
+            return await Created(req, article, article.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("ReplaceArticle")]
+    public async Task<HttpResponseData> Replace(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "articles/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var (input, err) = await ReadValidatedAsync<ArticleInput>(req, ct);
+        if (err is not null) return err;
+        try
+        {
+            var article = await repo.ReplaceArticleAsync(id, input!, IfMatch(req), ct);
+            return await Ok(req, article, article.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("DeleteArticle")]
+    public async Task<HttpResponseData> Delete(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "articles/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var status = QueryParam(req, "status");
+        if (string.IsNullOrWhiteSpace(status))
+            return await BadRequest(req, "DELETE /api/articles/{id} requires ?status=<partitionKey>.");
+        try
+        {
+            await repo.DeleteArticleAsync(id, status, IfMatch(req), ct);
+            return NoContent(req);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }
 }

--- a/src/api/Slypn.Api/Functions/EventsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/EventsFunctions.cs
@@ -1,24 +1,71 @@
-using System.Net;
-using System.Web;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
+using static Slypn.Api.Functions.FunctionHelpers;
 
 namespace Slypn.Api.Functions;
 
-public sealed class EventsFunctions(IContentRepository repo)
+public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunctions> log)
 {
     [Function("GetEvents")]
     public async Task<HttpResponseData> GetEvents(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "events")] HttpRequestData req,
         CancellationToken ct)
     {
-        var upcoming = HttpUtility.ParseQueryString(req.Url.Query)["upcoming"];
-        var onlyUpcoming = string.Equals(upcoming, "true", StringComparison.OrdinalIgnoreCase);
+        var upcoming = string.Equals(QueryParam(req, "upcoming"), "true", StringComparison.OrdinalIgnoreCase);
+        var events = await repo.ListEventsAsync(upcoming, ct);
+        return await Ok(req, events);
+    }
 
-        var events = await repo.ListEventsAsync(onlyUpcoming, ct);
-        var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(events);
-        return resp;
+    [Function("CreateEvent")]
+    public async Task<HttpResponseData> Create(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "events")] HttpRequestData req,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var (input, err) = await ReadValidatedAsync<EventInput>(req, ct);
+        if (err is not null) return err;
+        try
+        {
+            var ev = await repo.CreateEventAsync(input!, ct);
+            return await Created(req, ev, ev.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("ReplaceEvent")]
+    public async Task<HttpResponseData> Replace(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "events/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var (input, err) = await ReadValidatedAsync<EventInput>(req, ct);
+        if (err is not null) return err;
+        try
+        {
+            var ev = await repo.ReplaceEventAsync(id, input!, IfMatch(req), ct);
+            return await Ok(req, ev, ev.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("DeleteEvent")]
+    public async Task<HttpResponseData> Delete(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "events/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var yearMonth = QueryParam(req, "yearMonth");
+        if (string.IsNullOrWhiteSpace(yearMonth))
+            return await BadRequest(req, "DELETE /api/events/{id} requires ?yearMonth=YYYY-MM.");
+        try
+        {
+            await repo.DeleteEventAsync(id, yearMonth, IfMatch(req), ct);
+            return NoContent(req);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }
 }

--- a/src/api/Slypn.Api/Functions/FunctionHelpers.cs
+++ b/src/api/Slypn.Api/Functions/FunctionHelpers.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Web;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Slypn.Api.Services;
+
+namespace Slypn.Api.Functions;
+
+internal static class FunctionHelpers
+{
+    public static async Task<(T? Value, HttpResponseData? Error)> ReadValidatedAsync<T>(
+        HttpRequestData req, CancellationToken ct) where T : class
+    {
+        T? body;
+        try
+        {
+            body = await req.ReadFromJsonAsync<T>(ct);
+        }
+        catch (Exception ex)
+        {
+            return (null, await BadRequest(req, $"Invalid JSON: {ex.Message}"));
+        }
+        if (body is null) return (null, await BadRequest(req, "Empty request body."));
+
+        var ctx = new ValidationContext(body);
+        var errors = new List<ValidationResult>();
+        if (!Validator.TryValidateObject(body, ctx, errors, validateAllProperties: true))
+        {
+            var msg = string.Join("; ", errors.Select(e => e.ErrorMessage));
+            return (null, await BadRequest(req, msg));
+        }
+        return (body, null);
+    }
+
+    public static string? IfMatch(HttpRequestData req) =>
+        req.Headers.TryGetValues("If-Match", out var vals) ? vals.FirstOrDefault() : null;
+
+    public static string? QueryParam(HttpRequestData req, string name) =>
+        HttpUtility.ParseQueryString(req.Url.Query)[name];
+
+    public static async Task<HttpResponseData> Ok<T>(HttpRequestData req, T value, string? etag = null)
+    {
+        var resp = req.CreateResponse(HttpStatusCode.OK);
+        if (etag is not null) resp.Headers.Add("ETag", etag);
+        await resp.WriteAsJsonAsync(value);
+        return resp;
+    }
+
+    public static async Task<HttpResponseData> Created<T>(HttpRequestData req, T value, string? etag = null)
+    {
+        var resp = req.CreateResponse(HttpStatusCode.Created);
+        if (etag is not null) resp.Headers.Add("ETag", etag);
+        await resp.WriteAsJsonAsync(value);
+        return resp;
+    }
+
+    public static HttpResponseData NoContent(HttpRequestData req) =>
+        req.CreateResponse(HttpStatusCode.NoContent);
+
+    public static async Task<HttpResponseData> BadRequest(HttpRequestData req, string message)
+    {
+        var resp = req.CreateResponse(HttpStatusCode.BadRequest);
+        await resp.WriteStringAsync(message);
+        return resp;
+    }
+
+    public static async Task<HttpResponseData> WritesDisabled(HttpRequestData req)
+    {
+        var resp = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
+        await resp.WriteStringAsync(
+            "Writes require a configured Cosmos endpoint. Wire the emulator via scripts/start.ps1 (#17) or supply Cosmos__Endpoint/Cosmos__Key.");
+        return resp;
+    }
+
+    public static async Task<HttpResponseData> MapCosmosException(
+        HttpRequestData req, CosmosException ex, ILogger? log = null)
+    {
+        log?.LogWarning(ex, "Cosmos write failed with status {Status}", ex.StatusCode);
+        return ex.StatusCode switch
+        {
+            HttpStatusCode.PreconditionFailed => await Reject(req, HttpStatusCode.PreconditionFailed,
+                "ETag mismatch — refetch and retry."),
+            HttpStatusCode.NotFound           => await Reject(req, HttpStatusCode.NotFound,
+                "Item not found in this partition."),
+            HttpStatusCode.Conflict           => await Reject(req, HttpStatusCode.Conflict,
+                "An item with this id already exists."),
+            _ => await Reject(req, HttpStatusCode.InternalServerError,
+                $"Cosmos error: {ex.Message}"),
+        };
+    }
+
+    private static async Task<HttpResponseData> Reject(HttpRequestData req, HttpStatusCode code, string message)
+    {
+        var resp = req.CreateResponse(code);
+        await resp.WriteStringAsync(message);
+        return resp;
+    }
+}

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -1,11 +1,14 @@
-using System.Net;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
+using static Slypn.Api.Functions.FunctionHelpers;
 
 namespace Slypn.Api.Functions;
 
-public sealed class NewslettersFunctions(IContentRepository repo)
+public sealed class NewslettersFunctions(IContentRepository repo, ILogger<NewslettersFunctions> log)
 {
     [Function("GetNewsletters")]
     public async Task<HttpResponseData> GetNewsletters(
@@ -13,8 +16,55 @@ public sealed class NewslettersFunctions(IContentRepository repo)
         CancellationToken ct)
     {
         var items = await repo.ListNewslettersAsync(ct);
-        var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(items);
-        return resp;
+        return await Ok(req, items);
+    }
+
+    [Function("CreateNewsletter")]
+    public async Task<HttpResponseData> Create(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "newsletters")] HttpRequestData req,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var (input, err) = await ReadValidatedAsync<NewsletterInput>(req, ct);
+        if (err is not null) return err;
+        try
+        {
+            var n = await repo.CreateNewsletterAsync(input!, ct);
+            return await Created(req, n, n.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("ReplaceNewsletter")]
+    public async Task<HttpResponseData> Replace(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "newsletters/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var (input, err) = await ReadValidatedAsync<NewsletterInput>(req, ct);
+        if (err is not null) return err;
+        try
+        {
+            var n = await repo.ReplaceNewsletterAsync(id, input!, IfMatch(req), ct);
+            return await Ok(req, n, n.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("DeleteNewsletter")]
+    public async Task<HttpResponseData> Delete(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "newsletters/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var year = QueryParam(req, "year");
+        if (string.IsNullOrWhiteSpace(year))
+            return await BadRequest(req, "DELETE /api/newsletters/{id} requires ?year=YYYY.");
+        try
+        {
+            await repo.DeleteNewsletterAsync(id, year, IfMatch(req), ct);
+            return NoContent(req);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }
 }

--- a/src/api/Slypn.Api/Functions/ResourcesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ResourcesFunctions.cs
@@ -1,11 +1,14 @@
-using System.Net;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
+using static Slypn.Api.Functions.FunctionHelpers;
 
 namespace Slypn.Api.Functions;
 
-public sealed class ResourcesFunctions(IContentRepository repo)
+public sealed class ResourcesFunctions(IContentRepository repo, ILogger<ResourcesFunctions> log)
 {
     [Function("GetResources")]
     public async Task<HttpResponseData> GetResources(
@@ -13,8 +16,55 @@ public sealed class ResourcesFunctions(IContentRepository repo)
         CancellationToken ct)
     {
         var items = await repo.ListResourcesAsync(ct);
-        var resp = req.CreateResponse(HttpStatusCode.OK);
-        await resp.WriteAsJsonAsync(items);
-        return resp;
+        return await Ok(req, items);
+    }
+
+    [Function("CreateResource")]
+    public async Task<HttpResponseData> Create(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "resources")] HttpRequestData req,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var (input, err) = await ReadValidatedAsync<ResourceInput>(req, ct);
+        if (err is not null) return err;
+        try
+        {
+            var r = await repo.CreateResourceAsync(input!, ct);
+            return await Created(req, r, r.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("ReplaceResource")]
+    public async Task<HttpResponseData> Replace(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "resources/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var (input, err) = await ReadValidatedAsync<ResourceInput>(req, ct);
+        if (err is not null) return err;
+        try
+        {
+            var r = await repo.ReplaceResourceAsync(id, input!, IfMatch(req), ct);
+            return await Ok(req, r, r.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("DeleteResource")]
+    public async Task<HttpResponseData> Delete(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "resources/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var category = QueryParam(req, "category");
+        if (string.IsNullOrWhiteSpace(category))
+            return await BadRequest(req, "DELETE /api/resources/{id} requires ?category=<partitionKey>.");
+        try
+        {
+            await repo.DeleteResourceAsync(id, category, IfMatch(req), ct);
+            return NoContent(req);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }
 }

--- a/src/api/Slypn.Api/Models/Article.cs
+++ b/src/api/Slypn.Api/Models/Article.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Slypn.Api.Models;
 
 public sealed record Article(
@@ -11,4 +13,9 @@ public sealed record Article(
     int ReadingMinutes,
     string Category,
     IReadOnlyList<string> Tags,
-    string Status = "published");
+    string Status = "published")
+{
+    /// <summary>Cosmos optimistic-concurrency token. Echoed in the ETag HTTP header for clients.</summary>
+    [JsonPropertyName("_etag")]
+    public string? Etag { get; init; }
+}

--- a/src/api/Slypn.Api/Models/CommunityEvent.cs
+++ b/src/api/Slypn.Api/Models/CommunityEvent.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Slypn.Api.Models;
 
 public sealed record CommunityEvent(
@@ -12,4 +14,7 @@ public sealed record CommunityEvent(
 {
     /// <summary>Partition key for the events container — "yyyy-MM" of StartsAt (UTC).</summary>
     public string YearMonth => StartsAt.UtcDateTime.ToString("yyyy-MM");
+
+    [JsonPropertyName("_etag")]
+    public string? Etag { get; init; }
 }

--- a/src/api/Slypn.Api/Models/Inputs/ArticleInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/ArticleInput.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+public sealed class ArticleInput
+{
+    [Required, StringLength(120, MinimumLength = 3)]
+    public string Slug { get; set; } = "";
+
+    [Required, StringLength(200, MinimumLength = 3)]
+    public string Title { get; set; } = "";
+
+    [Required, StringLength(500, MinimumLength = 10)]
+    public string Summary { get; set; } = "";
+
+    [Required, StringLength(50_000, MinimumLength = 10)]
+    public string Body { get; set; } = "";
+
+    [Required, StringLength(120)]
+    public string Author { get; set; } = "";
+
+    [Range(1, 60)]
+    public int ReadingMinutes { get; set; } = 5;
+
+    [Required, StringLength(60)]
+    public string Category { get; set; } = "";
+
+    public List<string> Tags { get; set; } = new();
+
+    [Required, RegularExpression("^(draft|in-review|published|rejected)$",
+        ErrorMessage = "Status must be one of: draft, in-review, published, rejected.")]
+    public string Status { get; set; } = "draft";
+}

--- a/src/api/Slypn.Api/Models/Inputs/EventInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/EventInput.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+public sealed class EventInput
+{
+    [Required, StringLength(200, MinimumLength = 3)]
+    public string Title { get; set; } = "";
+
+    [Required, StringLength(60)]
+    public string Type { get; set; } = "";
+
+    [Required]
+    public DateTimeOffset StartsAt { get; set; }
+
+    [Required]
+    public DateTimeOffset EndsAt { get; set; }
+
+    [Required, StringLength(200)]
+    public string Location { get; set; } = "";
+
+    [Required, StringLength(2_000)]
+    public string Description { get; set; } = "";
+
+    [Url, StringLength(500)]
+    public string? SignupUrl { get; set; }
+}

--- a/src/api/Slypn.Api/Models/Inputs/NewsletterInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/NewsletterInput.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+public sealed class NewsletterInput
+{
+    [Required, StringLength(200, MinimumLength = 3)]
+    public string Title { get; set; } = "";
+
+    [Required]
+    public DateOnly IssueDate { get; set; }
+
+    [Required, StringLength(1_000, MinimumLength = 10)]
+    public string Summary { get; set; } = "";
+
+    public List<string> Topics { get; set; } = new();
+}

--- a/src/api/Slypn.Api/Models/Inputs/ResourceInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/ResourceInput.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+public sealed class ResourceInput
+{
+    [Required, StringLength(200, MinimumLength = 3)]
+    public string Title { get; set; } = "";
+
+    [Required, StringLength(500, MinimumLength = 10)]
+    public string Description { get; set; } = "";
+
+    [Required, Url, StringLength(500)]
+    public string Url { get; set; } = "";
+
+    [Required, StringLength(60)]
+    public string Category { get; set; } = "";
+}

--- a/src/api/Slypn.Api/Models/Newsletter.cs
+++ b/src/api/Slypn.Api/Models/Newsletter.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Slypn.Api.Models;
 
 public sealed record Newsletter(
@@ -5,4 +7,11 @@ public sealed record Newsletter(
     string Title,
     DateOnly IssueDate,
     string Summary,
-    IReadOnlyList<string> Topics);
+    IReadOnlyList<string> Topics)
+{
+    /// <summary>Partition key — four-digit year of IssueDate.</summary>
+    public string Year => IssueDate.Year.ToString("D4");
+
+    [JsonPropertyName("_etag")]
+    public string? Etag { get; init; }
+}

--- a/src/api/Slypn.Api/Models/Resource.cs
+++ b/src/api/Slypn.Api/Models/Resource.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Slypn.Api.Models;
 
 public sealed record Resource(
@@ -5,4 +7,8 @@ public sealed record Resource(
     string Title,
     string Description,
     string Url,
-    string Category);
+    string Category)
+{
+    [JsonPropertyName("_etag")]
+    public string? Etag { get; init; }
+}

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -1,19 +1,21 @@
 using Microsoft.Azure.Cosmos;
 using Slypn.Api.Models;
+using Slypn.Api.Models.Inputs;
 
 namespace Slypn.Api.Services;
 
 public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mock) : IContentRepository
 {
+    public bool SupportsWrites => cosmos.IsConfigured;
+
+    // ---- Reads ----------------------------------------------------------------
     public async Task<IReadOnlyList<Article>> ListArticlesAsync(string? status, CancellationToken ct)
     {
         if (!cosmos.IsConfigured)
         {
             IEnumerable<Article> source = mock.Articles;
             if (status is not null)
-            {
                 source = source.Where(a => string.Equals(a.Status, status, StringComparison.OrdinalIgnoreCase));
-            }
             return source.OrderByDescending(a => a.PublishedAt).ToList();
         }
 
@@ -21,7 +23,6 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
             ? new QueryDefinition("SELECT * FROM c ORDER BY c.publishedAt DESC")
             : new QueryDefinition("SELECT * FROM c WHERE c.status = @status ORDER BY c.publishedAt DESC")
                 .WithParameter("@status", status);
-
         var options = new QueryRequestOptions
         {
             PartitionKey = status is null ? null : new PartitionKey(status),
@@ -32,10 +33,8 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
     public async Task<Article?> GetArticleBySlugAsync(string slug, CancellationToken ct)
     {
         if (!cosmos.IsConfigured)
-        {
             return mock.Articles.FirstOrDefault(a =>
                 string.Equals(a.Slug, slug, StringComparison.OrdinalIgnoreCase));
-        }
 
         var query = new QueryDefinition("SELECT * FROM c WHERE c.slug = @slug")
             .WithParameter("@slug", slug);
@@ -49,10 +48,7 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
         {
             IEnumerable<CommunityEvent> source = mock.Events;
             if (upcomingOnly)
-            {
-                var nowUtc = DateTimeOffset.UtcNow;
-                source = source.Where(e => e.StartsAt >= nowUtc);
-            }
+                source = source.Where(e => e.StartsAt >= DateTimeOffset.UtcNow);
             return source.OrderBy(e => e.StartsAt).ToList();
         }
 
@@ -65,24 +61,178 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
 
     public async Task<IReadOnlyList<Resource>> ListResourcesAsync(CancellationToken ct)
     {
-        if (!cosmos.IsConfigured)
-        {
-            return mock.Resources;
-        }
-
+        if (!cosmos.IsConfigured) return mock.Resources;
         var query = new QueryDefinition("SELECT * FROM c ORDER BY c.category, c.title");
         return await CollectAsync<Resource>(cosmos.Resources, query, new QueryRequestOptions(), ct);
     }
 
     public async Task<IReadOnlyList<Newsletter>> ListNewslettersAsync(CancellationToken ct)
     {
-        if (!cosmos.IsConfigured)
-        {
-            return mock.Newsletters.OrderByDescending(n => n.IssueDate).ToList();
-        }
-
+        if (!cosmos.IsConfigured) return mock.Newsletters.OrderByDescending(n => n.IssueDate).ToList();
         var query = new QueryDefinition("SELECT * FROM c ORDER BY c.issueDate DESC");
         return await CollectAsync<Newsletter>(cosmos.Newsletters, query, new QueryRequestOptions(), ct);
+    }
+
+    // ---- Articles writes ------------------------------------------------------
+    public async Task<Article> CreateArticleAsync(ArticleInput input, CancellationToken ct)
+    {
+        EnsureWrites();
+        var article = new Article(
+            Id:             Guid.NewGuid().ToString("N"),
+            Slug:           input.Slug,
+            Title:          input.Title,
+            Summary:        input.Summary,
+            Body:           input.Body,
+            Author:         input.Author,
+            PublishedAt:    DateTime.UtcNow,
+            ReadingMinutes: input.ReadingMinutes,
+            Category:       input.Category,
+            Tags:           input.Tags,
+            Status:         input.Status);
+        var resp = await cosmos.Articles.CreateItemAsync(article, new PartitionKey(article.Status), cancellationToken: ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task<Article> ReplaceArticleAsync(string id, ArticleInput input, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        var article = new Article(
+            Id:             id,
+            Slug:           input.Slug,
+            Title:          input.Title,
+            Summary:        input.Summary,
+            Body:           input.Body,
+            Author:         input.Author,
+            PublishedAt:    DateTime.UtcNow,
+            ReadingMinutes: input.ReadingMinutes,
+            Category:       input.Category,
+            Tags:           input.Tags,
+            Status:         input.Status);
+        var resp = await cosmos.Articles.ReplaceItemAsync(article, id,
+            new PartitionKey(article.Status),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task DeleteArticleAsync(string id, string status, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        await cosmos.Articles.DeleteItemAsync<Article>(id,
+            new PartitionKey(status),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+    }
+
+    // ---- Events writes --------------------------------------------------------
+    public async Task<CommunityEvent> CreateEventAsync(EventInput input, CancellationToken ct)
+    {
+        EnsureWrites();
+        var ev = new CommunityEvent(
+            Id:          Guid.NewGuid().ToString("N"),
+            Title:       input.Title,
+            Type:        input.Type,
+            StartsAt:    input.StartsAt,
+            EndsAt:      input.EndsAt,
+            Location:    input.Location,
+            Description: input.Description,
+            SignupUrl:   input.SignupUrl);
+        var resp = await cosmos.Events.CreateItemAsync(ev, new PartitionKey(ev.YearMonth), cancellationToken: ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task<CommunityEvent> ReplaceEventAsync(string id, EventInput input, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        var ev = new CommunityEvent(
+            Id:          id,
+            Title:       input.Title,
+            Type:        input.Type,
+            StartsAt:    input.StartsAt,
+            EndsAt:      input.EndsAt,
+            Location:    input.Location,
+            Description: input.Description,
+            SignupUrl:   input.SignupUrl);
+        var resp = await cosmos.Events.ReplaceItemAsync(ev, id,
+            new PartitionKey(ev.YearMonth),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task DeleteEventAsync(string id, string yearMonth, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        await cosmos.Events.DeleteItemAsync<CommunityEvent>(id,
+            new PartitionKey(yearMonth),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+    }
+
+    // ---- Resources writes -----------------------------------------------------
+    public async Task<Resource> CreateResourceAsync(ResourceInput input, CancellationToken ct)
+    {
+        EnsureWrites();
+        var r = new Resource(Guid.NewGuid().ToString("N"), input.Title, input.Description, input.Url, input.Category);
+        var resp = await cosmos.Resources.CreateItemAsync(r, new PartitionKey(r.Category), cancellationToken: ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task<Resource> ReplaceResourceAsync(string id, ResourceInput input, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        var r = new Resource(id, input.Title, input.Description, input.Url, input.Category);
+        var resp = await cosmos.Resources.ReplaceItemAsync(r, id,
+            new PartitionKey(r.Category),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task DeleteResourceAsync(string id, string category, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        await cosmos.Resources.DeleteItemAsync<Resource>(id,
+            new PartitionKey(category),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+    }
+
+    // ---- Newsletters writes ---------------------------------------------------
+    public async Task<Newsletter> CreateNewsletterAsync(NewsletterInput input, CancellationToken ct)
+    {
+        EnsureWrites();
+        var n = new Newsletter(Guid.NewGuid().ToString("N"), input.Title, input.IssueDate, input.Summary, input.Topics);
+        var resp = await cosmos.Newsletters.CreateItemAsync(n, new PartitionKey(n.Year), cancellationToken: ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task<Newsletter> ReplaceNewsletterAsync(string id, NewsletterInput input, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        var n = new Newsletter(id, input.Title, input.IssueDate, input.Summary, input.Topics);
+        var resp = await cosmos.Newsletters.ReplaceItemAsync(n, id,
+            new PartitionKey(n.Year),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task DeleteNewsletterAsync(string id, string year, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        await cosmos.Newsletters.DeleteItemAsync<Newsletter>(id,
+            new PartitionKey(year),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+    }
+
+    // ---- helpers --------------------------------------------------------------
+    private void EnsureWrites()
+    {
+        if (!cosmos.IsConfigured)
+            throw new InvalidOperationException(
+                "ContentRepository cannot write: Cosmos is not configured. Run setup.ps1 + start.ps1 after Phase 2 emulator wiring (#17), or supply Cosmos__Endpoint/Cosmos__Key.");
     }
 
     private static async Task<IReadOnlyList<T>> CollectAsync<T>(

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -1,17 +1,40 @@
 using Slypn.Api.Models;
+using Slypn.Api.Models.Inputs;
 
 namespace Slypn.Api.Services;
 
 /// <summary>
-/// Read-side abstraction for public content. Uses Cosmos when configured,
-/// falls back to <see cref="IMockDataService"/> otherwise so the API keeps
-/// working on a fresh checkout. Write-side endpoints land in #15.
+/// Reads + writes for SLYPN public content. Cosmos when configured; mock
+/// otherwise (mock writes return false / null — writes need real persistence).
+///
+/// Optimistic concurrency is propagated via Cosmos's _etag. Write methods
+/// take a nullable If-Match etag; null means "don't check".
 /// </summary>
 public interface IContentRepository
 {
+    bool SupportsWrites { get; }
+
+    // Reads ------------------------------------------------------------------
     Task<IReadOnlyList<Article>>        ListArticlesAsync(string? status, CancellationToken ct);
     Task<Article?>                      GetArticleBySlugAsync(string slug, CancellationToken ct);
     Task<IReadOnlyList<CommunityEvent>> ListEventsAsync(bool upcomingOnly, CancellationToken ct);
     Task<IReadOnlyList<Resource>>       ListResourcesAsync(CancellationToken ct);
     Task<IReadOnlyList<Newsletter>>     ListNewslettersAsync(CancellationToken ct);
+
+    // Writes -----------------------------------------------------------------
+    Task<Article>     CreateArticleAsync     (ArticleInput input, CancellationToken ct);
+    Task<Article>     ReplaceArticleAsync    (string id, ArticleInput input, string? ifMatch, CancellationToken ct);
+    Task              DeleteArticleAsync     (string id, string status, string? ifMatch, CancellationToken ct);
+
+    Task<CommunityEvent> CreateEventAsync    (EventInput input, CancellationToken ct);
+    Task<CommunityEvent> ReplaceEventAsync   (string id, EventInput input, string? ifMatch, CancellationToken ct);
+    Task                 DeleteEventAsync    (string id, string yearMonth, string? ifMatch, CancellationToken ct);
+
+    Task<Resource>   CreateResourceAsync     (ResourceInput input, CancellationToken ct);
+    Task<Resource>   ReplaceResourceAsync    (string id, ResourceInput input, string? ifMatch, CancellationToken ct);
+    Task             DeleteResourceAsync     (string id, string category, string? ifMatch, CancellationToken ct);
+
+    Task<Newsletter> CreateNewsletterAsync   (NewsletterInput input, CancellationToken ct);
+    Task<Newsletter> ReplaceNewsletterAsync  (string id, NewsletterInput input, string? ifMatch, CancellationToken ct);
+    Task             DeleteNewsletterAsync   (string id, string year, string? ifMatch, CancellationToken ct);
 }


### PR DESCRIPTION
## Summary
POST/PUT/DELETE for **articles**, **events**, **resources**, **newsletters** with DataAnnotations validation and Cosmos ETag-based concurrency.

### URL shape
```
POST   /api/{type}                       body = input dto  -> 201 + ETag
PUT    /api/{type}/{id}   If-Match: ...  body = input dto  -> 200 + ETag  | 412
DELETE /api/{type}/{id}?<pk>=...  If-Match: ...            -> 204         | 412
```

DELETE requires the partition-key value as a query param (`?status`, `?yearMonth`, `?category`, `?year`) because Cosmos can't address an item without it — and the editor UI always knows it.

### Input DTOs
`Models/Inputs/*` carry the validation attributes (separate from the read records so positional record syntax stays clean). Each endpoint validates with `Validator.TryValidateObject` and returns `400` with the aggregated message on failure.

### ETag plumbing
Each read record gains `[JsonPropertyName("_etag")] public string? Etag { get; init; }` so the value flows through Cosmos deserialization. The HTTP `ETag` response header is set on GET/POST/PUT. Clients send it back as `If-Match` on PUT/DELETE.

### Helpers
`FunctionHelpers` centralises body read + validation, header extraction, query-param parsing, and `CosmosException` → HTTP mapping (412/404/409/500). Each Function class stays small (~80 lines).

### Mock fallback
When Cosmos isn't configured, `IContentRepository.SupportsWrites` is false and every write endpoint returns `503` with a hint pointing at #17. Reads still work via the mock fallback.

### Smoke (local)
- `GET /api/articles` → 200.
- `POST/PUT/DELETE` without Cosmos → 503 with the helpful message.
- End-to-end write paths against Cosmos: validated as part of #17 (emulator wiring).

### Test plan
- [x] `dotnet build` clean (0/0).
- [x] Local smoke as above.
- [ ] End-to-end create/update/delete + 412 on stale ETag: validated via #17.
- [ ] Auth — endpoints are anonymous for now; #21 wires roles.
- [ ] CI green.

Closes #15