### PR TITLE
feat(web): route guards + role-aware nav + dashboard/editor/admin shells

### DIFF
--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -99,6 +99,9 @@ async function onSignOut() {
             <p class="mt-0.5 truncate font-medium text-slypn-900">{{ auth.account?.username }}</p>
           </div>
           <ul class="text-sm text-slypn-700">
+            <li>
+              <RouterLink to="/dashboard" class="block px-4 py-2 hover:bg-slypn-50" @click="userMenuOpen = false">Dashboard</RouterLink>
+            </li>
             <li v-if="auth.isContributor || auth.isAdmin">
               <RouterLink to="/editor" class="block px-4 py-2 hover:bg-slypn-50" @click="userMenuOpen = false">Editor</RouterLink>
             </li>

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vue-router'
 import HomeView from '@/views/HomeView.vue'
 import AboutView from '@/views/AboutView.vue'
 import ArticlesView from '@/views/ArticlesView.vue'
@@ -9,9 +9,22 @@ import ResourcesView from '@/views/ResourcesView.vue'
 import NewsletterView from '@/views/NewsletterView.vue'
 import LoginView from '@/views/LoginView.vue'
 import AuthCallbackView from '@/views/AuthCallbackView.vue'
+import DashboardView from '@/views/DashboardView.vue'
+import EditorView from '@/views/EditorView.vue'
+import AdminView from '@/views/AdminView.vue'
 import NotFoundView from '@/views/NotFoundView.vue'
+import { useAuthStore } from '@/stores/auth'
 
-export default createRouter({
+declare module 'vue-router' {
+  interface RouteMeta {
+    /** Redirect to /login if the user isn't signed in. */
+    requiresAuth?: boolean
+    /** Roles that may access the route. Logical OR. Implies requiresAuth. */
+    requiresRole?: string[]
+  }
+}
+
+const router = createRouter({
   history: createWebHistory(),
   scrollBehavior: () => ({ top: 0 }),
   routes: [
@@ -25,6 +38,31 @@ export default createRouter({
     { path: '/newsletter',        name: 'newsletter',      component: NewsletterView },
     { path: '/login',             name: 'login',           component: LoginView },
     { path: '/auth/callback',     name: 'auth-callback',   component: AuthCallbackView },
+
+    { path: '/dashboard', name: 'dashboard', component: DashboardView,
+      meta: { requiresAuth: true } },
+    { path: '/editor', name: 'editor', component: EditorView,
+      meta: { requiresAuth: true, requiresRole: ['Admin', 'Contributor'] } },
+    { path: '/admin', name: 'admin', component: AdminView,
+      meta: { requiresAuth: true, requiresRole: ['Admin'] } },
+
     { path: '/:pathMatch(.*)*',   name: 'not-found',       component: NotFoundView },
   ],
 })
+
+router.beforeEach(async (to: RouteLocationNormalized) => {
+  if (!to.meta.requiresAuth && !to.meta.requiresRole) return true
+
+  const auth = useAuthStore()
+  await auth.initialize()
+
+  if (!auth.isAuthenticated) {
+    return { name: 'login', query: { returnTo: to.fullPath } }
+  }
+  if (to.meta.requiresRole && !to.meta.requiresRole.some(r => auth.roles.includes(r))) {
+    return { name: 'home', query: { forbidden: to.fullPath } }
+  }
+  return true
+})
+
+export default router

--- a/src/web/src/views/AdminView.vue
+++ b/src/web/src/views/AdminView.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import HeroBanner from '@/components/common/HeroBanner.vue'
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Admin"
+    title="SLYPN administration"
+    subtitle="The approvals queue, member management, and content moderation views land with #24 and #29. This page is the role-guarded shell."
+  />
+
+  <section class="mx-auto max-w-3xl px-6 py-16 space-y-6">
+    <article class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
+      <h2 class="font-display text-lg font-bold text-slypn-700">Approvals (coming in #29)</h2>
+      <p class="mt-2 text-sm text-slypn-900/75">
+        Pending articles + blog posts grouped by author with inline publish / reject.
+      </p>
+    </article>
+    <article class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
+      <h2 class="font-display text-lg font-bold text-slypn-700">Members (coming in #24)</h2>
+      <p class="mt-2 text-sm text-slypn-900/75">
+        Invite a new member by email, assign a role, revoke access.
+      </p>
+    </article>
+  </section>
+</template>

--- a/src/web/src/views/DashboardView.vue
+++ b/src/web/src/views/DashboardView.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const auth = useAuthStore()
+</script>
+
+<template>
+  <main class="mx-auto max-w-3xl px-6 py-16">
+    <p class="font-display text-sm font-semibold uppercase tracking-[0.2em] text-slypn-500">
+      Dashboard
+    </p>
+    <h1 class="mt-2 text-4xl font-extrabold text-slypn-700">
+      Welcome back, {{ auth.displayName }}
+    </h1>
+    <p class="mt-3 text-slypn-900/80">
+      You&rsquo;re signed in as <code class="rounded bg-slypn-100 px-1.5 py-0.5 text-slypn-800">{{ auth.account?.username }}</code>.
+    </p>
+
+    <section class="mt-10">
+      <h2 class="font-display text-xl font-bold text-slypn-700">Your roles</h2>
+      <ul v-if="auth.roles.length" class="mt-3 flex flex-wrap gap-2">
+        <li
+          v-for="role in auth.roles"
+          :key="role"
+          class="rounded-full bg-slypn-100 px-3 py-1 text-sm font-medium text-slypn-800"
+        >
+          {{ role }}
+        </li>
+      </ul>
+      <p v-else class="mt-3 text-sm text-slypn-900/70">
+        You don&rsquo;t hold any SLYPN roles yet. An admin will assign one.
+      </p>
+    </section>
+
+    <section class="mt-10 grid gap-4 sm:grid-cols-2">
+      <RouterLink
+        v-if="auth.isContributor || auth.isAdmin"
+        to="/editor"
+        class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+      >
+        <p class="font-display font-bold text-slypn-700">Editor</p>
+        <p class="mt-2 text-sm text-slypn-900/75">
+          Draft articles and blog posts. Submit for admin approval when ready.
+        </p>
+      </RouterLink>
+      <RouterLink
+        v-if="auth.isAdmin"
+        to="/admin"
+        class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+      >
+        <p class="font-display font-bold text-slypn-700">Admin</p>
+        <p class="mt-2 text-sm text-slypn-900/75">
+          Approve pending content, manage members, edit anything.
+        </p>
+      </RouterLink>
+    </section>
+  </main>
+</template>

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import HeroBanner from '@/components/common/HeroBanner.vue'
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Editor"
+    title="Write something for the community"
+    subtitle="The rich-text editor with autosave and draft management lands with #26-#30. This page is the shell that the guard protects."
+  />
+
+  <section class="mx-auto max-w-3xl px-6 py-16">
+    <p class="text-slypn-900/80">
+      For now: see
+      <a
+        href="https://github.com/users/sinclapa/projects/2"
+        class="text-slypn-600 underline underline-offset-4 hover:text-slypn-700"
+        rel="noopener"
+        target="_blank"
+      >Phase 4</a> on the project board for the editor build plan.
+    </p>
+  </section>
+</template>

--- a/src/web/src/views/LoginView.vue
+++ b/src/web/src/views/LoginView.vue
@@ -1,15 +1,22 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import { useAuthStore } from '@/stores/auth'
 
 const auth = useAuthStore()
+const route = useRoute()
 const error = ref<string | null>(null)
+
+const returnTo = computed(() => {
+  const q = route.query.returnTo
+  return typeof q === 'string' && q.startsWith('/') ? q : '/'
+})
 
 async function signIn() {
   error.value = null
   try {
-    await auth.login()
+    await auth.login(window.location.origin + returnTo.value)
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err)
   }


### PR DESCRIPTION
## Summary
Protects the post-sign-in surface area of the app.

### Router
- `meta.requiresAuth?: boolean` and `meta.requiresRole?: string[]` added via vue-router module augmentation.
- Global `beforeEach`:
  1. Lets public routes through.
  2. Awaits `auth.initialize()` so the redirect knows about a cached MSAL account.
  3. Redirects unauthenticated callers to `/login?returnTo=<fullPath>`.
  4. Redirects 403-equivalent (auth but wrong role) to `/` with `?forbidden=<fullPath>` so a future toast can surface why.

### New protected routes
| Path | Required |
|---|---|
| `/dashboard` | any signed-in user |
| `/editor`    | `Admin` or `Contributor` |
| `/admin`     | `Admin` only |

### New views
- **`DashboardView`** — greets by display name, lists assigned roles, links to Editor/Admin if eligible.
- **`EditorView`** — shell pointing at #26 (rich-text editor).
- **`AdminView`** — shell pointing at #24 (member mgmt) + #29 (approvals).

### Bits glued together
- **LoginView** reads `?returnTo` from the query and passes it to `auth.login()` so MSAL `navigateToLoginRequestUrl` bounces the user back to the page they tried to open.
- **AppNav** user menu gains a Dashboard link above Editor / Admin.

### Test plan
- [x] `npm run lint` clean.
- [x] `npm run build` clean — 215 modules, 418 KB JS / 18 KB CSS gzipped 120 KB / 4 KB.
- [ ] Full sign-in/guard dance needs the real Entra tenant (manual setup from #19).
- [ ] CI green.

Closes #23