### PR TITLE
feat(api): server-side HTML sanitisation via HtmlSanitizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,6 @@ jobs:
 
       - name: Build (Seed CLI)
         run: dotnet build src/api/Slypn.Seed/Slypn.Seed.csproj --configuration Release
+
+      - name: Test (API)
+        run: dotnet test src/api/Slypn.Api.Tests/Slypn.Api.Tests.csproj --configuration Release --logger "trx;LogFileName=test-results.trx" --verbosity normal

--- a/src/api/Slypn.Api.Tests/HtmlSanitizerTests.cs
+++ b/src/api/Slypn.Api.Tests/HtmlSanitizerTests.cs
@@ -1,0 +1,93 @@
+using Slypn.Api.Services;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class HtmlSanitizerTests
+{
+    private readonly IHtmlSanitizer _sut = new HtmlSanitizer();
+
+    [Theory]
+    [InlineData("<p>Plain paragraph</p>")]
+    [InlineData("<p><strong>bold</strong> and <em>italic</em></p>")]
+    [InlineData("<h1>Heading</h1><p>Body</p>")]
+    [InlineData("<ul><li>one</li><li>two</li></ul>")]
+    [InlineData("<blockquote><p>quoted</p></blockquote>")]
+    [InlineData("<a href=\"https://www.parkinsons.org.uk/\" target=\"_blank\" rel=\"noopener\">PUK</a>")]
+    [InlineData("<a href=\"mailto:hello@example.com\">email</a>")]
+    [InlineData("<img src=\"https://example.com/x.png\" alt=\"x\" />")]
+    public void Sanitize_AllowsTipTapToolbarOutput(string html)
+    {
+        var output = _sut.Sanitize(html);
+        Assert.False(string.IsNullOrWhiteSpace(output),
+            $"Expected '{html}' to survive sanitisation, got empty.");
+        // The sanitiser may normalise whitespace / quote style — just ensure the
+        // core marker survives, not byte-equality.
+    }
+
+    [Theory]
+    // Inline scripts of every shape — must be removed entirely.
+    [InlineData("<script>alert(1)</script>")]
+    [InlineData("<scr<script>ipt>alert(1)</scr</script>ipt>")]
+    [InlineData("<svg/onload=alert(1)>")]
+    [InlineData("<math><mtext><script>alert(1)</script></mtext></math>")]
+    [InlineData("<iframe src=\"https://evil.example.com\"></iframe>")]
+    [InlineData("<object data=\"javascript:alert(1)\"></object>")]
+    [InlineData("<embed src=\"javascript:alert(1)\" />")]
+    [InlineData("<form action=\"https://evil.example.com\"><input/></form>")]
+    [InlineData("<meta http-equiv=\"refresh\" content=\"0;url=https://evil.example.com\" />")]
+    [InlineData("<style>body { background: url('javascript:alert(1)') }</style>")]
+    public void Sanitize_StripsScriptingAndDangerousTags(string html)
+    {
+        var output = _sut.Sanitize(html);
+        Assert.DoesNotContain("alert",       output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("javascript:", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<script",     output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<iframe",     output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<svg",        output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<object",     output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<embed",      output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<form",       output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<meta",       output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    // Inline event handlers anywhere — must not survive.
+    [InlineData("<p onclick=\"alert(1)\">click</p>")]
+    [InlineData("<a href=\"#\" onmouseover=\"alert(1)\">x</a>")]
+    [InlineData("<img src=\"https://example.com/x.png\" onerror=\"alert(1)\" />")]
+    [InlineData("<div onload=\"alert(1)\">x</div>")]
+    public void Sanitize_StripsInlineEventHandlers(string html)
+    {
+        var output = _sut.Sanitize(html);
+        Assert.DoesNotContain("onclick",     output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onmouseover", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onerror",     output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onload",      output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("alert",       output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    // javascript: / data: / vbscript: URLs in href or src — must be dropped.
+    [InlineData("<a href=\"javascript:alert(1)\">click</a>")]
+    [InlineData("<a href=\"JaVaScRiPt:alert(1)\">case</a>")]
+    [InlineData("<a href=\"vbscript:msgbox(1)\">vb</a>")]
+    [InlineData("<img src=\"javascript:alert(1)\" />")]
+    [InlineData("<img src=\"data:text/html;base64,PHN2Zw==\" />")]
+    public void Sanitize_StripsDangerousUriSchemes(string html)
+    {
+        var output = _sut.Sanitize(html);
+        Assert.DoesNotContain("javascript:", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("vbscript:",   output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("data:",       output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("alert",       output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sanitize_NullAndEmpty_AreSafe()
+    {
+        Assert.Equal(string.Empty, _sut.Sanitize(null));
+        Assert.Equal(string.Empty, _sut.Sanitize(""));
+        Assert.Equal(string.Empty, _sut.Sanitize("   "));
+    }
+}

--- a/src/api/Slypn.Api.Tests/Slypn.Api.Tests.csproj
+++ b/src/api/Slypn.Api.Tests/Slypn.Api.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Slypn.Api.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Slypn.Api\Slypn.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -10,7 +10,7 @@ using static Slypn.Api.Functions.FunctionHelpers;
 
 namespace Slypn.Api.Functions;
 
-public sealed class ArticlesFunctions(IContentRepository repo, ILogger<ArticlesFunctions> log)
+public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sanitizer, ILogger<ArticlesFunctions> log)
 {
     [Function("GetArticles")]
     public async Task<HttpResponseData> GetArticles(
@@ -40,9 +40,10 @@ public sealed class ArticlesFunctions(IContentRepository repo, ILogger<ArticlesF
         if (!repo.SupportsWrites) return await WritesDisabled(req);
         var (input, err) = await ReadValidatedAsync<ArticleInput>(req, ct);
         if (err is not null) return err;
+        input!.Body = sanitizer.Sanitize(input.Body);
         try
         {
-            var article = await repo.CreateArticleAsync(input!, ct);
+            var article = await repo.CreateArticleAsync(input, ct);
             return await Created(req, article, article.Etag);
         }
         catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
@@ -57,9 +58,10 @@ public sealed class ArticlesFunctions(IContentRepository repo, ILogger<ArticlesF
         if (!repo.SupportsWrites) return await WritesDisabled(req);
         var (input, err) = await ReadValidatedAsync<ArticleInput>(req, ct);
         if (err is not null) return err;
+        input!.Body = sanitizer.Sanitize(input.Body);
         try
         {
-            var article = await repo.ReplaceArticleAsync(id, input!, IfMatch(req), ct);
+            var article = await repo.ReplaceArticleAsync(id, input, IfMatch(req), ct);
             return await Ok(req, article, article.Etag);
         }
         catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }

--- a/src/api/Slypn.Api/Functions/DraftsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/DraftsFunctions.cs
@@ -10,7 +10,7 @@ using static Slypn.Api.Functions.FunctionHelpers;
 
 namespace Slypn.Api.Functions;
 
-public sealed class DraftsFunctions(IContentRepository repo, ILogger<DraftsFunctions> log)
+public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sanitizer, ILogger<DraftsFunctions> log)
 {
     [Function("ListMyDrafts")]
     [RequireRole("Admin", "Contributor")]
@@ -86,7 +86,7 @@ public sealed class DraftsFunctions(IContentRepository repo, ILogger<DraftsFunct
             Title:          input.Title,
             Slug:           input.Slug,
             Summary:        input.Summary,
-            Body:           input.Body,
+            Body:           sanitizer.Sanitize(input.Body),
             Category:       input.Category,
             Tags:           input.Tags,
             ReadingMinutes: input.ReadingMinutes,

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -22,6 +22,7 @@ var host = new HostBuilder()
 
         services.AddSingleton<IMockDataService, MockDataService>();
         services.AddSingleton<IContentRepository, ContentRepository>();
+        services.AddSingleton<IHtmlSanitizer, HtmlSanitizer>();
 
         services
             .AddOptions<CosmosOptions>()

--- a/src/api/Slypn.Api/Services/HtmlSanitizer.cs
+++ b/src/api/Slypn.Api/Services/HtmlSanitizer.cs
@@ -1,0 +1,58 @@
+using Ganss.Xss;
+
+namespace Slypn.Api.Services;
+
+/// <summary>
+/// Allowlist matches the TipTap editor's toolbar exactly (StarterKit
+/// headings 1-3, lists, blockquote, code, plus the Image and Link
+/// extensions). Anything outside this list is dropped; the editor can
+/// never emit it, so any drift implies tampering and we ignore it.
+/// </summary>
+public sealed class HtmlSanitizer : IHtmlSanitizer
+{
+    private static readonly HashSet<string> AllowedTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Block-level
+        "p", "h1", "h2", "h3", "h4", "h5", "h6",
+        "ul", "ol", "li", "blockquote", "pre", "hr",
+        // Inline
+        "strong", "b", "em", "i", "u", "s", "code", "br", "span",
+        // Media + links
+        "a", "img",
+    };
+
+    private static readonly HashSet<string> AllowedAttributes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "href", "rel", "target",  // <a>
+        "src", "alt", "title",    // <img>, <a>
+        "class",                  // TipTap occasionally attaches utility classes
+    };
+
+    private static readonly HashSet<string> AllowedSchemes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "http", "https", "mailto",
+    };
+
+    private readonly Ganss.Xss.HtmlSanitizer _inner;
+
+    public HtmlSanitizer()
+    {
+        _inner = new Ganss.Xss.HtmlSanitizer();
+        _inner.AllowedTags.Clear();
+        foreach (var t in AllowedTags) _inner.AllowedTags.Add(t);
+        _inner.AllowedAttributes.Clear();
+        foreach (var a in AllowedAttributes) _inner.AllowedAttributes.Add(a);
+        _inner.AllowedSchemes.Clear();
+        foreach (var s in AllowedSchemes) _inner.AllowedSchemes.Add(s);
+        // Defence in depth — no CSS even if a span sneaks one in.
+        _inner.AllowedCssProperties.Clear();
+        // Refuse data: URIs everywhere (we upload images to Blob and link by URL).
+        _inner.AllowedAtRules.Clear();
+    }
+
+    public string Sanitize(string? html)
+    {
+        if (string.IsNullOrWhiteSpace(html)) return string.Empty;
+        return _inner.Sanitize(html);
+    }
+}

--- a/src/api/Slypn.Api/Services/IHtmlSanitizer.cs
+++ b/src/api/Slypn.Api/Services/IHtmlSanitizer.cs
@@ -1,0 +1,11 @@
+namespace Slypn.Api.Services;
+
+public interface IHtmlSanitizer
+{
+    /// <summary>
+    /// Strips disallowed tags / attributes / schemes from the supplied HTML.
+    /// Returns an empty string when input is null/empty so callers can safely
+    /// persist the result without an extra null check.
+    /// </summary>
+    string Sanitize(string? html);
+}

--- a/src/api/Slypn.Api/Slypn.Api.csproj
+++ b/src/api/Slypn.Api/Slypn.Api.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="HttpMultipartParser" Version="8.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
## Summary
Every TipTap body the API stores is now run through Ganss `HtmlSanitizer` with an allowlist that mirrors the editor's toolbar exactly. Anything outside that list is dropped; the editor can never emit it, so any drift implies tampering.

### Allowlist
| Category | Allowed |
|---|---|
| Tags | `p`, `h1`-`h6`, `ul`, `ol`, `li`, `blockquote`, `pre`, `hr`, `strong`, `b`, `em`, `i`, `u`, `s`, `code`, `br`, `span`, `a`, `img` |
| Attributes | `href`, `rel`, `target`, `src`, `alt`, `title`, `class` |
| URI schemes | `http`, `https`, `mailto` |

CSS properties + at-rules cleared. `javascript:`, `data:`, `vbscript:` all refused.

### Where it runs
- `PUT /api/drafts/{id}` — sanitises `input.Body` before constructing the Draft.
- `POST /api/articles` + `PUT /api/articles/{id}` — same.

`Sanitize(null/empty/whitespace)` returns `""` so callers persist without an extra null check.

### Tests
New `src/api/Slypn.Api.Tests/` project (xUnit 2.9.2). **28 cases**:
- Allowed TipTap output survives.
- Scripting / iframes / forms / metas / svgs / objects / embeds / math+mtext+script payloads stripped, no `alert` survives.
- Inline event handlers (`onclick`, `onmouseover`, `onerror`, `onload`) removed.
- Dangerous URI schemes stripped from `href` + `src`.
- `null` / `""` / `"   "` return `""` without throwing.

### CI
`.github/workflows/ci.yml` — the `api` job now runs `dotnet test src/api/Slypn.Api.Tests --logger trx` after the API and Seed builds.

### Notes
- `Slypn.Api.csproj` pinned to `HtmlSanitizer 9.0.892` (latest stable, no known CVEs).

### Test plan
- [x] `dotnet build` clean.
- [x] `dotnet test` — 28 / 28 pass locally.
- [ ] CI green.

Closes #30