### PR TITLE
feat(api): JWT validation middleware + [RequireRole] for Functions

### DIFF
--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -3,6 +3,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Slypn.Api.Infrastructure;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
@@ -31,6 +32,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, ILogger<ArticlesF
     }
 
     [Function("CreateArticle")]
+    [RequireRole("Admin", "Contributor")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles")] HttpRequestData req,
         CancellationToken ct)
@@ -47,6 +49,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, ILogger<ArticlesF
     }
 
     [Function("ReplaceArticle")]
+    [RequireRole("Admin", "Contributor")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "articles/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -63,6 +66,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, ILogger<ArticlesF
     }
 
     [Function("DeleteArticle")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "articles/{id}")] HttpRequestData req,
         string id, CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/EventsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/EventsFunctions.cs
@@ -2,6 +2,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Slypn.Api.Infrastructure;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
@@ -21,6 +22,7 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     }
 
     [Function("CreateEvent")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "events")] HttpRequestData req,
         CancellationToken ct)
@@ -37,6 +39,7 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     }
 
     [Function("ReplaceEvent")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "events/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -53,6 +56,7 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     }
 
     [Function("DeleteEvent")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "events/{id}")] HttpRequestData req,
         string id, CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -2,6 +2,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Slypn.Api.Infrastructure;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
@@ -20,6 +21,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
     }
 
     [Function("CreateNewsletter")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "newsletters")] HttpRequestData req,
         CancellationToken ct)
@@ -36,6 +38,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
     }
 
     [Function("ReplaceNewsletter")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "newsletters/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -52,6 +55,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
     }
 
     [Function("DeleteNewsletter")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "newsletters/{id}")] HttpRequestData req,
         string id, CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/ResourcesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ResourcesFunctions.cs
@@ -2,6 +2,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Slypn.Api.Infrastructure;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
@@ -20,6 +21,7 @@ public sealed class ResourcesFunctions(IContentRepository repo, ILogger<Resource
     }
 
     [Function("CreateResource")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "resources")] HttpRequestData req,
         CancellationToken ct)
@@ -36,6 +38,7 @@ public sealed class ResourcesFunctions(IContentRepository repo, ILogger<Resource
     }
 
     [Function("ReplaceResource")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "resources/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -52,6 +55,7 @@ public sealed class ResourcesFunctions(IContentRepository repo, ILogger<Resource
     }
 
     [Function("DeleteResource")]
+    [RequireRole("Admin")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "resources/{id}")] HttpRequestData req,
         string id, CancellationToken ct)

--- a/src/api/Slypn.Api/Infrastructure/EntraJwtValidator.cs
+++ b/src/api/Slypn.Api/Infrastructure/EntraJwtValidator.cs
@@ -1,0 +1,54 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Slypn.Api.Infrastructure;
+
+public sealed class EntraJwtValidator : IJwtValidator
+{
+    private readonly EntraOptions _opts;
+    private readonly ConfigurationManager<OpenIdConnectConfiguration>? _configManager;
+    private readonly JwtSecurityTokenHandler _handler = new();
+
+    public EntraJwtValidator(IOptions<EntraOptions> options)
+    {
+        _opts = options.Value;
+        if (!_opts.IsConfigured) return;
+
+        var metadataAddress = $"{_opts.Authority!.TrimEnd('/')}/.well-known/openid-configuration";
+        _configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+            metadataAddress,
+            new OpenIdConnectConfigurationRetriever(),
+            new HttpDocumentRetriever { RequireHttps = !metadataAddress.StartsWith("http://localhost", StringComparison.OrdinalIgnoreCase) });
+    }
+
+    public bool IsConfigured => _opts.IsConfigured;
+
+    public async Task<ClaimsPrincipal> ValidateAsync(string token, CancellationToken ct)
+    {
+        if (_configManager is null)
+            throw new InvalidOperationException("EntraJwtValidator is not configured.");
+
+        var config = await _configManager.GetConfigurationAsync(ct);
+
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer           = true,
+            ValidIssuers             = _opts.ValidIssuers.Length > 0 ? _opts.ValidIssuers : [ _opts.Authority!.TrimEnd('/') ],
+            ValidateAudience         = true,
+            ValidAudience            = _opts.Audience,
+            ValidateLifetime         = true,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys        = config.SigningKeys,
+            ClockSkew                = TimeSpan.FromMinutes(2),
+            RoleClaimType            = "roles",
+            NameClaimType            = "name",
+        };
+
+        var principal = _handler.ValidateToken(token, validationParameters, out _);
+        return principal;
+    }
+}

--- a/src/api/Slypn.Api/Infrastructure/EntraOptions.cs
+++ b/src/api/Slypn.Api/Infrastructure/EntraOptions.cs
@@ -1,0 +1,29 @@
+namespace Slypn.Api.Infrastructure;
+
+public sealed class EntraOptions
+{
+    public const string SectionName = "AzureAd";
+
+    /// <summary>Entra External ID authority, e.g. https://slypn.ciamlogin.com/&lt;tenant-id&gt;/v2.0.</summary>
+    public string? Authority { get; set; }
+
+    /// <summary>Expected audience claim, e.g. api://&lt;api-client-id&gt;.</summary>
+    public string? Audience { get; set; }
+
+    /// <summary>Acceptable issuers. If empty, defaults to a single issuer matching the authority.</summary>
+    public string[] ValidIssuers { get; set; } = [];
+
+    /// <summary>Tenant id (kept separately so the OpenID metadata document is reachable).</summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
+    /// Local-dev escape hatch — bypasses JWT validation and synthesises an Admin principal for
+    /// any [RequireRole] endpoint. Set to true in local.settings.json when working without Entra.
+    /// MUST be false in any deployed environment.
+    /// </summary>
+    public bool SkipAuth { get; set; }
+
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(Authority) &&
+        !string.IsNullOrWhiteSpace(Audience);
+}

--- a/src/api/Slypn.Api/Infrastructure/IJwtValidator.cs
+++ b/src/api/Slypn.Api/Infrastructure/IJwtValidator.cs
@@ -1,0 +1,14 @@
+using System.Security.Claims;
+
+namespace Slypn.Api.Infrastructure;
+
+public interface IJwtValidator
+{
+    bool IsConfigured { get; }
+
+    /// <summary>
+    /// Validates a raw bearer token against the configured Entra authority + audience.
+    /// Returns the principal on success; throws on failure (caller maps to 401).
+    /// </summary>
+    Task<ClaimsPrincipal> ValidateAsync(string token, CancellationToken ct);
+}

--- a/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
@@ -1,0 +1,151 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+using System.Security.Claims;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Slypn.Api.Infrastructure;
+
+public sealed class JwtMiddleware(
+    IJwtValidator validator,
+    IOptions<EntraOptions> options,
+    ILogger<JwtMiddleware> logger) : IFunctionsWorkerMiddleware
+{
+    private static readonly ConcurrentDictionary<string, RequireRoleAttribute?> AttrCache = new();
+
+    public const string PrincipalContextKey = "Slypn.Principal";
+
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        var attr = GetRoleAttribute(context);
+
+        // No auth requirement on this Function — proceed unauthenticated.
+        if (attr is null)
+        {
+            await next(context);
+            return;
+        }
+
+        // Need HTTP context to short-circuit with a 401/403.
+        var httpReq = await context.GetHttpRequestDataAsync();
+        if (httpReq is null)
+        {
+            // Non-HTTP trigger with [RequireRole] is a misconfiguration; refuse loudly.
+            logger.LogError("[RequireRole] is only supported on HTTP-triggered functions.");
+            throw new InvalidOperationException("[RequireRole] is only supported on HTTP-triggered functions.");
+        }
+
+        // Local-dev escape hatch — synthesise an Admin principal when SkipAuth=true.
+        if (options.Value.SkipAuth)
+        {
+            logger.LogWarning("AzureAd:SkipAuth=true — bypassing JWT validation. DO NOT use in production.");
+            var identity = new ClaimsIdentity("dev", "name", "roles");
+            identity.AddClaim(new Claim("name", "dev-admin"));
+            identity.AddClaim(new Claim("oid",  "00000000-0000-0000-0000-000000000000"));
+            foreach (var role in new[] { "Admin", "Contributor", "Member" })
+                identity.AddClaim(new Claim("roles", role));
+            context.Items[PrincipalContextKey] = new ClaimsPrincipal(identity);
+            await next(context);
+            return;
+        }
+
+        if (!validator.IsConfigured)
+        {
+            await ShortCircuit(context, httpReq, HttpStatusCode.ServiceUnavailable,
+                "Auth is not configured. Set AzureAd__Authority / AzureAd__Audience or AzureAd__SkipAuth=true.");
+            return;
+        }
+
+        var token = ExtractBearer(httpReq);
+        if (token is null)
+        {
+            await ShortCircuit(context, httpReq, HttpStatusCode.Unauthorized, "Missing Bearer token.");
+            return;
+        }
+
+        ClaimsPrincipal principal;
+        try
+        {
+            principal = await validator.ValidateAsync(token, context.CancellationToken);
+        }
+        catch (SecurityTokenException ex)
+        {
+            logger.LogInformation(ex, "JWT validation failed: {Message}", ex.Message);
+            await ShortCircuit(context, httpReq, HttpStatusCode.Unauthorized, $"Invalid token: {ex.Message}");
+            return;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unexpected error validating JWT");
+            await ShortCircuit(context, httpReq, HttpStatusCode.Unauthorized, "Token validation error.");
+            return;
+        }
+
+        if (attr.Roles.Length > 0 && !attr.Roles.Any(r => principal.IsInRole(r)))
+        {
+            await ShortCircuit(context, httpReq, HttpStatusCode.Forbidden,
+                $"Required role: {string.Join(" or ", attr.Roles)}.");
+            return;
+        }
+
+        context.Items[PrincipalContextKey] = principal;
+        await next(context);
+    }
+
+    private static RequireRoleAttribute? GetRoleAttribute(FunctionContext context)
+    {
+        return AttrCache.GetOrAdd(context.FunctionDefinition.EntryPoint, entryPoint =>
+        {
+            // EntryPoint is "Namespace.Type.Method".
+            var lastDot = entryPoint.LastIndexOf('.');
+            if (lastDot < 0) return null;
+            var typeName   = entryPoint[..lastDot];
+            var methodName = entryPoint[(lastDot + 1)..];
+
+            var type = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(SafeGetTypes)
+                .FirstOrDefault(t => t.FullName == typeName);
+            if (type is null) return null;
+
+            var method = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+                .FirstOrDefault(m => m.Name == methodName);
+            return method?.GetCustomAttribute<RequireRoleAttribute>();
+        });
+    }
+
+    private static IEnumerable<Type> SafeGetTypes(Assembly a)
+    {
+        try { return a.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
+    }
+
+    private static string? ExtractBearer(HttpRequestData req)
+    {
+        if (!req.Headers.TryGetValues("Authorization", out var vals)) return null;
+        var raw = vals.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        const string prefix = "Bearer ";
+        return raw.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ? raw[prefix.Length..].Trim() : null;
+    }
+
+    private static async Task ShortCircuit(FunctionContext context, HttpRequestData req, HttpStatusCode code, string message)
+    {
+        var resp = req.CreateResponse(code);
+        await resp.WriteStringAsync(message);
+        context.GetInvocationResult().Value = resp;
+    }
+}
+
+public static class FunctionContextExtensions
+{
+    public static ClaimsPrincipal? GetPrincipal(this FunctionContext context) =>
+        context.Items.TryGetValue(JwtMiddleware.PrincipalContextKey, out var v) ? v as ClaimsPrincipal : null;
+
+    public static string? GetUserOid(this FunctionContext context) =>
+        context.GetPrincipal()?.FindFirst("oid")?.Value;
+}

--- a/src/api/Slypn.Api/Infrastructure/RequireRoleAttribute.cs
+++ b/src/api/Slypn.Api/Infrastructure/RequireRoleAttribute.cs
@@ -1,0 +1,12 @@
+namespace Slypn.Api.Infrastructure;
+
+/// <summary>
+/// Marks a Function as requiring a signed-in caller. If <see cref="Roles"/> is non-empty,
+/// the caller must hold at least one of the listed roles (logical OR). An empty role list
+/// means "authenticated, no specific role".
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class RequireRoleAttribute(params string[] roles) : Attribute
+{
+    public string[] Roles { get; } = roles;
+}

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -8,10 +8,12 @@ using Slypn.Api.Infrastructure;
 using Slypn.Api.Services;
 
 var host = new HostBuilder()
-    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureFunctionsWorkerDefaults(builder =>
+    {
+        builder.UseMiddleware<JwtMiddleware>();
+    })
     .ConfigureServices((context, services) =>
     {
-        // camelCase + lowercase enum names on every HttpResponseData.WriteAsJsonAsync.
         services.Configure<WorkerOptions>(options =>
         {
             options.Serializer = new JsonObjectSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
@@ -30,6 +32,11 @@ var host = new HostBuilder()
             .AddOptions<StorageOptions>()
             .Bind(context.Configuration.GetSection(StorageOptions.SectionName));
         services.AddSingleton<IBlobService, BlobService>();
+
+        services
+            .AddOptions<EntraOptions>()
+            .Bind(context.Configuration.GetSection(EntraOptions.SectionName));
+        services.AddSingleton<IJwtValidator, EntraJwtValidator>();
     })
     .Build();
 

--- a/src/api/Slypn.Api/Slypn.Api.csproj
+++ b/src/api/Slypn.Api/Slypn.Api.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/api/Slypn.Api/local.settings.sample.json
+++ b/src/api/Slypn.Api/local.settings.sample.json
@@ -8,7 +8,11 @@
     "Cosmos__Key": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
     "Cosmos__Database": "slypn",
     "Storage__ConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;",
-    "Storage__MediaContainer": "media"
+    "Storage__MediaContainer": "media",
+    "AzureAd__Authority": "",
+    "AzureAd__Audience": "",
+    "AzureAd__TenantId": "",
+    "AzureAd__SkipAuth": "true"
   },
   "Host": {
     "CORS": "http://localhost:5173",


### PR DESCRIPTION
## Summary
Isolated-worker middleware that validates Entra External ID JWTs, attaches the principal to `FunctionContext`, and enforces a `[RequireRole(...)]` attribute on the entry-point method.

### Components
| File | Role |
|---|---|
| `Infrastructure/EntraOptions.cs` | `Authority`, `Audience`, `ValidIssuers`, `TenantId`, `SkipAuth` (local-dev escape hatch). |
| `Infrastructure/RequireRoleAttribute.cs` | Marks a Function as authenticated; role list is OR-checked. Empty list = "any signed-in user". |
| `Infrastructure/IJwtValidator.cs` + `EntraJwtValidator.cs` | `ConfigurationManager` caches JWKS; ValidIssuer/Audience/SigningKey validation; `RoleClaimType` pinned to `roles`; 2-minute clock skew. |
| `Infrastructure/JwtMiddleware.cs` | The actual enforcement (see decision table below). Caches `RequireRoleAttribute` lookup per `EntryPoint`. |
| `FunctionContext.GetPrincipal()` / `GetUserOid()` | Helpers for downstream handlers. |

### Decision table

| State | Outcome |
|---|---|
| No `[RequireRole]` on the function | Passes through anonymously — public reads unaffected. |
| `SkipAuth=true` (local-dev only, logs a warning each call) | Synthesises an Admin/Contributor/Member principal and proceeds. |
| `AzureAd` not configured + `SkipAuth=false` | `503` with a hint pointing at `docs/auth-setup.md`. |
| Missing/invalid token | `401`. |
| Role mismatch | `403`. |

### Applied attributes
- **Articles**: Create/Replace → `Admin | Contributor`; Delete → `Admin` only.
- **Events / Resources / Newsletters**: Create/Replace/Delete → `Admin`.

(Contributor write paths get narrower in #28 once draft ownership is enforced.)

### `local.settings.sample.json`
Adds `AzureAd__Authority/Audience/TenantId` placeholders + `AzureAd__SkipAuth: "true"` so a fresh clone can still exercise the write endpoints locally without an Entra tenant. **MUST be `false` in any deployed environment** — wiring is in #41.

### Test plan
- [x] `dotnet build` clean.
- [x] GET `/api/articles` → 200 unaffected by middleware.
- [x] POST `/api/articles` with `SkipAuth=true` → 200 + Admin synth.
- [x] POST `/api/articles` with `SkipAuth=false`, no `AzureAd` → 503.
- [x] POST `/api/articles` with `SkipAuth=false`, fake bearer → 503.
- [ ] End-to-end with a real Entra-issued token: needs the manual tenant setup from #19.
- [ ] CI green.

Closes #22