### PR TITLE
feat(api,web): autosave + PUT /api/drafts/{id} (drafts container, /authorId)

### DIFF
--- a/src/api/Slypn.Api/Functions/DraftsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/DraftsFunctions.cs
@@ -1,0 +1,124 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
+using Slypn.Api.Models.Inputs;
+using Slypn.Api.Services;
+using static Slypn.Api.Functions.FunctionHelpers;
+
+namespace Slypn.Api.Functions;
+
+public sealed class DraftsFunctions(IContentRepository repo, ILogger<DraftsFunctions> log)
+{
+    [Function("ListMyDrafts")]
+    [RequireRole("Admin", "Contributor")]
+    public async Task<HttpResponseData> List(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "drafts")] HttpRequestData req,
+        FunctionContext context,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var authorId = context.GetUserOid();
+        if (authorId is null) return await BadRequest(req, "Token missing oid claim.");
+        try
+        {
+            var drafts = await repo.ListDraftsByAuthorAsync(authorId, ct);
+            return await Ok(req, drafts);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("GetDraft")]
+    [RequireRole("Admin", "Contributor")]
+    public async Task<HttpResponseData> Get(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "drafts/{id}")] HttpRequestData req,
+        FunctionContext context,
+        string id,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var authorId = context.GetUserOid();
+        if (authorId is null) return await BadRequest(req, "Token missing oid claim.");
+        try
+        {
+            var draft = await repo.GetDraftAsync(id, authorId, ct);
+            if (draft is null) return req.CreateResponse(System.Net.HttpStatusCode.NotFound);
+            return await Ok(req, draft, draft.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    /// <summary>
+    /// Upsert — the client owns the id. Authors can only write to drafts
+    /// under their own oid; the partition key is forced from the JWT.
+    /// </summary>
+    [Function("UpsertDraft")]
+    [RequireRole("Admin", "Contributor")]
+    public async Task<HttpResponseData> Upsert(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "drafts/{id}")] HttpRequestData req,
+        FunctionContext context,
+        string id,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+
+        var authorId = context.GetUserOid();
+        if (authorId is null) return await BadRequest(req, "Token missing oid claim.");
+
+        var (input, err) = await ReadValidatedAsync<DraftInput>(req, ct);
+        if (err is not null) return err;
+
+        var principal = context.GetPrincipal();
+        var authorName = principal?.FindFirst("name")?.Value ?? "Member";
+
+        var now = DateTime.UtcNow;
+        Draft? existing;
+        try { existing = await repo.GetDraftAsync(id, authorId, ct); }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+
+        var draft = new Draft(
+            Id:             id,
+            AuthorId:       authorId,
+            AuthorName:     authorName,
+            Type:           input!.Type,
+            Title:          input.Title,
+            Slug:           input.Slug,
+            Summary:        input.Summary,
+            Body:           input.Body,
+            Category:       input.Category,
+            Tags:           input.Tags,
+            ReadingMinutes: input.ReadingMinutes,
+            CreatedAt:      existing?.CreatedAt ?? now,
+            UpdatedAt:      now);
+
+        try
+        {
+            var saved = existing is null
+                ? await repo.UpsertDraftAsync(draft, null, ct)
+                : await repo.UpsertDraftAsync(draft, IfMatch(req), ct);
+            return await Ok(req, saved, saved.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    [Function("DeleteDraft")]
+    [RequireRole("Admin", "Contributor")]
+    public async Task<HttpResponseData> Delete(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "drafts/{id}")] HttpRequestData req,
+        FunctionContext context,
+        string id,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var authorId = context.GetUserOid();
+        if (authorId is null) return await BadRequest(req, "Token missing oid claim.");
+        try
+        {
+            await repo.DeleteDraftAsync(id, authorId, IfMatch(req), ct);
+            return NoContent(req);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+}

--- a/src/api/Slypn.Api/Models/Draft.cs
+++ b/src/api/Slypn.Api/Models/Draft.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace Slypn.Api.Models;
+
+public sealed record Draft(
+    string Id,
+    string AuthorId,
+    string AuthorName,
+    string Type,        // "article" | "blog"
+    string Title,
+    string Slug,
+    string Summary,
+    string Body,
+    string Category,
+    IReadOnlyList<string> Tags,
+    int ReadingMinutes,
+    DateTime CreatedAt,
+    DateTime UpdatedAt)
+{
+    [JsonPropertyName("_etag")]
+    [Newtonsoft.Json.JsonProperty("_etag")]
+    public string? Etag { get; init; }
+}

--- a/src/api/Slypn.Api/Models/Inputs/DraftInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/DraftInput.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+/// <summary>
+/// Most fields are optional during drafting — autosave fires while the
+/// author is still filling things in. Server-side validation tightens
+/// when the draft moves to "in-review" in #28.
+/// </summary>
+public sealed class DraftInput
+{
+    [Required, RegularExpression("^(article|blog)$", ErrorMessage = "Type must be 'article' or 'blog'.")]
+    public string Type { get; set; } = "article";
+
+    [StringLength(200)] public string Title { get; set; } = "";
+    [StringLength(120)] public string Slug { get; set; } = "";
+    [StringLength(500)] public string Summary { get; set; } = "";
+    [StringLength(50_000)] public string Body { get; set; } = "";
+    [StringLength(60)]  public string Category { get; set; } = "";
+
+    public List<string> Tags { get; set; } = new();
+
+    [Range(0, 60)]
+    public int ReadingMinutes { get; set; }
+}

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -255,6 +255,48 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
         return resp.Resource with { Etag = resp.ETag };
     }
 
+    // ---- Drafts --------------------------------------------------------------
+    public async Task<Draft?> GetDraftAsync(string id, string authorId, CancellationToken ct)
+    {
+        EnsureWrites();
+        try
+        {
+            var resp = await cosmos.Drafts.ReadItemAsync<Draft>(id, new PartitionKey(authorId), cancellationToken: ct);
+            return resp.Resource with { Etag = resp.ETag };
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<Draft>> ListDraftsByAuthorAsync(string authorId, CancellationToken ct)
+    {
+        EnsureWrites();
+        var query = new QueryDefinition("SELECT * FROM c ORDER BY c.updatedAt DESC");
+        var options = new QueryRequestOptions { PartitionKey = new PartitionKey(authorId) };
+        return await CollectAsync<Draft>(cosmos.Drafts, query, options, ct);
+    }
+
+    public async Task<Draft> UpsertDraftAsync(Draft draft, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        var resp = await cosmos.Drafts.UpsertItemAsync(draft,
+            new PartitionKey(draft.AuthorId),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+        return resp.Resource with { Etag = resp.ETag };
+    }
+
+    public async Task DeleteDraftAsync(string id, string authorId, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        await cosmos.Drafts.DeleteItemAsync<Draft>(id,
+            new PartitionKey(authorId),
+            new ItemRequestOptions { IfMatchEtag = ifMatch },
+            ct);
+    }
+
     // ---- helpers --------------------------------------------------------------
     private void EnsureWrites()
     {

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -42,4 +42,10 @@ public interface IContentRepository
     Task<Member?>             GetMemberByEmailAsync(string email, CancellationToken ct);
     Task<IReadOnlyList<Member>> ListMembersAsync(CancellationToken ct);
     Task<Member>              UpsertMemberAsync(Member member, string? ifMatch, CancellationToken ct);
+
+    // Drafts ---------------------------------------------------------------
+    Task<Draft?>              GetDraftAsync(string id, string authorId, CancellationToken ct);
+    Task<IReadOnlyList<Draft>> ListDraftsByAuthorAsync(string authorId, CancellationToken ct);
+    Task<Draft>               UpsertDraftAsync(Draft draft, string? ifMatch, CancellationToken ct);
+    Task                      DeleteDraftAsync(string id, string authorId, string? ifMatch, CancellationToken ct);
 }

--- a/src/web/src/components/editor/SaveIndicator.vue
+++ b/src/web/src/components/editor/SaveIndicator.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { AutoSaveStatus } from '@/composables/useAutoSave'
+
+const props = defineProps<{
+  status: AutoSaveStatus
+  lastSavedAt: Date | null
+  error?: string | null
+}>()
+
+const label = computed(() => {
+  if (props.status === 'pending') return 'Editing&hellip;'
+  if (props.status === 'saving')  return 'Saving&hellip;'
+  if (props.status === 'error')   return `Save failed${props.error ? `: ${props.error}` : ''}`
+  if (props.status === 'saved' || props.lastSavedAt) {
+    return `Saved at ${formatTime(props.lastSavedAt ?? new Date())}`
+  }
+  return 'Not saved yet'
+})
+
+const dotClass = computed(() => {
+  switch (props.status) {
+    case 'saving':  return 'bg-slypn-500 animate-pulse'
+    case 'saved':   return 'bg-emerald-500'
+    case 'error':   return 'bg-rose-500'
+    case 'pending': return 'bg-amber-400'
+    default:        return 'bg-slypn-200'
+  }
+})
+
+function formatTime(d: Date) {
+  return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+}
+</script>
+
+<template>
+  <p class="inline-flex items-center gap-2 text-xs text-slypn-900/70">
+    <span :class="['inline-block h-2 w-2 rounded-full', dotClass]" />
+    <span v-html="label" />
+  </p>
+</template>

--- a/src/web/src/composables/useAutoSave.ts
+++ b/src/web/src/composables/useAutoSave.ts
@@ -1,0 +1,60 @@
+import { onBeforeUnmount, ref, watch, type Ref } from 'vue'
+
+export type AutoSaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error'
+
+export interface UseAutoSaveOptions {
+  /** Milliseconds of inactivity before the save fires. Default 1500. */
+  debounce?: number
+  /** Skip the initial save when the watched value first becomes truthy. Default true. */
+  skipInitial?: boolean
+}
+
+/**
+ * Watches a reactive value and calls saveFn after `debounce` ms of quiet.
+ * Returns reactive { status, lastSavedAt, errorMessage }.
+ *
+ * Designed for the editor: bind to the draft object, pass a saveFn that
+ * does the PUT, and surface status via the SaveIndicator.
+ */
+export function useAutoSave<T>(
+  state: Ref<T>,
+  saveFn: (value: T) => Promise<void>,
+  options: UseAutoSaveOptions = {},
+) {
+  const debounce    = options.debounce ?? 1500
+  const skipInitial = options.skipInitial ?? true
+
+  const status        = ref<AutoSaveStatus>('idle')
+  const lastSavedAt   = ref<Date | null>(null)
+  const errorMessage  = ref<string | null>(null)
+
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let firstFire = true
+
+  watch(state, (value) => {
+    if (firstFire) {
+      firstFire = false
+      if (skipInitial) return
+    }
+    if (timer) clearTimeout(timer)
+    status.value = 'pending'
+    timer = setTimeout(async () => {
+      status.value = 'saving'
+      try {
+        await saveFn(value)
+        status.value = 'saved'
+        lastSavedAt.value = new Date()
+        errorMessage.value = null
+      } catch (err) {
+        status.value = 'error'
+        errorMessage.value = err instanceof Error ? err.message : String(err)
+      }
+    }, debounce)
+  }, { deep: true })
+
+  onBeforeUnmount(() => {
+    if (timer) clearTimeout(timer)
+  })
+
+  return { status, lastSavedAt, errorMessage }
+}

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -1,32 +1,186 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import RichTextEditor from '@/components/editor/RichTextEditor.vue'
+import SaveIndicator from '@/components/editor/SaveIndicator.vue'
+import { useAutoSave } from '@/composables/useAutoSave'
+import { apiFetch } from '@/lib/api'
 
-const body = ref('<p>Start writing&hellip;</p>')
+interface DraftPayload {
+  type: 'article' | 'blog'
+  title: string
+  slug: string
+  summary: string
+  body: string
+  category: string
+  tags: string[]
+  readingMinutes: number
+}
+
+const DRAFT_ID_KEY = 'slypn:editor:draft-id'
+
+function makeId() {
+  if ('randomUUID' in crypto) return crypto.randomUUID().replace(/-/g, '')
+  return Math.random().toString(16).slice(2).padEnd(32, '0')
+}
+
+const draftId = ref<string>(localStorage.getItem(DRAFT_ID_KEY) ?? makeId())
+localStorage.setItem(DRAFT_ID_KEY, draftId.value)
+
+const draft = ref<DraftPayload>({
+  type: 'article',
+  title: '',
+  slug: '',
+  summary: '',
+  body: '<p>Start writing&hellip;</p>',
+  category: '',
+  tags: [],
+  readingMinutes: 0,
+})
 const uploadError = ref<string | null>(null)
+
+async function loadExisting() {
+  try {
+    const resp = await apiFetch(`/drafts/${draftId.value}`)
+    if (resp.status === 404) return
+    if (!resp.ok) return
+    const fetched = await resp.json() as DraftPayload
+    draft.value = { ...draft.value, ...fetched }
+  } catch {
+    // Network errors are fine on first load — we'll create on first autosave.
+  }
+}
+
+async function save(value: DraftPayload) {
+  const resp = await apiFetch(`/drafts/${draftId.value}`, {
+    method: 'PUT',
+    body: JSON.stringify(value),
+  })
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`${resp.status} ${resp.statusText}${body ? ` — ${body}` : ''}`)
+  }
+}
+
+function startFresh() {
+  draftId.value = makeId()
+  localStorage.setItem(DRAFT_ID_KEY, draftId.value)
+  draft.value = {
+    type: 'article',
+    title: '',
+    slug: '',
+    summary: '',
+    body: '<p>Start writing&hellip;</p>',
+    category: '',
+    tags: [],
+    readingMinutes: 0,
+  }
+}
+
+onMounted(loadExisting)
+
+const { status, lastSavedAt, errorMessage } = useAutoSave(draft, save, { debounce: 1500 })
+
+const tagsCsv = computed({
+  get: () => draft.value.tags.join(', '),
+  set: (v: string) => { draft.value.tags = v.split(',').map(s => s.trim()).filter(Boolean) },
+})
 </script>
 
 <template>
   <HeroBanner
     eyebrow="Editor"
     title="Write something for the community"
-    subtitle="Rich-text editor with images, links, headings, and lists. Autosave + draft workflow + admin approval land in #27-#30."
-  />
+    subtitle="Edits autosave 1.5s after you stop typing. Submitting for admin review lands in #28."
+  >
+    <template #actions>
+      <button
+        type="button"
+        class="rounded-md border border-slypn-200 bg-white px-4 py-2 text-sm font-semibold text-slypn-700 hover:bg-slypn-50"
+        @click="startFresh"
+      >
+        Start a new draft
+      </button>
+    </template>
+  </HeroBanner>
 
-  <section class="mx-auto max-w-3xl px-6 py-12">
+  <section class="mx-auto max-w-3xl space-y-6 px-6 py-12">
+    <div class="flex items-center justify-between">
+      <p class="font-display text-xs uppercase tracking-widest text-slypn-500">
+        Draft <code class="text-slypn-700">{{ draftId }}</code>
+      </p>
+      <SaveIndicator :status="status" :last-saved-at="lastSavedAt" :error="errorMessage" />
+    </div>
+
+    <div class="space-y-4 rounded-xl border border-slypn-100 bg-white p-6 shadow-sm">
+      <div>
+        <label class="block text-sm font-medium text-slypn-800">Title</label>
+        <input
+          v-model="draft.title"
+          type="text"
+          maxlength="200"
+          class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+        />
+      </div>
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label class="block text-sm font-medium text-slypn-800">Slug</label>
+          <input
+            v-model="draft.slug"
+            type="text"
+            maxlength="120"
+            placeholder="my-article-title"
+            class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slypn-800">Category</label>
+          <input
+            v-model="draft.category"
+            type="text"
+            maxlength="60"
+            class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+          />
+        </div>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-slypn-800">Summary</label>
+        <textarea
+          v-model="draft.summary"
+          maxlength="500"
+          rows="2"
+          class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+        />
+      </div>
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label class="block text-sm font-medium text-slypn-800">Tags (comma-separated)</label>
+          <input
+            v-model="tagsCsv"
+            type="text"
+            class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slypn-800">Reading minutes</label>
+          <input
+            v-model.number="draft.readingMinutes"
+            type="number"
+            min="0"
+            max="60"
+            class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+          />
+        </div>
+      </div>
+    </div>
+
     <RichTextEditor
-      v-model="body"
+      v-model="draft.body"
       @upload-error="(msg) => uploadError = msg"
     />
 
-    <p v-if="uploadError" class="mt-3 rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
+    <p v-if="uploadError" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
       Image upload failed: {{ uploadError }}
     </p>
-
-    <details class="mt-8 rounded-md border border-slypn-100 bg-slypn-50 p-4">
-      <summary class="cursor-pointer text-sm font-semibold text-slypn-700">Preview the HTML the API will store</summary>
-      <pre class="mt-3 overflow-x-auto whitespace-pre-wrap break-words text-xs text-slypn-900/80">{{ body }}</pre>
-    </details>
   </section>
 </template>


### PR DESCRIPTION
## Summary
Typing pauses for 1.5s, then the editor PUTs to `/api/drafts/{id}`; "Saved at HH:mm:ss" lights up. Refresh resumes the same draft via a localStorage-pinned id.

### API
- **`Models/Draft.cs`** — Id, AuthorId, AuthorName, Type (article/blog), Title, Slug, Summary, Body, Category, Tags, ReadingMinutes, CreatedAt, UpdatedAt + Cosmos `_etag`.
- **`Models/Inputs/DraftInput.cs`** — light validation (most fields optional, drafts are mid-write); `Type` ∈ {article, blog}.
- **`IContentRepository`** + **`ContentRepository`** — `GetDraftAsync`, `ListDraftsByAuthorAsync`, `UpsertDraftAsync`, `DeleteDraftAsync` against the `drafts` container (`/authorId` partition). 404 → null on Get.
- **`DraftsFunctions`** —

| Route | Auth | Notes |
|---|---|---|
| `GET /api/drafts` | Admin / Contributor | mine |
| `GET /api/drafts/{id}` | Admin / Contributor | mine |
| `PUT /api/drafts/{id}` | Admin / Contributor | upsert |
| `DELETE /api/drafts/{id}` | Admin / Contributor | mine |

`authorId` comes from the JWT `oid` via `JwtMiddleware`; clients never set it. `authorName` from JWT `name`. `CreatedAt` is preserved across upserts.

### Web
- **`composables/useAutoSave.ts`** — `useAutoSave(state, saveFn, { debounce: 1500 })` returns reactive `{ status, lastSavedAt, errorMessage }`. Status: `idle → pending (typing) → saving → saved | error`. Skips the initial-mount value by default. Cleans the timer on unmount.
- **`components/editor/SaveIndicator.vue`** — small status pill (coloured dot + label).
- **`views/EditorView.vue`** — reactive draft object (title / slug / summary / category / tags / readingMinutes + body). On mount tries `GET /drafts/{id}` to resume; autosaves the whole object via PUT on 1.5s quiet. Draft id persists in `localStorage` (`slypn:editor:draft-id`); "Start a new draft" mints a fresh one.

### Test plan
- [x] `dotnet build` clean.
- [x] `npm run lint` clean.
- [x] `npm run build` clean (TipTap-driven chunk size warning is informational).
- [ ] End-to-end autosave against the local Cosmos emulator with `SkipAuth=true` requires the full stack via `scripts/start.ps1`.
- [ ] CI green.

Closes #27