### PR TITLE
feat(seed): console app + script that seeds Cosmos from the sample newsletter docx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
   api:
     name: API (.NET Functions)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src/api/Slypn.Api
     steps:
       - uses: actions/checkout@v4
 
@@ -58,8 +55,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      - name: Restore
-        run: dotnet restore
+      - name: Restore (API)
+        run: dotnet restore src/api/Slypn.Api/Slypn.Api.csproj
 
-      - name: Build
-        run: dotnet build --no-restore --configuration Release
+      - name: Build (API)
+        run: dotnet build src/api/Slypn.Api/Slypn.Api.csproj --no-restore --configuration Release
+
+      - name: Build (Seed CLI)
+        run: dotnet build src/api/Slypn.Seed/Slypn.Seed.csproj --configuration Release

--- a/scripts/seed.ps1
+++ b/scripts/seed.ps1
@@ -1,0 +1,55 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Seeds Cosmos DB with the sample newsletter parsed from brief/.
+
+.DESCRIPTION
+  Reads Cosmos__* values from src/api/Slypn.Api/local.settings.json, then
+  runs the Slypn.Seed console app against brief/SLYPN_Newsletter_MAY_2026.docx
+  and upserts a newsletter document into the configured database.
+
+.EXAMPLE
+  .\scripts\seed.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Docx = ''
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_lib.ps1')
+
+$SeedDir = Join-Path $RepoRoot 'src/api/Slypn.Seed'
+if (-not $Docx) {
+    $Docx = Join-Path $RepoRoot 'brief/SLYPN_Newsletter_MAY_2026.docx'
+}
+if (-not (Test-Path $Docx)) { Write-Err "docx not found: $Docx"; exit 1 }
+
+$localSettings = Join-Path $ApiDir 'local.settings.json'
+if (-not (Test-Path $localSettings)) {
+    Write-Err 'local.settings.json missing. Run scripts/setup.ps1 first.'
+    exit 1
+}
+
+$settings = Get-Content $localSettings -Raw | ConvertFrom-Json
+$endpoint = $settings.Values.'Cosmos__Endpoint'
+$key      = $settings.Values.'Cosmos__Key'
+$database = $settings.Values.'Cosmos__Database'
+
+if (-not $endpoint -or -not $key -or -not $database) {
+    Write-Err 'Cosmos__Endpoint / Cosmos__Key / Cosmos__Database not set in local.settings.json.'
+    Write-Err 'Re-copy from local.settings.sample.json (setup.ps1 only copies if local.settings.json is absent).'
+    exit 1
+}
+
+Write-Step "Seeding newsletter from $Docx into $database"
+
+Push-Location $SeedDir
+try {
+    dotnet run --configuration Release --no-launch-profile -- $Docx --endpoint $endpoint --key $key --database $database
+    if ($LASTEXITCODE -ne 0) { throw "seed failed (exit $LASTEXITCODE)" }
+}
+finally { Pop-Location }
+
+Write-Ok 'Seed complete.'

--- a/src/api/Slypn.Seed/Program.cs
+++ b/src/api/Slypn.Seed/Program.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Microsoft.Azure.Cosmos;
+using Slypn.Seed;
+
+// Args:
+//   <docx-path>  --endpoint <url>  --key <key>  --database <name>  [--container <name>]
+//
+// Defaults: container = "newsletters".
+// Exit codes: 0 success, 1 bad args, 2 docx error, 3 Cosmos error.
+
+if (args.Length < 1)
+{
+    Console.Error.WriteLine("usage: dotnet run -- <docx-path> --endpoint <url> --key <key> --database <name> [--container <name>]");
+    return 1;
+}
+
+string docxPath = args[0];
+var named = ParseNamed(args.Skip(1).ToArray());
+if (!named.TryGetValue("endpoint", out var endpoint) ||
+    !named.TryGetValue("key",      out var key)      ||
+    !named.TryGetValue("database", out var database))
+{
+    Console.Error.WriteLine("Missing one of --endpoint / --key / --database.");
+    return 1;
+}
+var container = named.GetValueOrDefault("container", "newsletters");
+
+if (!File.Exists(docxPath))
+{
+    Console.Error.WriteLine($"docx not found: {docxPath}");
+    return 2;
+}
+
+SeedNewsletter newsletter;
+try
+{
+    newsletter = BuildFromDocx(docxPath);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"docx parse failed: {ex.Message}");
+    return 2;
+}
+
+Console.WriteLine($"Parsed newsletter: id={newsletter.Id} title='{newsletter.Title}' issue={newsletter.IssueDate} year={newsletter.Year} topics={newsletter.Topics.Count}");
+
+try
+{
+    await UpsertAsync(endpoint, key, database, container, newsletter);
+    Console.WriteLine($"Upserted into {database}.{container}.");
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Cosmos upsert failed: {ex.Message}");
+    return 3;
+}
+
+// ----- helpers ----------------------------------------------------------------
+
+static Dictionary<string, string> ParseNamed(string[] args)
+{
+    var d = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    for (int i = 0; i < args.Length - 1; i += 2)
+    {
+        if (args[i].StartsWith("--")) d[args[i].Substring(2)] = args[i + 1];
+    }
+    return d;
+}
+
+static SeedNewsletter BuildFromDocx(string path)
+{
+    using var doc = WordprocessingDocument.Open(path, false);
+    var body = doc.MainDocumentPart?.Document.Body
+        ?? throw new InvalidOperationException("document has no body");
+
+    var paragraphs = body.Descendants<Paragraph>()
+        .Select(p => p.InnerText.Trim())
+        .Where(t => t.Length > 0)
+        .ToList();
+
+    var headings = body.Descendants<Paragraph>()
+        .Where(p => p.ParagraphProperties?.ParagraphStyleId?.Val?.Value?.StartsWith("Heading", StringComparison.OrdinalIgnoreCase) == true)
+        .Select(p => p.InnerText.Trim())
+        .Where(t => t.Length > 0)
+        .Distinct()
+        .Take(8)
+        .ToList();
+
+    var (issueDate, derivedTitle) = ExtractIssueDateAndTitle(path);
+    var title = paragraphs.FirstOrDefault(p => p.Length is > 3 and < 100) ?? derivedTitle;
+
+    var summary = string.Join(' ', paragraphs.Skip(1).Take(4));
+    if (summary.Length > 800) summary = summary.Substring(0, 800) + "...";
+    if (summary.Length == 0) summary = $"SLYPN newsletter — {derivedTitle}.";
+
+    return new SeedNewsletter(
+        Id:        $"newsletter-{issueDate:yyyy-MM}",
+        Title:     derivedTitle,
+        IssueDate: issueDate,
+        Summary:   summary,
+        Topics:    headings.Count > 0 ? headings : new List<string> { "Newsletter" },
+        Year:      issueDate.Year.ToString("D4", CultureInfo.InvariantCulture));
+}
+
+static (DateOnly IssueDate, string Title) ExtractIssueDateAndTitle(string path)
+{
+    // Expected filename shape: SLYPN_Newsletter_<MONTH>_<YEAR>.docx
+    var name = Path.GetFileNameWithoutExtension(path);
+    var match = Regex.Match(name, @"_(?<m>[A-Za-z]+)_(?<y>\d{4})$");
+    if (match.Success)
+    {
+        var month = DateTime.ParseExact(match.Groups["m"].Value, "MMMM", CultureInfo.InvariantCulture).Month;
+        var year  = int.Parse(match.Groups["y"].Value, CultureInfo.InvariantCulture);
+        var title = $"{CultureInfo.InvariantCulture.TextInfo.ToTitleCase(match.Groups["m"].Value.ToLowerInvariant())} {year}";
+        return (new DateOnly(year, month, 1), title);
+    }
+    return (DateOnly.FromDateTime(DateTime.UtcNow), name);
+}
+
+static async Task UpsertAsync(string endpoint, string key, string database, string container, SeedNewsletter newsletter)
+{
+    var isLocalEmulator =
+        endpoint.Contains("localhost", StringComparison.OrdinalIgnoreCase) ||
+        endpoint.Contains("127.0.0.1", StringComparison.Ordinal);
+
+    var options = new CosmosClientOptions
+    {
+        ConnectionMode  = ConnectionMode.Gateway,
+        ApplicationName = "Slypn.Seed",
+        SerializerOptions = new CosmosSerializationOptions { PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase },
+    };
+    if (isLocalEmulator)
+    {
+        options.HttpClientFactory = () => new HttpClient(new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        });
+    }
+
+    using var client = new CosmosClient(endpoint, key, options);
+    var db  = (await client.CreateDatabaseIfNotExistsAsync(database)).Database;
+    var col = (await db.CreateContainerIfNotExistsAsync(new ContainerProperties(container, "/year"))).Container;
+
+    await col.UpsertItemAsync(newsletter, new PartitionKey(newsletter.Year));
+}

--- a/src/api/Slypn.Seed/SeedNewsletter.cs
+++ b/src/api/Slypn.Seed/SeedNewsletter.cs
@@ -1,0 +1,13 @@
+namespace Slypn.Seed;
+
+/// <summary>
+/// Local mirror of <c>Slypn.Api.Models.Newsletter</c>. The Cosmos schema
+/// is the source of truth — keep these field names in sync.
+/// </summary>
+public sealed record SeedNewsletter(
+    string Id,
+    string Title,
+    DateOnly IssueDate,
+    string Summary,
+    IReadOnlyList<string> Topics,
+    string Year);

--- a/src/api/Slypn.Seed/Slypn.Seed.csproj
+++ b/src/api/Slypn.Seed/Slypn.Seed.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Slypn.Seed</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
Phase 2.6 — parse `brief/SLYPN_Newsletter_MAY_2026.docx` via the OpenXML SDK and upsert it as a newsletter document into the Cosmos `newsletters` container.

### `src/api/Slypn.Seed/` — new net8.0 console app
- `Slypn.Seed.csproj` — DocumentFormat.OpenXml 3.2.0 + Microsoft.Azure.Cosmos 3.46.0 + explicit Newtonsoft.Json (Cosmos 3.x requirement).
- `SeedNewsletter.cs` — local mirror of `Slypn.Api.Models.Newsletter` with a `Year` field so the schema matches the `/year` partition key. Doc comment flags the sync requirement for future readers.
- `Program.cs`:
  - Positional `<docx-path>` + `--endpoint --key --database` (and optional `--container`).
  - Extracts title + issue date from the filename pattern `SLYPN_Newsletter_<MONTH>_<YEAR>.docx`.
  - Grabs paragraph styles starting with `Heading` as `topics`.
  - Joins the first few paragraphs as `summary` (truncated at 800 chars).
  - Idempotent via id `newsletter-yyyy-MM`.
  - Accepts the emulator's self-signed cert.

### `scripts/seed.ps1`
Reads Cosmos config from `src/api/Slypn.Api/local.settings.json` and invokes `dotnet run` on the seed project.

### CI
`.github/workflows/ci.yml` — the `api` job now builds both `Slypn.Api` and `Slypn.Seed` so the seed project doesn't silently rot.

### Test plan
- [x] `dotnet build` clean for both API and Seed (0/0).
- [ ] End-to-end seed against the emulator: validated as part of #17.
- [ ] CI green.

Closes #16