### PR TITLE
feat(api,web): draft → in-review → published | rejected workflow

### DIFF
--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -82,4 +82,54 @@ public sealed class ArticlesFunctions(IContentRepository repo, ILogger<ArticlesF
         }
         catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }
+
+    /// <summary>
+    /// Admin approves an in-review article. Moves it to status=published
+    /// and stamps PublishedAt with the approval time.
+    /// </summary>
+    [Function("PublishArticle")]
+    [RequireRole("Admin")]
+    public async Task<HttpResponseData> Publish(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/publish")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        try
+        {
+            var article = await repo.PublishArticleAsync(id, ct);
+            return await Ok(req, article, article.Etag);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return await BadRequest(req, ex.Message);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    /// <summary>
+    /// Admin rejects an in-review article with required feedback. Moves it to
+    /// status=rejected so the author can see the feedback alongside their draft.
+    /// </summary>
+    [Function("RejectArticle")]
+    [RequireRole("Admin")]
+    public async Task<HttpResponseData> Reject(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/reject")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+
+        var (input, err) = await ReadValidatedAsync<RejectionInput>(req, ct);
+        if (err is not null) return err;
+
+        try
+        {
+            var article = await repo.RejectArticleAsync(id, input!.Feedback.Trim(), ct);
+            return await Ok(req, article, article.Etag);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return await BadRequest(req, ex.Message);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
 }

--- a/src/api/Slypn.Api/Functions/DraftsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/DraftsFunctions.cs
@@ -121,4 +121,33 @@ public sealed class DraftsFunctions(IContentRepository repo, ILogger<DraftsFunct
         }
         catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }
+
+    /// <summary>
+    /// Submit the author's own draft for admin review. Promotes it to an
+    /// in-review article with the draft's id (so re-submits are idempotent)
+    /// and removes the draft.
+    /// </summary>
+    [Function("SubmitDraft")]
+    [RequireRole("Admin", "Contributor")]
+    public async Task<HttpResponseData> Submit(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "drafts/{id}/submit")] HttpRequestData req,
+        FunctionContext context,
+        string id,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var authorId = context.GetUserOid();
+        if (authorId is null) return await BadRequest(req, "Token missing oid claim.");
+
+        try
+        {
+            var article = await repo.SubmitDraftAsync(id, authorId, ct);
+            return await Created(req, article, article.Etag);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return await BadRequest(req, ex.Message);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
 }

--- a/src/api/Slypn.Api/Models/Article.cs
+++ b/src/api/Slypn.Api/Models/Article.cs
@@ -15,6 +15,12 @@ public sealed record Article(
     IReadOnlyList<string> Tags,
     string Status = "published")
 {
+    /// <summary>Author's Entra oid — set on submit; carries through workflow transitions.</summary>
+    public string? AuthorId { get; init; }
+
+    /// <summary>Set when an admin rejects an in-review article. Null otherwise.</summary>
+    public string? RejectionReason { get; init; }
+
     /// <summary>Cosmos optimistic-concurrency token. Echoed in the ETag HTTP header for clients.</summary>
     [JsonPropertyName("_etag")]
     [Newtonsoft.Json.JsonProperty("_etag")]

--- a/src/api/Slypn.Api/Models/Inputs/RejectionInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/RejectionInput.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+public sealed class RejectionInput
+{
+    [Required, StringLength(1_000, MinimumLength = 5,
+        ErrorMessage = "Feedback must be 5-1000 characters so the author understands the rejection.")]
+    public string Feedback { get; set; } = "";
+}

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -297,6 +297,92 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
             ct);
     }
 
+    // ---- Workflow ------------------------------------------------------------
+    public async Task<Article> SubmitDraftAsync(string draftId, string authorId, CancellationToken ct)
+    {
+        EnsureWrites();
+
+        Draft draft;
+        try
+        {
+            var read = await cosmos.Drafts.ReadItemAsync<Draft>(draftId, new PartitionKey(authorId), cancellationToken: ct);
+            draft = read.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            throw new InvalidOperationException($"Draft {draftId} not found for author {authorId}.");
+        }
+
+        var article = new Article(
+            Id:             draft.Id,
+            Slug:           draft.Slug,
+            Title:          draft.Title,
+            Summary:        draft.Summary,
+            Body:           draft.Body,
+            Author:         draft.AuthorName,
+            PublishedAt:    DateTime.UtcNow, // submission time; updated on publish
+            ReadingMinutes: draft.ReadingMinutes,
+            Category:       draft.Category,
+            Tags:           draft.Tags,
+            Status:         "in-review")
+        {
+            AuthorId = draft.AuthorId,
+        };
+
+        var upserted = await cosmos.Articles.UpsertItemAsync(article, new PartitionKey("in-review"), cancellationToken: ct);
+        await cosmos.Drafts.DeleteItemAsync<Draft>(draft.Id, new PartitionKey(authorId), cancellationToken: ct);
+        return upserted.Resource with { Etag = upserted.ETag };
+    }
+
+    public async Task<Article?> GetArticleAsync(string id, string status, CancellationToken ct)
+    {
+        EnsureWrites();
+        try
+        {
+            var resp = await cosmos.Articles.ReadItemAsync<Article>(id, new PartitionKey(status), cancellationToken: ct);
+            return resp.Resource with { Etag = resp.ETag };
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<Article> PublishArticleAsync(string id, CancellationToken ct)
+        => await TransitionAsync(id, fromStatus: "in-review", toStatus: "published",
+            update: a => a with { PublishedAt = DateTime.UtcNow, RejectionReason = null }, ct);
+
+    public async Task<Article> RejectArticleAsync(string id, string feedback, CancellationToken ct)
+        => await TransitionAsync(id, fromStatus: "in-review", toStatus: "rejected",
+            update: a => a with { RejectionReason = feedback }, ct);
+
+    private async Task<Article> TransitionAsync(
+        string id, string fromStatus, string toStatus, Func<Article, Article> update, CancellationToken ct)
+    {
+        EnsureWrites();
+        // Cosmos doesn't permit changing a document's partition-key value, so
+        // we read from the source partition, create in the target, then delete
+        // the source. Not atomic; admin actions are rare and re-runs are
+        // idempotent (re-doing publish on an already-published article is a
+        // no-op because the source is gone — the 404 surfaces as a clean error).
+        Article source;
+        try
+        {
+            var read = await cosmos.Articles.ReadItemAsync<Article>(id, new PartitionKey(fromStatus), cancellationToken: ct);
+            source = read.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            throw new InvalidOperationException($"Article {id} is not in '{fromStatus}'.");
+        }
+
+        var transitioned = update(source with { Status = toStatus, Etag = null });
+
+        var created = await cosmos.Articles.UpsertItemAsync(transitioned, new PartitionKey(toStatus), cancellationToken: ct);
+        await cosmos.Articles.DeleteItemAsync<Article>(id, new PartitionKey(fromStatus), cancellationToken: ct);
+        return created.Resource with { Etag = created.ETag };
+    }
+
     // ---- helpers --------------------------------------------------------------
     private void EnsureWrites()
     {

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -48,4 +48,17 @@ public interface IContentRepository
     Task<IReadOnlyList<Draft>> ListDraftsByAuthorAsync(string authorId, CancellationToken ct);
     Task<Draft>               UpsertDraftAsync(Draft draft, string? ifMatch, CancellationToken ct);
     Task                      DeleteDraftAsync(string id, string authorId, string? ifMatch, CancellationToken ct);
+
+    // Workflow -------------------------------------------------------------
+    /// <summary>Promote a draft to an in-review article and remove the draft.</summary>
+    Task<Article>             SubmitDraftAsync(string draftId, string authorId, CancellationToken ct);
+
+    /// <summary>Read an article addressed by id + current status (partition key).</summary>
+    Task<Article?>            GetArticleAsync(string id, string status, CancellationToken ct);
+
+    /// <summary>Move an article from in-review to published. Sets PublishedAt to now.</summary>
+    Task<Article>             PublishArticleAsync(string id, CancellationToken ct);
+
+    /// <summary>Move an article from in-review to rejected and store the admin's feedback.</summary>
+    Task<Article>             RejectArticleAsync(string id, string feedback, CancellationToken ct);
 }

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -38,6 +38,9 @@ const draft = ref<DraftPayload>({
   readingMinutes: 0,
 })
 const uploadError = ref<string | null>(null)
+const submitting = ref(false)
+const submitMessage = ref<string | null>(null)
+const submitError   = ref<string | null>(null)
 
 async function loadExisting() {
   try {
@@ -59,6 +62,28 @@ async function save(value: DraftPayload) {
   if (!resp.ok) {
     const body = await resp.text().catch(() => '')
     throw new Error(`${resp.status} ${resp.statusText}${body ? ` — ${body}` : ''}`)
+  }
+}
+
+async function submitForReview() {
+  if (submitting.value) return
+  submitMessage.value = null
+  submitError.value = null
+  submitting.value = true
+  try {
+    // Force a save first so the in-review article has the latest body.
+    await save(draft.value)
+    const resp = await apiFetch(`/drafts/${draftId.value}/submit`, { method: 'POST' })
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '')
+      throw new Error(`${resp.status} ${resp.statusText}${body ? ` — ${body}` : ''}`)
+    }
+    submitMessage.value = 'Submitted for admin review. You can start a new draft now.'
+    localStorage.removeItem(DRAFT_ID_KEY)
+  } catch (err) {
+    submitError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    submitting.value = false
   }
 }
 
@@ -91,9 +116,17 @@ const tagsCsv = computed({
   <HeroBanner
     eyebrow="Editor"
     title="Write something for the community"
-    subtitle="Edits autosave 1.5s after you stop typing. Submitting for admin review lands in #28."
+    subtitle="Edits autosave 1.5s after you stop typing. Hit Submit when you're ready for an admin to review."
   >
     <template #actions>
+      <button
+        type="button"
+        class="rounded-md bg-slypn-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700 disabled:opacity-50"
+        :disabled="submitting || !draft.title || !draft.summary || !draft.body"
+        @click="submitForReview"
+      >
+        {{ submitting ? 'Submitting…' : 'Submit for review' }}
+      </button>
       <button
         type="button"
         class="rounded-md border border-slypn-200 bg-white px-4 py-2 text-sm font-semibold text-slypn-700 hover:bg-slypn-50"
@@ -181,6 +214,12 @@ const tagsCsv = computed({
 
     <p v-if="uploadError" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
       Image upload failed: {{ uploadError }}
+    </p>
+    <p v-if="submitError" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
+      Submit failed: {{ submitError }}
+    </p>
+    <p v-if="submitMessage" class="rounded-md bg-emerald-50 px-4 py-2 text-sm text-emerald-900">
+      {{ submitMessage }}
     </p>
   </section>
 </template>


### PR DESCRIPTION
## Summary
Three workflow endpoints plus the Submit-for-review button on the editor:

| Route | Auth | Body | Returns |
|---|---|---|---|
| `POST /api/drafts/{id}/submit` | Admin / Contributor | — | `201 + Article` |
| `POST /api/articles/{id}/publish` | Admin | — | `200 + Article` |
| `POST /api/articles/{id}/reject` | Admin | `{ feedback: string }` | `200 + Article` |

### Article model
Adds optional `AuthorId` (Entra oid) and `RejectionReason` init properties so existing rows deserialise unchanged.

### Repository
- **`SubmitDraftAsync(draftId, authorId)`** — reads the draft, upserts an `Article` into `articles/in-review` (re-using `draft.Id` so re-submits are idempotent), and deletes the draft.
- **`PublishArticleAsync(id)`** and **`RejectArticleAsync(id, feedback)`** — both call a shared `TransitionAsync(fromStatus, toStatus, mutator)` helper. Cosmos forbids changing a document's partition-key, so the helper reads-from-source, upserts-to-target, then deletes-source. **Not atomic**; admin actions are infrequent and a 404 on the source surfaces as a clean error if the transition has already happened.
- Publish stamps `PublishedAt = now` and clears any prior `RejectionReason`.

### Authorization
- **Submit**: Admin OR Contributor; `authorId` is forced from the JWT `oid` so a contributor can only submit their own drafts.
- **Publish + Reject**: Admin only (already enforced by `[RequireRole]`).

### Web
EditorView gains a primary "Submit for review" button next to the existing "Start a new draft" button. Clicking it forces a save, calls `POST /drafts/{id}/submit`, clears the localStorage draft id, and shows an inline success message. Disabled until title + summary + body are non-empty.

### Test plan
- [x] `dotnet build` clean.
- [x] `npm run lint` clean.
- [x] `npm run build` clean.
- [ ] End-to-end submit/publish/reject against the local stack — exercise manually with `SkipAuth=true` and emulators.
- [ ] Admin Approvals queue UI: #29.
- [ ] CI green.

Closes #28