### PR TITLE
feat(web): MSAL.js auth + Pinia auth store + fetch wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ $RECYCLE.BIN/
 .env
 .env.local
 .env.*.local
+src/web/.env
 *.pem
 *.key
 secrets.*

--- a/src/web/.env.example
+++ b/src/web/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env.local (gitignored) and fill in real values from docs/auth-setup.md.
+# Empty values disable MSAL — the app renders but Sign in is shown as unavailable.
+
+VITE_MSAL_AUTHORITY=https://slypn.ciamlogin.com/<tenant-id>/v2.0
+VITE_MSAL_CLIENT_ID=<spa-client-id>
+VITE_API_SCOPE=api://<api-client-id>/access_as_user

--- a/src/web/env.d.ts
+++ b/src/web/env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_MSAL_AUTHORITY?: string
+  readonly VITE_MSAL_CLIENT_ID?: string
+  readonly VITE_API_SCOPE?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "slypn-web",
       "version": "0.0.1",
       "dependencies": {
+        "@azure/msal-browser": "^3.27.0",
         "pinia": "^2.2.6",
         "vue": "^3.5.13",
         "vue-router": "^4.4.5"
@@ -38,6 +39,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.30.0.tgz",
+      "integrity": "sha512-I0XlIGVdM4E9kYP5eTjgW8fgATdzwxJvQ6bm2PNiHaZhEuUz47NYw1xHthC9R+lXz4i9zbShS0VdLyxd7n0GGA==",
+      "dependencies": {
+        "@azure/msal-common": "14.16.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.1.tgz",
+      "integrity": "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . --max-warnings 0"
   },
   "dependencies": {
+    "@azure/msal-browser": "^3.27.0",
     "pinia": "^2.2.6",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import TulipIcon from '@/components/common/TulipIcon.vue'
+import { useAuthStore } from '@/stores/auth'
 
 const navItems = [
   { to: '/',           label: 'Home' },
@@ -13,7 +14,32 @@ const navItems = [
   { to: '/newsletter', label: 'Newsletter' },
 ]
 
+const auth = useAuthStore()
+const router = useRouter()
 const mobileOpen = ref(false)
+const userMenuOpen = ref(false)
+
+async function onSignIn() {
+  if (!auth.isConfigured) {
+    router.push({ name: 'login' })
+    return
+  }
+  try {
+    await auth.login()
+  } catch (err) {
+    console.error('login failed', err)
+    router.push({ name: 'login' })
+  }
+}
+
+async function onSignOut() {
+  userMenuOpen.value = false
+  try {
+    await auth.logout()
+  } catch (err) {
+    console.error('logout failed', err)
+  }
+}
 </script>
 
 <template>
@@ -41,13 +67,49 @@ const mobileOpen = ref(false)
         </RouterLink>
       </nav>
 
-      <div class="hidden md:block">
-        <RouterLink
-          to="/login"
+      <div class="relative hidden md:block">
+        <button
+          v-if="auth.isAuthenticated"
+          type="button"
+          class="flex items-center gap-2 rounded-full bg-slypn-50 px-3 py-1.5 text-sm font-semibold text-slypn-700 hover:bg-slypn-100"
+          :aria-expanded="userMenuOpen"
+          @click="userMenuOpen = !userMenuOpen"
+        >
+          <span class="grid h-7 w-7 place-items-center rounded-full bg-slypn-600 text-xs font-bold text-white">
+            {{ auth.displayName.charAt(0).toUpperCase() }}
+          </span>
+          <span class="max-w-[10rem] truncate">{{ auth.displayName }}</span>
+        </button>
+        <button
+          v-else
+          type="button"
           class="rounded-md bg-slypn-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-slypn-700"
+          @click="onSignIn"
         >
           Sign in
-        </RouterLink>
+        </button>
+
+        <div
+          v-if="auth.isAuthenticated && userMenuOpen"
+          class="absolute right-0 mt-2 w-56 overflow-hidden rounded-md border border-slypn-100 bg-white shadow-lg"
+          @mouseleave="userMenuOpen = false"
+        >
+          <div class="border-b border-slypn-100 px-4 py-2 text-xs text-slypn-900/60">
+            Signed in as
+            <p class="mt-0.5 truncate font-medium text-slypn-900">{{ auth.account?.username }}</p>
+          </div>
+          <ul class="text-sm text-slypn-700">
+            <li v-if="auth.isContributor || auth.isAdmin">
+              <RouterLink to="/editor" class="block px-4 py-2 hover:bg-slypn-50" @click="userMenuOpen = false">Editor</RouterLink>
+            </li>
+            <li v-if="auth.isAdmin">
+              <RouterLink to="/admin" class="block px-4 py-2 hover:bg-slypn-50" @click="userMenuOpen = false">Admin</RouterLink>
+            </li>
+            <li>
+              <button class="block w-full px-4 py-2 text-left hover:bg-slypn-50" @click="onSignOut">Sign out</button>
+            </li>
+          </ul>
+        </div>
       </div>
 
       <button
@@ -84,13 +146,20 @@ const mobileOpen = ref(false)
         >
           {{ item.label }}
         </RouterLink>
-        <RouterLink
-          to="/login"
+        <button
+          v-if="!auth.isAuthenticated"
           class="mt-1 rounded-md bg-slypn-600 px-3 py-2 text-center text-base font-semibold text-white hover:bg-slypn-700"
-          @click="mobileOpen = false"
+          @click="mobileOpen = false; onSignIn()"
         >
           Sign in
-        </RouterLink>
+        </button>
+        <button
+          v-else
+          class="mt-1 rounded-md border border-slypn-200 bg-white px-3 py-2 text-center text-base font-semibold text-slypn-700 hover:bg-slypn-50"
+          @click="mobileOpen = false; onSignOut()"
+        >
+          Sign out
+        </button>
       </div>
     </nav>
   </header>

--- a/src/web/src/lib/api.ts
+++ b/src/web/src/lib/api.ts
@@ -1,0 +1,34 @@
+import { useAuthStore } from '@/stores/auth'
+
+/**
+ * Thin fetch wrapper for the SLYPN API.
+ *
+ * - Prepends `/api` so callers pass the relative path (e.g. `/articles`).
+ * - Attaches `Authorization: Bearer <token>` when the user is signed in.
+ * - Defaults Content-Type to application/json for requests with a body.
+ *
+ * Public endpoints work unauthenticated; the bearer header is just absent.
+ */
+export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const auth = useAuthStore()
+  const headers = new Headers(init.headers)
+
+  if (auth.isAuthenticated) {
+    const token = await auth.acquireToken()
+    if (token) headers.set('Authorization', `Bearer ${token}`)
+  }
+  if (init.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  return fetch(`/api${path}`, { ...init, headers })
+}
+
+export async function apiJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const resp = await apiFetch(path, init)
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`${resp.status} ${resp.statusText}${body ? ` — ${body}` : ''}`)
+  }
+  return resp.json() as Promise<T>
+}

--- a/src/web/src/lib/msal.ts
+++ b/src/web/src/lib/msal.ts
@@ -1,0 +1,56 @@
+import {
+  PublicClientApplication,
+  type AccountInfo,
+  type AuthenticationResult,
+  type Configuration,
+  type SilentRequest,
+} from '@azure/msal-browser'
+
+const clientId  = import.meta.env.VITE_MSAL_CLIENT_ID ?? ''
+const authority = import.meta.env.VITE_MSAL_AUTHORITY ?? ''
+export const apiScope = import.meta.env.VITE_API_SCOPE ?? ''
+
+/**
+ * True when all three MSAL env vars are present. When false the app still
+ * renders — Sign in is just shown as unavailable, useful for offline UI work
+ * and for the period before the tenant is set up (#19/#20).
+ */
+export const isAuthConfigured = Boolean(clientId && authority && apiScope)
+
+const msalConfig: Configuration = {
+  auth: {
+    clientId,
+    authority,
+    knownAuthorities: authority ? [new URL(authority).host] : [],
+    redirectUri:          `${window.location.origin}/auth/callback`,
+    postLogoutRedirectUri: window.location.origin,
+    navigateToLoginRequestUrl: true,
+  },
+  cache: {
+    cacheLocation: 'localStorage',
+    storeAuthStateInCookie: false,
+  },
+}
+
+export const msalInstance: PublicClientApplication | null = isAuthConfigured
+  ? new PublicClientApplication(msalConfig)
+  : null
+
+let initPromise: Promise<AuthenticationResult | null> | null = null
+
+/**
+ * Idempotent initialise. Returns the redirect response (when the page is
+ * resuming from /auth/callback) or null.
+ */
+export function ensureMsalInitialized(): Promise<AuthenticationResult | null> {
+  if (!msalInstance) return Promise.resolve(null)
+  if (!initPromise) {
+    initPromise = msalInstance.initialize()
+      .then(() => msalInstance!.handleRedirectPromise())
+  }
+  return initPromise
+}
+
+export function buildSilentRequest(account: AccountInfo): SilentRequest {
+  return { account, scopes: [apiScope] }
+}

--- a/src/web/src/main.ts
+++ b/src/web/src/main.ts
@@ -2,9 +2,14 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
+import { useAuthStore } from '@/stores/auth'
 import './assets/main.css'
 
 const app = createApp(App)
 app.use(createPinia())
 app.use(router)
-app.mount('#app')
+
+// Drive MSAL through initialize + handleRedirectPromise once before
+// the first render so the nav can show the signed-in account immediately.
+const auth = useAuthStore()
+auth.initialize().finally(() => app.mount('#app'))

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -8,6 +8,7 @@ import EventsView from '@/views/EventsView.vue'
 import ResourcesView from '@/views/ResourcesView.vue'
 import NewsletterView from '@/views/NewsletterView.vue'
 import LoginView from '@/views/LoginView.vue'
+import AuthCallbackView from '@/views/AuthCallbackView.vue'
 import NotFoundView from '@/views/NotFoundView.vue'
 
 export default createRouter({
@@ -23,6 +24,7 @@ export default createRouter({
     { path: '/resources',         name: 'resources',       component: ResourcesView },
     { path: '/newsletter',        name: 'newsletter',      component: NewsletterView },
     { path: '/login',             name: 'login',           component: LoginView },
+    { path: '/auth/callback',     name: 'auth-callback',   component: AuthCallbackView },
     { path: '/:pathMatch(.*)*',   name: 'not-found',       component: NotFoundView },
   ],
 })

--- a/src/web/src/stores/auth.ts
+++ b/src/web/src/stores/auth.ts
@@ -1,0 +1,115 @@
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import {
+  InteractionRequiredAuthError,
+  type AccountInfo,
+} from '@azure/msal-browser'
+import {
+  apiScope,
+  buildSilentRequest,
+  ensureMsalInitialized,
+  isAuthConfigured,
+  msalInstance,
+} from '@/lib/msal'
+
+type IdTokenClaims = Record<string, unknown> & { roles?: string[] }
+
+export const useAuthStore = defineStore('auth', () => {
+  const account = ref<AccountInfo | null>(null)
+  const initializing = ref(false)
+  const initialized = ref(false)
+
+  const isAuthenticated = computed(() => account.value !== null)
+  const isConfigured = computed(() => isAuthConfigured)
+
+  const roles = computed<string[]>(() => {
+    const claims = account.value?.idTokenClaims as IdTokenClaims | undefined
+    return Array.isArray(claims?.roles) ? claims!.roles! : []
+  })
+  const isAdmin       = computed(() => roles.value.includes('Admin'))
+  const isContributor = computed(() => roles.value.includes('Contributor'))
+  const isMember      = computed(() => roles.value.includes('Member'))
+
+  const displayName = computed(() =>
+    (account.value?.name ?? account.value?.username ?? '').trim() || 'Member')
+
+  /**
+   * Drive MSAL through initialize + handleRedirectPromise and pick up an
+   * already-cached account if any. Safe to call multiple times.
+   */
+  async function initialize() {
+    if (initialized.value || initializing.value) return
+    initializing.value = true
+    try {
+      const redirectResult = await ensureMsalInitialized()
+      if (redirectResult?.account) {
+        msalInstance!.setActiveAccount(redirectResult.account)
+        account.value = redirectResult.account
+      } else if (msalInstance) {
+        const cached = msalInstance.getAllAccounts()[0]
+        if (cached) {
+          msalInstance.setActiveAccount(cached)
+          account.value = cached
+        }
+      }
+      initialized.value = true
+    } finally {
+      initializing.value = false
+    }
+  }
+
+  async function login(returnTo?: string) {
+    if (!msalInstance) {
+      throw new Error('Auth not configured — set VITE_MSAL_* env vars.')
+    }
+    await ensureMsalInitialized()
+    await msalInstance.loginRedirect({
+      scopes: [apiScope],
+      redirectStartPage: returnTo ?? window.location.href,
+    })
+  }
+
+  async function logout() {
+    if (!msalInstance || !account.value) {
+      account.value = null
+      return
+    }
+    await msalInstance.logoutRedirect({ account: account.value })
+  }
+
+  /**
+   * Returns a bearer access token for the SLYPN API, or null if the user
+   * isn't signed in / MSAL isn't configured. Falls back to interactive
+   * sign-in if silent acquisition fails for an interaction-required reason.
+   */
+  async function acquireToken(): Promise<string | null> {
+    if (!msalInstance || !account.value) return null
+    await ensureMsalInitialized()
+    try {
+      const result = await msalInstance.acquireTokenSilent(buildSilentRequest(account.value))
+      return result.accessToken
+    } catch (err) {
+      if (err instanceof InteractionRequiredAuthError) {
+        await msalInstance.acquireTokenRedirect({ scopes: [apiScope] })
+        return null
+      }
+      throw err
+    }
+  }
+
+  return {
+    account,
+    initialized,
+    isAuthenticated,
+    isConfigured,
+    roles,
+    isAdmin,
+    isContributor,
+    isMember,
+    displayName,
+    initialize,
+    login,
+    logout,
+    acquireToken,
+  }
+})

--- a/src/web/src/views/AuthCallbackView.vue
+++ b/src/web/src/views/AuthCallbackView.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const router = useRouter()
+const auth = useAuthStore()
+
+onMounted(async () => {
+  await auth.initialize()
+  // MSAL.handleRedirectPromise already consumed the hash. Send the user home.
+  await router.replace({ name: 'home' })
+})
+</script>
+
+<template>
+  <main class="flex min-h-[40vh] items-center justify-center px-6 py-20">
+    <p class="font-display text-slypn-700">Signing you in&hellip;</p>
+  </main>
+</template>

--- a/src/web/src/views/LoginView.vue
+++ b/src/web/src/views/LoginView.vue
@@ -1,30 +1,60 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const auth = useAuthStore()
+const error = ref<string | null>(null)
+
+async function signIn() {
+  error.value = null
+  try {
+    await auth.login()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  }
+}
 </script>
 
 <template>
   <HeroBanner
     eyebrow="Sign in"
-    title="Member sign-in is coming soon"
-    subtitle="We're wiring up sign-in via Entra External ID — with Google and Facebook as social options — as part of Phase 3 of the build. Until then, all public content is available without signing in."
+    title="Sign in to SLYPN"
+    subtitle="Sign-in uses Entra External ID with Google or Facebook as social options. Public content is available without signing in; signing in unlocks members-only features, drafts, and admin."
   />
 
-  <section class="mx-auto max-w-3xl px-6 py-16">
-    <h2 class="font-display text-2xl font-bold text-slypn-700">What sign-in will unlock</h2>
-    <ul class="mt-4 space-y-3 text-slypn-900/85">
-      <li><strong>Members</strong> — a private dashboard, RSVP for events, comment on articles.</li>
-      <li><strong>Contributors</strong> — write articles and blog posts in the browser with autosave; admin approves before publication.</li>
-      <li><strong>Admins</strong> — manage members, articles, events, resources, and the newsletter.</li>
-    </ul>
+  <section class="mx-auto max-w-2xl px-6 py-16">
+    <div v-if="auth.isAuthenticated" class="rounded-xl border border-slypn-100 bg-white p-6 shadow-sm">
+      <p class="font-display text-lg font-semibold text-slypn-700">
+        You&rsquo;re already signed in as {{ auth.displayName }}.
+      </p>
+      <p class="mt-2 text-sm text-slypn-900/75">
+        Use the menu in the top right to view your editor or admin tools, or to sign out.
+      </p>
+    </div>
 
-    <p class="mt-8 text-sm text-slypn-900/70">
-      The detailed plan is on
-      <a
-        href="https://github.com/sinclapa/slypn/issues/18"
-        class="text-slypn-600 underline underline-offset-4 hover:text-slypn-700"
-        rel="noopener"
-        target="_blank"
-      >issue #18 (Phase 3 &mdash; Auth + RBAC)</a>.
-    </p>
+    <div v-else-if="auth.isConfigured">
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-md bg-slypn-600 px-6 py-3 text-base font-semibold text-white shadow-sm hover:bg-slypn-700"
+        @click="signIn"
+      >
+        Continue with Entra External ID
+      </button>
+      <p class="mt-3 text-sm text-slypn-900/65">
+        You&rsquo;ll be redirected to the SLYPN sign-in page where you can use email + password, Google, or Facebook.
+      </p>
+      <p v-if="error" class="mt-4 rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">{{ error }}</p>
+    </div>
+
+    <div v-else class="rounded-xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
+      <p class="font-display font-semibold">Sign-in is not configured in this environment.</p>
+      <p class="mt-2">
+        Set <code class="rounded bg-amber-100 px-1.5 py-0.5">VITE_MSAL_CLIENT_ID</code>,
+        <code class="rounded bg-amber-100 px-1.5 py-0.5">VITE_MSAL_AUTHORITY</code>, and
+        <code class="rounded bg-amber-100 px-1.5 py-0.5">VITE_API_SCOPE</code> in <code>src/web/.env.local</code>.
+        See <a class="underline" href="https://github.com/sinclapa/slypn/blob/main/docs/auth-setup.md" rel="noopener" target="_blank">docs/auth-setup.md</a>.
+      </p>
+    </div>
   </section>
 </template>


### PR DESCRIPTION
## Summary
Wires Entra External ID sign-in into the Vue app. When env vars aren't set the app still renders fine and Sign in shows a clear "not configured" message pointing at `docs/auth-setup.md`.

### What's new
- **`@azure/msal-browser ^3.27.0`** — PKCE flow with `localStorage` cache, `/auth/callback` redirect URI.
- **`src/web/.env.example`** + augmented `env.d.ts` — `VITE_MSAL_AUTHORITY`, `VITE_MSAL_CLIENT_ID`, `VITE_API_SCOPE`.
- **`lib/msal.ts`** — `PublicClientApplication` factory + idempotent `ensureMsalInitialized()` that runs `initialize` + `handleRedirectPromise` exactly once.
- **`stores/auth.ts`** — Pinia store holding the account, exposing `roles` + `isAdmin/isContributor/isMember` (from the id-token `roles` claim), with `login` (redirect), `logout`, and `acquireToken` (silent with interactive fallback when consent required).
- **`lib/api.ts`** — `apiFetch` / `apiJson` prepends `/api`, attaches `Authorization: Bearer ...` when signed in. Public reads still work unauthenticated.
- **`views/AuthCallbackView.vue`** + `/auth/callback` route — consumes the MSAL redirect, navigates home.
- **`main.ts`** — drives `auth.initialize()` before mounting so the nav can show the signed-in user from the first render.
- **`AppNav.vue`** — user menu with initial avatar + display name, role-aware Editor / Admin links, Sign out. Mobile drawer mirrors the same.
- **`LoginView.vue`** — real "Continue with Entra External ID" button when configured; clear unconfigured-banner with env-var hints otherwise.

### Test plan
- [x] `npm run lint` clean.
- [x] `npm run build` clean — 212 modules, 414 KB JS / 18 KB CSS gzipped 119 KB / 4 KB. MSAL is the new heavyweight.
- [x] Local `/`, `/login`, `/auth/callback` all return HTTP 200.
- [ ] End-to-end sign-in dance requires a real Entra External ID tenant (#19 manual setup).
- [ ] CI green.

Closes #21