### PR TITLE
feat(api,web): admin invite-a-member flow end to end

### DIFF
--- a/src/api/Slypn.Api/Functions/MembersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MembersFunctions.cs
@@ -1,0 +1,92 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
+using Slypn.Api.Models.Inputs;
+using Slypn.Api.Services;
+using static Slypn.Api.Functions.FunctionHelpers;
+
+namespace Slypn.Api.Functions;
+
+public sealed class MembersFunctions(
+    IContentRepository repo,
+    IInviteService invites,
+    ILogger<MembersFunctions> log)
+{
+    private static readonly HashSet<string> AllowedRoles = new(StringComparer.OrdinalIgnoreCase)
+        { "Admin", "Contributor", "Member" };
+
+    [Function("ListMembers")]
+    [RequireRole("Admin")]
+    public async Task<HttpResponseData> List(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "members")] HttpRequestData req,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        try
+        {
+            var members = await repo.ListMembersAsync(ct);
+            return await Ok(req, members);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("InviteMember")]
+    [RequireRole("Admin")]
+    public async Task<HttpResponseData> Invite(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "members/invite")] HttpRequestData req,
+        FunctionContext context,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+
+        var (input, err) = await ReadValidatedAsync<MemberInviteInput>(req, ct);
+        if (err is not null) return err;
+
+        var badRoles = input!.Roles.Where(r => !AllowedRoles.Contains(r)).ToArray();
+        if (badRoles.Length > 0)
+            return await BadRequest(req, $"Unknown role(s): {string.Join(", ", badRoles)}. Allowed: Admin, Contributor, Member.");
+
+        var email = input.Email.Trim().ToLowerInvariant();
+
+        Member? existing;
+        try { existing = await repo.GetMemberByEmailAsync(email, ct); }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+
+        var now = DateTime.UtcNow;
+        var member = existing is null
+            ? new Member(
+                Id:          Guid.NewGuid().ToString("N"),
+                Email:       email,
+                DisplayName: input.DisplayName.Trim(),
+                Roles:       input.Roles.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                Status:      "invited",
+                InvitedAt:   now,
+                AcceptedAt:  null,
+                InvitedBy:   context.GetUserOid(),
+                Oid:         null)
+            : existing with
+            {
+                DisplayName = input.DisplayName.Trim(),
+                Roles       = input.Roles.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                Status      = existing.AcceptedAt is null ? "invited" : "active",
+                InvitedBy   = context.GetUserOid(),
+            };
+
+        Member saved;
+        try { saved = await repo.UpsertMemberAsync(member, existing?.Etag, ct); }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+
+        var inviteResult = await invites.SendInviteAsync(member.Email, member.DisplayName, ct);
+
+        return await Created(req, new
+        {
+            member       = saved,
+            inviteSent   = inviteResult.Sent,
+            redeemUrl    = inviteResult.RedeemUrl,
+            inviteReason = inviteResult.Reason,
+        }, saved.Etag);
+    }
+}

--- a/src/api/Slypn.Api/Infrastructure/GraphOptions.cs
+++ b/src/api/Slypn.Api/Infrastructure/GraphOptions.cs
@@ -1,0 +1,23 @@
+namespace Slypn.Api.Infrastructure;
+
+public sealed class GraphOptions
+{
+    public const string SectionName = "Graph";
+
+    /// <summary>Entra tenant id used for the token endpoint.</summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>Client (application) id of the SLYPN API app registration.</summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>Client secret for client-credentials auth against Microsoft Graph.</summary>
+    public string? ClientSecret { get; set; }
+
+    /// <summary>Where invitees land after accepting. Should be the production SWA URL in prod.</summary>
+    public string InviteRedirectUrl { get; set; } = "http://localhost:5173/";
+
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(TenantId)     &&
+        !string.IsNullOrWhiteSpace(ClientId)     &&
+        !string.IsNullOrWhiteSpace(ClientSecret);
+}

--- a/src/api/Slypn.Api/Models/Inputs/MemberInviteInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/MemberInviteInput.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+public sealed class MemberInviteInput
+{
+    [Required, EmailAddress, StringLength(254)]
+    public string Email { get; set; } = "";
+
+    [Required, StringLength(120, MinimumLength = 1)]
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>One or more of: Admin, Contributor, Member.</summary>
+    [Required, MinLength(1)]
+    public List<string> Roles { get; set; } = new();
+}

--- a/src/api/Slypn.Api/Models/Member.cs
+++ b/src/api/Slypn.Api/Models/Member.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Slypn.Api.Models;
+
+public sealed record Member(
+    string Id,
+    string Email,
+    string DisplayName,
+    IReadOnlyList<string> Roles,
+    string Status,
+    DateTime InvitedAt,
+    DateTime? AcceptedAt = null,
+    string? InvitedBy = null,
+    string? Oid = null)
+{
+    [JsonPropertyName("_etag")]
+    [Newtonsoft.Json.JsonProperty("_etag")]
+    public string? Etag { get; init; }
+}

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Slypn.Api.Infrastructure;
 using Slypn.Api.Services;
 
@@ -37,6 +38,18 @@ var host = new HostBuilder()
             .AddOptions<EntraOptions>()
             .Bind(context.Configuration.GetSection(EntraOptions.SectionName));
         services.AddSingleton<IJwtValidator, EntraJwtValidator>();
+
+        services
+            .AddOptions<GraphOptions>()
+            .Bind(context.Configuration.GetSection(GraphOptions.SectionName));
+        services.AddHttpClient();
+        services.AddSingleton<IInviteService>(sp =>
+        {
+            var graphOpts = sp.GetRequiredService<IOptions<GraphOptions>>().Value;
+            return graphOpts.IsConfigured
+                ? ActivatorUtilities.CreateInstance<GraphInviteService>(sp)
+                : ActivatorUtilities.CreateInstance<LoggingInviteService>(sp);
+        });
     })
     .Build();
 

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -227,6 +227,34 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
             ct);
     }
 
+    // ---- Members -------------------------------------------------------------
+    public async Task<Member?> GetMemberByEmailAsync(string email, CancellationToken ct)
+    {
+        EnsureWrites();
+        var normalized = email.Trim().ToLowerInvariant();
+        var query = new QueryDefinition("SELECT * FROM c WHERE LOWER(c.email) = @email")
+            .WithParameter("@email", normalized);
+        var results = await CollectAsync<Member>(cosmos.Members, query, new QueryRequestOptions(), ct);
+        return results.FirstOrDefault();
+    }
+
+    public async Task<IReadOnlyList<Member>> ListMembersAsync(CancellationToken ct)
+    {
+        EnsureWrites();
+        var query = new QueryDefinition("SELECT * FROM c ORDER BY c.invitedAt DESC");
+        return await CollectAsync<Member>(cosmos.Members, query, new QueryRequestOptions(), ct);
+    }
+
+    public async Task<Member> UpsertMemberAsync(Member member, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        var resp = await cosmos.Members.UpsertItemAsync(member,
+            new PartitionKey(member.Id),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
     // ---- helpers --------------------------------------------------------------
     private void EnsureWrites()
     {

--- a/src/api/Slypn.Api/Services/GraphInviteService.cs
+++ b/src/api/Slypn.Api/Services/GraphInviteService.cs
@@ -1,0 +1,78 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Slypn.Api.Infrastructure;
+
+namespace Slypn.Api.Services;
+
+/// <summary>
+/// Calls the Microsoft Graph invitations endpoint with client-credentials
+/// auth. Pure HttpClient — avoids dragging in the full Microsoft.Graph SDK.
+/// </summary>
+public sealed class GraphInviteService(
+    IOptions<GraphOptions> options,
+    IHttpClientFactory httpFactory,
+    ILogger<GraphInviteService> logger) : IInviteService
+{
+    private readonly GraphOptions _opts = options.Value;
+
+    public bool IsConfigured => _opts.IsConfigured;
+
+    public async Task<InviteResult> SendInviteAsync(string email, string displayName, CancellationToken ct)
+    {
+        if (!IsConfigured)
+            return new InviteResult(false, null, "graph-not-configured");
+
+        var http = httpFactory.CreateClient();
+
+        var token = await AcquireTokenAsync(http, ct);
+        if (token is null)
+            return new InviteResult(false, null, "token-acquisition-failed");
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/invitations")
+        {
+            Content = JsonContent.Create(new
+            {
+                invitedUserEmailAddress = email,
+                invitedUserDisplayName  = displayName,
+                inviteRedirectUrl       = _opts.InviteRedirectUrl,
+                sendInvitationMessage   = true,
+            }),
+        };
+        req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        using var resp = await http.SendAsync(req, ct);
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            logger.LogWarning("Graph invitation failed: {Status} {Body}", (int)resp.StatusCode, body);
+            return new InviteResult(false, null, $"graph-{(int)resp.StatusCode}");
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        var redeemUrl = doc.RootElement.TryGetProperty("inviteRedeemUrl", out var u) ? u.GetString() : null;
+        return new InviteResult(true, redeemUrl, null);
+    }
+
+    private async Task<string?> AcquireTokenAsync(HttpClient http, CancellationToken ct)
+    {
+        var form = new FormUrlEncodedContent(new[]
+        {
+            KeyValuePair.Create("client_id",     _opts.ClientId!),
+            KeyValuePair.Create("client_secret", _opts.ClientSecret!),
+            KeyValuePair.Create("scope",         "https://graph.microsoft.com/.default"),
+            KeyValuePair.Create("grant_type",    "client_credentials"),
+        });
+        var tokenUrl = $"https://login.microsoftonline.com/{_opts.TenantId}/oauth2/v2.0/token";
+        using var resp = await http.PostAsync(tokenUrl, form, ct);
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            logger.LogWarning("Graph token acquisition failed: {Status} {Body}", (int)resp.StatusCode, body);
+            return null;
+        }
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.TryGetProperty("access_token", out var t) ? t.GetString() : null;
+    }
+}

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -37,4 +37,9 @@ public interface IContentRepository
     Task<Newsletter> CreateNewsletterAsync   (NewsletterInput input, CancellationToken ct);
     Task<Newsletter> ReplaceNewsletterAsync  (string id, NewsletterInput input, string? ifMatch, CancellationToken ct);
     Task             DeleteNewsletterAsync   (string id, string year, string? ifMatch, CancellationToken ct);
+
+    // Members --------------------------------------------------------------
+    Task<Member?>             GetMemberByEmailAsync(string email, CancellationToken ct);
+    Task<IReadOnlyList<Member>> ListMembersAsync(CancellationToken ct);
+    Task<Member>              UpsertMemberAsync(Member member, string? ifMatch, CancellationToken ct);
 }

--- a/src/api/Slypn.Api/Services/IInviteService.cs
+++ b/src/api/Slypn.Api/Services/IInviteService.cs
@@ -1,0 +1,9 @@
+namespace Slypn.Api.Services;
+
+public sealed record InviteResult(bool Sent, string? RedeemUrl, string? Reason);
+
+public interface IInviteService
+{
+    bool IsConfigured { get; }
+    Task<InviteResult> SendInviteAsync(string email, string displayName, CancellationToken ct);
+}

--- a/src/api/Slypn.Api/Services/LoggingInviteService.cs
+++ b/src/api/Slypn.Api/Services/LoggingInviteService.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+namespace Slypn.Api.Services;
+
+/// <summary>
+/// Fallback used when Graph isn't configured. The member record is still
+/// persisted; this just logs that the email step was skipped.
+/// </summary>
+public sealed class LoggingInviteService(ILogger<LoggingInviteService> logger) : IInviteService
+{
+    public bool IsConfigured => false;
+
+    public Task<InviteResult> SendInviteAsync(string email, string displayName, CancellationToken ct)
+    {
+        logger.LogWarning(
+            "Graph is not configured — recording the invite for {Email} but no email was sent. " +
+            "Set Graph__TenantId/ClientId/ClientSecret (see docs/auth-setup.md) to enable.",
+            email);
+        return Task.FromResult(new InviteResult(Sent: false, RedeemUrl: null, Reason: "graph-not-configured"));
+    }
+}

--- a/src/api/Slypn.Api/local.settings.sample.json
+++ b/src/api/Slypn.Api/local.settings.sample.json
@@ -12,7 +12,11 @@
     "AzureAd__Authority": "",
     "AzureAd__Audience": "",
     "AzureAd__TenantId": "",
-    "AzureAd__SkipAuth": "true"
+    "AzureAd__SkipAuth": "true",
+    "Graph__TenantId": "",
+    "Graph__ClientId": "",
+    "Graph__ClientSecret": "",
+    "Graph__InviteRedirectUrl": "http://localhost:5173/"
   },
   "Host": {
     "CORS": "http://localhost:5173",

--- a/src/web/src/views/AdminView.vue
+++ b/src/web/src/views/AdminView.vue
@@ -1,25 +1,144 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
+import { apiFetch } from '@/lib/api'
+
+type Role = 'Admin' | 'Contributor' | 'Member'
+
+interface InviteResponseOk {
+  member: { id: string; email: string; displayName: string; roles: string[]; status: string }
+  inviteSent: boolean
+  redeemUrl: string | null
+  inviteReason: string | null
+}
+
+const allRoles: Role[] = ['Admin', 'Contributor', 'Member']
+
+const email = ref('')
+const displayName = ref('')
+const roles = ref<Role[]>(['Member'])
+const submitting = ref(false)
+const error = ref<string | null>(null)
+const success = ref<InviteResponseOk | null>(null)
+
+function toggleRole(r: Role) {
+  const i = roles.value.indexOf(r)
+  if (i >= 0) roles.value.splice(i, 1)
+  else roles.value.push(r)
+}
+
+async function submit() {
+  if (submitting.value) return
+  error.value = null
+  success.value = null
+  submitting.value = true
+  try {
+    const resp = await apiFetch('/members/invite', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: email.value.trim(),
+        displayName: displayName.value.trim(),
+        roles: roles.value,
+      }),
+    })
+    if (!resp.ok) {
+      const body = await resp.text()
+      throw new Error(`${resp.status} ${resp.statusText}${body ? ` — ${body}` : ''}`)
+    }
+    success.value = await resp.json() as InviteResponseOk
+    email.value = ''
+    displayName.value = ''
+    roles.value = ['Member']
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    submitting.value = false
+  }
+}
 </script>
 
 <template>
   <HeroBanner
     eyebrow="Admin"
     title="SLYPN administration"
-    subtitle="The approvals queue, member management, and content moderation views land with #24 and #29. This page is the role-guarded shell."
+    subtitle="Invite members, manage roles, and (soon) approve pending content."
   />
 
-  <section class="mx-auto max-w-3xl px-6 py-16 space-y-6">
+  <section class="mx-auto max-w-3xl space-y-6 px-6 py-16">
+    <article class="rounded-xl border border-slypn-100 bg-white p-6 shadow-sm">
+      <h2 class="font-display text-xl font-bold text-slypn-700">Invite a member</h2>
+      <p class="mt-2 text-sm text-slypn-900/75">
+        Sends an Entra External ID invitation. The recipient gets an email with a link
+        to sign up; when they accept they&rsquo;ll be granted the role(s) you choose.
+      </p>
+
+      <form class="mt-6 space-y-4" @submit.prevent="submit">
+        <div>
+          <label class="block text-sm font-medium text-slypn-800">Email</label>
+          <input
+            v-model="email"
+            type="email"
+            required
+            class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slypn-800">Display name</label>
+          <input
+            v-model="displayName"
+            type="text"
+            required
+            class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+          />
+        </div>
+        <fieldset>
+          <legend class="text-sm font-medium text-slypn-800">Roles</legend>
+          <div class="mt-2 flex flex-wrap gap-2">
+            <button
+              v-for="r in allRoles"
+              :key="r"
+              type="button"
+              :class="[
+                'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
+                roles.includes(r)
+                  ? 'border-slypn-600 bg-slypn-600 text-white'
+                  : 'border-slypn-200 bg-white text-slypn-700 hover:bg-slypn-50',
+              ]"
+              @click="toggleRole(r)"
+            >
+              {{ r }}
+            </button>
+          </div>
+        </fieldset>
+
+        <button
+          type="submit"
+          class="rounded-md bg-slypn-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700 disabled:opacity-50"
+          :disabled="submitting || !email || !displayName || roles.length === 0"
+        >
+          {{ submitting ? 'Inviting…' : 'Send invitation' }}
+        </button>
+
+        <p v-if="error" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">{{ error }}</p>
+        <div v-if="success" class="rounded-md bg-emerald-50 p-4 text-sm text-emerald-900">
+          <p class="font-semibold">Invitation recorded for {{ success.member.email }}.</p>
+          <p v-if="success.inviteSent" class="mt-1">Graph sent the invitation email.</p>
+          <p v-else class="mt-1">
+            Graph was skipped ({{ success.inviteReason }}) &mdash; the member record is in Cosmos but no email
+            was sent. Configure <code class="rounded bg-emerald-100 px-1 text-emerald-900">Graph__*</code>
+            settings on the API to enable.
+          </p>
+          <p v-if="success.redeemUrl" class="mt-1">
+            Redeem URL: <a class="underline" :href="success.redeemUrl">{{ success.redeemUrl }}</a>
+          </p>
+        </div>
+      </form>
+    </article>
+
     <article class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
       <h2 class="font-display text-lg font-bold text-slypn-700">Approvals (coming in #29)</h2>
       <p class="mt-2 text-sm text-slypn-900/75">
         Pending articles + blog posts grouped by author with inline publish / reject.
-      </p>
-    </article>
-    <article class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
-      <h2 class="font-display text-lg font-bold text-slypn-700">Members (coming in #24)</h2>
-      <p class="mt-2 text-sm text-slypn-900/75">
-        Invite a new member by email, assign a role, revoke access.
       </p>
     </article>
   </section>


### PR DESCRIPTION
## Summary
Admin enters email + display name + roles. The API records the pending member in Cosmos and (when Graph is configured) calls Microsoft Graph to send the External ID invitation email.

### API
| File | Role |
|---|---|
| `Models/Member.cs` | Persisted shape — Id, Email (lowercased), DisplayName, Roles, Status (`invited` / `active` / `revoked`), InvitedAt, AcceptedAt, InvitedBy (admin's oid), Oid (populated on first sign-in). `_etag` for OCC. |
| `Models/Inputs/MemberInviteInput.cs` | Email + DisplayName + Roles, with DataAnnotations. |
| `Infrastructure/GraphOptions.cs` | TenantId / ClientId / ClientSecret / InviteRedirectUrl. |
| `Services/IInviteService.cs` + `LoggingInviteService` + `GraphInviteService` | Pure-HttpClient client-credentials → `POST /v1.0/invitations`. **No `Microsoft.Graph` SDK dependency**. DI picks Graph when configured, Logging otherwise. |
| `IContentRepository` + `ContentRepository` | `GetMemberByEmailAsync`, `ListMembersAsync`, `UpsertMemberAsync` against the `members` container (`/id` partition). |
| `Functions/MembersFunctions.cs` | `GET /api/members` and `POST /api/members/invite`, both `[RequireRole("Admin")]`. Idempotent — re-inviting the same email updates display name + roles. |

### Web
- `views/AdminView.vue` now has a real invite form (email + display name + role chips). Uses `apiFetch` so the Bearer token from the auth store rides along. Shows success vs Graph-skipped paths inline and reveals the redeem URL when Graph returns one.

### Test plan
- [x] `dotnet build` clean.
- [x] `npm run lint` clean.
- [x] `npm run build` clean — 218 modules, 422 KB JS / 19 KB CSS gzipped 121 KB / 4 KB.
- [ ] End-to-end against a real Entra tenant + Graph permissions: requires #19/#20 manual setup.
- [ ] CI green.

Closes #24