### PR TITLE
feat(scripts): wire Azurite + Cosmos emulator into the local dev stack

### DIFF
--- a/docs/local-emulators.md
+++ b/docs/local-emulators.md
@@ -1,0 +1,34 @@
+# Local emulators
+
+`scripts/start.ps1` launches two Docker containers alongside the Vue dev server and the Functions host:
+
+| Container | Image | Purpose | Ports |
+|---|---|---|---|
+| `slypn-azurite` | `mcr.microsoft.com/azure-storage/azurite:latest` | Blob (+ queue + table) emulator | `10000`/`10001`/`10002` |
+| `slypn-cosmos`  | `mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview` | Cosmos DB emulator | `8081` |
+
+## Lifecycle
+
+- `scripts/start.ps1` — creates the containers on first run, then `docker start`s them on subsequent runs. **Data persists** between start/stop cycles.
+- `scripts/stop.ps1` — stops the containers (preserving data). Pass `-KeepEmulators` to leave them running between stops.
+- `scripts/clean.ps1` — removes the containers, wiping all emulator data.
+
+## Cosmos emulator TLS cert
+
+The Cosmos emulator serves over HTTPS with a self-signed certificate. The API and the seed CLI handle this in code:
+
+> when `Endpoint` contains `localhost` or `127.0.0.1`, the `CosmosClient` is built with a `HttpClient` that bypasses cert validation (`HttpClientHandler.DangerousAcceptAnyServerCertificateValidator`).
+
+That means **no OS-level cert install is required** for the SLYPN code paths. If you want to hit `https://localhost:8081/_explorer/index.html` in a browser, or use curl/Postman, you'll either need to install the emulator's cert (see [Microsoft Learn — Install the certificate](https://learn.microsoft.com/azure/cosmos-db/how-to-develop-emulator)) or accept the cert warning in your tool of choice.
+
+## Azurite
+
+Azurite is HTTP only on the emulator endpoints. The `Storage__ConnectionString` in `local.settings.sample.json` includes `BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1` — no cert wrangling needed.
+
+## Seeding
+
+After `start.ps1` (and the Cosmos emulator is ready), `scripts/seed.ps1` upserts the sample newsletter from `brief/SLYPN_Newsletter_MAY_2026.docx` into the `newsletters` container.
+
+## Skipping emulators
+
+`scripts/start.ps1 -NoEmulators` boots only vite + func and skips the Docker containers — handy if you've pointed the API at a real Cosmos / Storage account via env vars, or are working on UI-only changes.

--- a/scripts/_lib.ps1
+++ b/scripts/_lib.ps1
@@ -10,6 +10,17 @@ $script:ApiDir   = Join-Path $RepoRoot 'src/api/Slypn.Api'
 $script:WebPort = 5173
 $script:ApiPort = 7071
 
+# Emulators (Docker).
+$script:AzuriteContainer = 'slypn-azurite'
+$script:AzuriteImage     = 'mcr.microsoft.com/azure-storage/azurite:latest'
+$script:AzuriteBlobPort  = 10000
+$script:AzuriteQueuePort = 10001
+$script:AzuriteTablePort = 10002
+
+$script:CosmosContainer  = 'slypn-cosmos'
+$script:CosmosImage      = 'mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview'
+$script:CosmosPort       = 8081
+
 function Write-Step($msg) {
     Write-Host "==> $msg" -ForegroundColor Cyan
 }
@@ -36,4 +47,30 @@ function Stop-Port($port) {
             Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
         }
     }
+}
+
+# -- Docker helpers ---------------------------------------------------------
+function Test-DockerRunning {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) { return $false }
+    docker info --format '{{.ServerVersion}}' 2>$null | Out-Null
+    return $LASTEXITCODE -eq 0
+}
+
+function Test-ContainerRunning($name) {
+    $found = docker ps --filter "name=^/$name$" --format '{{.Names}}' 2>$null
+    return [bool]($found -and $found.Trim() -eq $name)
+}
+
+function Test-ContainerExists($name) {
+    $found = docker ps -a --filter "name=^/$name$" --format '{{.Names}}' 2>$null
+    return [bool]($found -and $found.Trim() -eq $name)
+}
+
+function Wait-Port($port, $timeoutSec) {
+    $start = Get-Date
+    while (((Get-Date) - $start).TotalSeconds -lt $timeoutSec) {
+        if (Test-Port $port) { return $true }
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
 }

--- a/scripts/clean.ps1
+++ b/scripts/clean.ps1
@@ -1,0 +1,36 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Removes the SLYPN emulator Docker containers (data is lost).
+
+.DESCRIPTION
+  Use this when you want a fresh Cosmos / Azurite. The next `start.ps1`
+  will re-create them. Vite + func are not touched — run `stop.ps1` first
+  if they're still up.
+
+.EXAMPLE
+  .\scripts\clean.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_lib.ps1')
+
+if (-not (Test-DockerRunning)) {
+    Write-Err 'Docker daemon is not running; nothing to clean.'
+    exit 1
+}
+
+foreach ($name in @($AzuriteContainer, $CosmosContainer)) {
+    if (Test-ContainerExists $name) {
+        if (Test-ContainerRunning $name) {
+            docker stop $name | Out-Null
+        }
+        docker rm $name | Out-Null
+        Write-Ok "removed $name"
+    } else {
+        Write-Warn "$name does not exist"
+    }
+}

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -97,6 +97,16 @@ if ($funcCmd) {
     exit 1
 }
 
+# --- Docker (for local emulators) ------------------------------------------
+Write-Step 'Checking Docker (for Azurite + Cosmos emulator)'
+if (Test-DockerRunning) {
+    $dockerVersion = docker version --format '{{.Server.Version}}' 2>$null
+    Write-Ok "Docker $dockerVersion"
+} else {
+    Write-Warn 'Docker daemon is not reachable. Start Docker Desktop before running scripts/start.ps1.'
+    Write-Warn 'Without Docker, start.ps1 must be invoked with -NoEmulators (API will skip Cosmos/Blob).'
+}
+
 # --- web deps ---------------------------------------------------------------
 Write-Step "npm ci in $WebDir"
 Push-Location $WebDir

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -1,24 +1,29 @@
 #requires -Version 7
 <#
 .SYNOPSIS
-  Boots the Vue dev server and the .NET Functions host side-by-side.
+  Boots Azurite + Cosmos emulator + Vue dev server + .NET Functions host.
 
 .DESCRIPTION
   Starts:
-    - vite (web)        on http://localhost:5173/
-    - func (API)        on http://localhost:7071/
-  Both are launched as background jobs whose logs stream to
-  scripts/.runtime/<web|api>.log. PIDs are written to scripts/.runtime/pids.json
-  so stop.ps1 can shut them down cleanly. The script waits until both ports
-  respond, then prints URLs and returns control. Ctrl+C does NOT stop the
-  servers — use stop.ps1.
+    - slypn-azurite (Docker)    blob/queue/table emulator on :10000-10002
+    - slypn-cosmos  (Docker)    Cosmos DB emulator (vnext-preview) on :8081
+    - vite (npm)                Vue dev server on http://localhost:5173/
+    - func (Functions Core)     .NET API host on http://localhost:7071/
+
+  Emulator containers persist between start/stop cycles so seeded data
+  survives. Use scripts/clean.ps1 to wipe them. Vite + func PIDs are
+  written to scripts/.runtime/pids.json for stop.ps1.
+
+  Ctrl+C does NOT stop anything — use scripts/stop.ps1.
 
 .EXAMPLE
   .\scripts\start.ps1
 #>
 
 [CmdletBinding()]
-param()
+param(
+    [switch] $NoEmulators   # skip starting Docker containers (e.g. when running against a real Cosmos / Storage account)
+)
 
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot '_lib.ps1')
@@ -29,7 +34,8 @@ $webLog  = Join-Path $runtimeDir 'web.log'
 $apiLog  = Join-Path $runtimeDir 'api.log'
 $pidFile = Join-Path $runtimeDir 'pids.json'
 
-# Refuse to start if anything is already on the ports.
+# Refuse to start if the app ports are already taken (emulator port collisions
+# are handled below — those map onto existing containers).
 foreach ($p in @($WebPort, $ApiPort)) {
     if (Test-Port $p) {
         Write-Err "Port $p is already in use. Run .\scripts\stop.ps1 first."
@@ -47,9 +53,55 @@ if (-not (Test-Path $localSettings)) {
     }
 }
 
-# Resolve a real Win32 executable (Start-Process can't launch .ps1 shims).
+# --- emulators --------------------------------------------------------------
+if (-not $NoEmulators) {
+    if (-not (Test-DockerRunning)) {
+        Write-Err 'Docker daemon is not running. Start Docker Desktop (or pass -NoEmulators).'
+        exit 1
+    }
+
+    Write-Step 'Ensuring Azurite container'
+    if (Test-ContainerRunning $AzuriteContainer) {
+        Write-Ok "$AzuriteContainer already running"
+    } elseif (Test-ContainerExists $AzuriteContainer) {
+        docker start $AzuriteContainer | Out-Null
+        Write-Ok "$AzuriteContainer started"
+    } else {
+        docker run -d --name $AzuriteContainer `
+            -p "${AzuriteBlobPort}:10000" `
+            -p "${AzuriteQueuePort}:10001" `
+            -p "${AzuriteTablePort}:10002" `
+            $AzuriteImage | Out-Null
+        Write-Ok "$AzuriteContainer created"
+    }
+    if (-not (Wait-Port $AzuriteBlobPort 30)) {
+        Write-Err "Azurite blob port $AzuriteBlobPort did not come up in 30s. See: docker logs $AzuriteContainer"
+        exit 1
+    }
+    Write-Ok "Azurite ready on http://127.0.0.1:$AzuriteBlobPort/"
+
+    Write-Step 'Ensuring Cosmos DB emulator container (vnext-preview)'
+    if (Test-ContainerRunning $CosmosContainer) {
+        Write-Ok "$CosmosContainer already running"
+    } elseif (Test-ContainerExists $CosmosContainer) {
+        docker start $CosmosContainer | Out-Null
+        Write-Ok "$CosmosContainer started"
+    } else {
+        docker run -d --name $CosmosContainer `
+            -p "${CosmosPort}:8081" `
+            $CosmosImage | Out-Null
+        Write-Ok "$CosmosContainer created (first start downloads the image; can take a few minutes)"
+    }
+    Write-Step 'Waiting for Cosmos emulator (~30-90s)'
+    if (-not (Wait-Port $CosmosPort 180)) {
+        Write-Err "Cosmos emulator port $CosmosPort did not come up in 180s. See: docker logs $CosmosContainer"
+        exit 1
+    }
+    Write-Ok "Cosmos emulator ready on https://localhost:$CosmosPort/"
+}
+
+# --- web --------------------------------------------------------------------
 function Resolve-WinExe($name) {
-    # Prefer .cmd / .exe forms over PowerShell .ps1 shims that npm/Functions install.
     foreach ($suffix in @('.exe', '.cmd', '.bat', '')) {
         $cmd = Get-Command "$name$suffix" -ErrorAction SilentlyContinue |
                Where-Object { $_.Source -match '\.(exe|cmd|bat)$' } |
@@ -59,7 +111,6 @@ function Resolve-WinExe($name) {
     return $null
 }
 
-# --- web --------------------------------------------------------------------
 Write-Step 'Starting Vite (web)'
 $npmExe = Resolve-WinExe 'npm'
 if (-not $npmExe) { Write-Err 'npm.cmd not on PATH'; exit 1 }
@@ -74,7 +125,6 @@ Write-Ok "vite PID $($webProc.Id), logging to $webLog"
 Write-Step 'Starting Functions host (API)'
 $funcExe = Resolve-WinExe 'func'
 if (-not $funcExe) {
-    # Fall back to our standard install location used by setup.ps1.
     $funcHome = Join-Path $env:LOCALAPPDATA 'AzureFunctionsCoreTools'
     $candidate = Join-Path $funcHome 'func.exe'
     if (Test-Path $candidate) { $funcExe = $candidate }
@@ -91,20 +141,10 @@ $apiProc = Start-Process -FilePath $funcExe -ArgumentList 'start' `
     -WindowStyle Hidden -PassThru
 Write-Ok "func PID $($apiProc.Id), logging to $apiLog"
 
-# Persist PIDs so stop.ps1 has something to kill.
 @{ web = $webProc.Id; api = $apiProc.Id } | ConvertTo-Json | Out-File -FilePath $pidFile -Encoding UTF8
 
-# --- wait until both ports respond -----------------------------------------
-function Wait-Port($port, $timeoutSec) {
-    $start = Get-Date
-    while (((Get-Date) - $start).TotalSeconds -lt $timeoutSec) {
-        if (Test-Port $port) { return $true }
-        Start-Sleep -Milliseconds 500
-    }
-    return $false
-}
-
-Write-Step 'Waiting for ports to come up'
+# --- wait for app ports -----------------------------------------------------
+Write-Step 'Waiting for vite + func to come up'
 if (-not (Wait-Port $WebPort 30)) {
     Write-Err "vite did not start on $WebPort within 30s. See $webLog."
     exit 1
@@ -118,9 +158,14 @@ if (-not (Wait-Port $ApiPort 90)) {
 Write-Ok "func ready on http://localhost:$ApiPort/"
 
 Write-Host ''
-Write-Host 'Both servers are up.' -ForegroundColor Green
-Write-Host "  Web:  http://localhost:$WebPort/" -ForegroundColor Green
-Write-Host "  API:  http://localhost:$ApiPort/api/articles" -ForegroundColor Green
+Write-Host 'Dev stack is up.' -ForegroundColor Green
+Write-Host "  Web:    http://localhost:$WebPort/"           -ForegroundColor Green
+Write-Host "  API:    http://localhost:$ApiPort/api/articles" -ForegroundColor Green
+if (-not $NoEmulators) {
+    Write-Host "  Cosmos: https://localhost:$CosmosPort/ (self-signed cert)" -ForegroundColor Green
+    Write-Host "  Blob:   http://127.0.0.1:$AzuriteBlobPort/devstoreaccount1" -ForegroundColor Green
+}
 Write-Host ''
-Write-Host "Logs:  $runtimeDir" -ForegroundColor DarkGray
-Write-Host "Stop:  .\scripts\stop.ps1" -ForegroundColor DarkGray
+Write-Host "Logs:  $runtimeDir"           -ForegroundColor DarkGray
+Write-Host "Seed:  .\scripts\seed.ps1"    -ForegroundColor DarkGray
+Write-Host "Stop:  .\scripts\stop.ps1"    -ForegroundColor DarkGray

--- a/scripts/stop.ps1
+++ b/scripts/stop.ps1
@@ -1,19 +1,26 @@
 #requires -Version 7
 <#
 .SYNOPSIS
-  Stops the local Vue + Functions dev stack started by start.ps1.
+  Stops the local dev stack: vite + func + Azurite + Cosmos emulator.
 
 .DESCRIPTION
-  First tries the PIDs persisted by start.ps1 in scripts/.runtime/pids.json.
-  Falls back to killing whatever is listening on ports 5173 and 7071. Safe
-  to run repeatedly.
+  - Kills the vite + func process trees recorded in scripts/.runtime/pids.json
+    and sweeps ports 5173 + 7071 as a safety net.
+  - Stops the slypn-azurite and slypn-cosmos Docker containers (they remain
+    so data persists across start/stop cycles — use scripts/clean.ps1 to
+    remove them).
+  - Pass -KeepEmulators to leave the Docker containers running (useful when
+    you want to seed or run the API on its own).
 
 .EXAMPLE
   .\scripts\stop.ps1
+  .\scripts\stop.ps1 -KeepEmulators
 #>
 
 [CmdletBinding()]
-param()
+param(
+    [switch] $KeepEmulators
+)
 
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot '_lib.ps1')
@@ -22,7 +29,7 @@ $runtimeDir = Join-Path $PSScriptRoot '.runtime'
 $pidFile    = Join-Path $runtimeDir 'pids.json'
 
 if (Test-Path $pidFile) {
-    Write-Step 'Stopping by recorded PIDs'
+    Write-Step 'Stopping vite + func by recorded PIDs'
     $procIds = Get-Content $pidFile -Raw | ConvertFrom-Json
     foreach ($key in @('web', 'api')) {
         $procId = $procIds.$key
@@ -30,7 +37,6 @@ if (Test-Path $pidFile) {
             $name = (Get-Process -Id $procId -ErrorAction SilentlyContinue).ProcessName
             if ($name) {
                 Write-Host "    killing PID $procId ($name) [$key]" -ForegroundColor DarkGray
-                # Kill the whole process tree (Start-Process spawns npm.cmd which spawns node).
                 Get-CimInstance Win32_Process |
                     Where-Object { $_.ParentProcessId -eq $procId } |
                     ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
@@ -41,16 +47,25 @@ if (Test-Path $pidFile) {
     Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
 }
 
-# Sweep ports as a safety net (catches orphaned children).
-Write-Step "Sweeping ports $WebPort and $ApiPort"
+Write-Step "Sweeping app ports $WebPort, $ApiPort"
 Stop-Port $WebPort
 Stop-Port $ApiPort
 
+if (-not $KeepEmulators) {
+    if (Test-DockerRunning) {
+        Write-Step 'Stopping emulator containers'
+        foreach ($name in @($AzuriteContainer, $CosmosContainer)) {
+            if (Test-ContainerRunning $name) {
+                Write-Host "    stopping $name" -ForegroundColor DarkGray
+                docker stop $name | Out-Null
+            }
+        }
+    } else {
+        Write-Warn 'Docker not reachable; skipping emulator stop.'
+    }
+}
+
 Start-Sleep -Milliseconds 500
 foreach ($p in @($WebPort, $ApiPort)) {
-    if (Test-Port $p) {
-        Write-Warn "Port $p still in use."
-    } else {
-        Write-Ok "Port $p free"
-    }
+    if (Test-Port $p) { Write-Warn "Port $p still in use." } else { Write-Ok "Port $p free" }
 }

--- a/src/api/Slypn.Api/Functions/FunctionHelpers.cs
+++ b/src/api/Slypn.Api/Functions/FunctionHelpers.cs
@@ -34,16 +34,27 @@ internal static class FunctionHelpers
         return (body, null);
     }
 
-    public static string? IfMatch(HttpRequestData req) =>
-        req.Headers.TryGetValues("If-Match", out var vals) ? vals.FirstOrDefault() : null;
+    public static string? IfMatch(HttpRequestData req)
+    {
+        if (!req.Headers.TryGetValues("If-Match", out var vals)) return null;
+        // Strip the RFC 7232 surrounding quotes before handing to Cosmos.
+        return vals.FirstOrDefault()?.Trim().Trim('"');
+    }
 
     public static string? QueryParam(HttpRequestData req, string name) =>
         HttpUtility.ParseQueryString(req.Url.Query)[name];
 
+    /// <summary>RFC 7232: ETag values must be wrapped in double quotes.</summary>
+    private static string QuoteEtag(string etag)
+    {
+        var clean = etag.Trim().Trim('"');
+        return $"\"{clean}\"";
+    }
+
     public static async Task<HttpResponseData> Ok<T>(HttpRequestData req, T value, string? etag = null)
     {
         var resp = req.CreateResponse(HttpStatusCode.OK);
-        if (etag is not null) resp.Headers.Add("ETag", etag);
+        if (!string.IsNullOrEmpty(etag)) resp.Headers.Add("ETag", QuoteEtag(etag));
         await resp.WriteAsJsonAsync(value);
         return resp;
     }
@@ -51,7 +62,7 @@ internal static class FunctionHelpers
     public static async Task<HttpResponseData> Created<T>(HttpRequestData req, T value, string? etag = null)
     {
         var resp = req.CreateResponse(HttpStatusCode.Created);
-        if (etag is not null) resp.Headers.Add("ETag", etag);
+        if (!string.IsNullOrEmpty(etag)) resp.Headers.Add("ETag", QuoteEtag(etag));
         await resp.WriteAsJsonAsync(value);
         return resp;
     }

--- a/src/api/Slypn.Api/Models/Article.cs
+++ b/src/api/Slypn.Api/Models/Article.cs
@@ -17,5 +17,6 @@ public sealed record Article(
 {
     /// <summary>Cosmos optimistic-concurrency token. Echoed in the ETag HTTP header for clients.</summary>
     [JsonPropertyName("_etag")]
+    [Newtonsoft.Json.JsonProperty("_etag")]
     public string? Etag { get; init; }
 }

--- a/src/api/Slypn.Api/Models/CommunityEvent.cs
+++ b/src/api/Slypn.Api/Models/CommunityEvent.cs
@@ -16,5 +16,6 @@ public sealed record CommunityEvent(
     public string YearMonth => StartsAt.UtcDateTime.ToString("yyyy-MM");
 
     [JsonPropertyName("_etag")]
+    [Newtonsoft.Json.JsonProperty("_etag")]
     public string? Etag { get; init; }
 }

--- a/src/api/Slypn.Api/Models/Newsletter.cs
+++ b/src/api/Slypn.Api/Models/Newsletter.cs
@@ -13,5 +13,6 @@ public sealed record Newsletter(
     public string Year => IssueDate.Year.ToString("D4");
 
     [JsonPropertyName("_etag")]
+    [Newtonsoft.Json.JsonProperty("_etag")]
     public string? Etag { get; init; }
 }

--- a/src/api/Slypn.Api/Models/Resource.cs
+++ b/src/api/Slypn.Api/Models/Resource.cs
@@ -10,5 +10,6 @@ public sealed record Resource(
     string Category)
 {
     [JsonPropertyName("_etag")]
+    [Newtonsoft.Json.JsonProperty("_etag")]
     public string? Etag { get; init; }
 }

--- a/src/api/Slypn.Api/local.settings.sample.json
+++ b/src/api/Slypn.Api/local.settings.sample.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "ASPNETCORE_URLS": "http://localhost:7071",
-    "Cosmos__Endpoint": "https://localhost:8081/",
+    "Cosmos__Endpoint": "http://localhost:8081/",
     "Cosmos__Key": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
     "Cosmos__Database": "slypn",
     "Storage__ConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;",


### PR DESCRIPTION
## Summary
`start.ps1` now boots two Docker containers alongside vite + func:

| Container | Image | Ports |
|---|---|---|
| `slypn-azurite` | `mcr.microsoft.com/azure-storage/azurite:latest` | 10000-10002 |
| `slypn-cosmos`  | `mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview` | 8081 |

Containers **persist between start/stop cycles** so seeded data survives. `stop.ps1` stops them (preserving data); `clean.ps1` removes them outright.

- `start.ps1 -NoEmulators` skips Docker (use against real Azure resources).
- `stop.ps1 -KeepEmulators` leaves containers running between stops.

`_lib.ps1` grows Docker helpers (`Test-DockerRunning`, `Test-ContainerRunning`, `Test-ContainerExists`, `Wait-Port`). `setup.ps1` now reports Docker status as a non-fatal warning.

`docs/local-emulators.md` covers lifecycle, the certificate situation (vnext-preview speaks HTTP on 8081 — no cert wrangling needed), and the `-NoEmulators` / `clean.ps1` escape hatches.

### Bugs the end-to-end test caught and fixed in-flight
- `local.settings.sample.json`: `Cosmos__Endpoint` → `http://localhost:8081/` (vnext-preview is plain HTTP). The legacy-emulator cert bypass in `CosmosClient` is kept for compatibility.
- Model `Etag` properties: add `[Newtonsoft.Json.JsonProperty("_etag")]` so Cosmos's default Newtonsoft deserializer populates them (System.Text.Json's `JsonPropertyName` only handles outbound serialization).
- `FunctionHelpers.Ok` / `Created` / `IfMatch`: ETag header values are now RFC 7232-quoted (`"abc-123"` not `abc-123`) so `HttpHeaders` accepts them; `If-Match` values are stripped of surrounding quotes before being handed to Cosmos.

### Verified end-to-end locally
```
start.ps1 (boots emulators + vite + func)
seed.ps1  (parses the May 2026 docx into slypn.newsletters)
GET  /api/newsletters     -> 200 + seeded item with populated _etag
POST /api/articles        -> 201 + ETag: "..."
GET  /api/articles/{slug} -> 200 + ETag: "..."
PUT  with stale If-Match  -> 412
stop.ps1  (vite + func + both containers stopped)
```

### Test plan
- [x] `start.ps1` brings up all four services.
- [x] `seed.ps1` populates Cosmos.
- [x] CRUD against real Cosmos works incl. 412 on ETag mismatch.
- [x] `stop.ps1` shuts down vite + func + containers cleanly.
- [x] `clean.ps1` removes containers.
- [ ] CI green (Docker is not exercised in CI — these scripts are local-dev only).

Closes #17