### PR TITLE
feat(api): OpenTelemetry traces + metrics + logs via OTLP

### DIFF
--- a/src/api/Slypn.Api/Infrastructure/OtelOptions.cs
+++ b/src/api/Slypn.Api/Infrastructure/OtelOptions.cs
@@ -1,0 +1,23 @@
+namespace Slypn.Api.Infrastructure;
+
+public sealed class OtelOptions
+{
+    public const string SectionName = "Otel";
+
+    /// <summary>OTLP HTTP endpoint (e.g. https://otlp-gateway-prod-eu-west-2.grafana.net/otlp).</summary>
+    public string? Endpoint { get; set; }
+
+    /// <summary>
+    /// Headers string in the OTLP convention (key=value, comma-separated). For
+    /// Grafana Cloud this looks like "Authorization=Basic &lt;base64&gt;".
+    /// </summary>
+    public string? Headers { get; set; }
+
+    /// <summary>service.name resource attribute. Defaults to "slypn-api".</summary>
+    public string ServiceName { get; set; } = "slypn-api";
+
+    /// <summary>deployment.environment resource attribute (dev / prod).</summary>
+    public string Env { get; set; } = "dev";
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(Endpoint);
+}

--- a/src/api/Slypn.Api/Infrastructure/OtelSources.cs
+++ b/src/api/Slypn.Api/Infrastructure/OtelSources.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace Slypn.Api.Infrastructure;
+
+/// <summary>
+/// Activity sources owned by the SLYPN API. Names are stable and end up as
+/// the `otel.scope.name` attribute on every span — use them to filter.
+/// </summary>
+public static class OtelSources
+{
+    public const string ApiName = "Slypn.Api";
+    public static readonly ActivitySource Api = new(ApiName);
+}

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -4,7 +4,13 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Slypn.Api.Infrastructure;
 using Slypn.Api.Services;
 
@@ -51,6 +57,55 @@ var host = new HostBuilder()
                 ? ActivatorUtilities.CreateInstance<GraphInviteService>(sp)
                 : ActivatorUtilities.CreateInstance<LoggingInviteService>(sp);
         });
+
+        // ---- OpenTelemetry ---------------------------------------------------
+        services
+            .AddOptions<OtelOptions>()
+            .Bind(context.Configuration.GetSection(OtelOptions.SectionName));
+
+        var otelOpts = new OtelOptions();
+        context.Configuration.GetSection(OtelOptions.SectionName).Bind(otelOpts);
+
+        if (otelOpts.IsConfigured)
+        {
+            var resourceBuilder = ResourceBuilder.CreateDefault()
+                .AddService(otelOpts.ServiceName, serviceVersion: typeof(Program).Assembly.GetName().Version?.ToString() ?? "0.0.1")
+                .AddAttributes(new[] { new KeyValuePair<string, object>("deployment.environment", otelOpts.Env) });
+
+            void ConfigureExporter(OpenTelemetry.Exporter.OtlpExporterOptions options)
+            {
+                options.Endpoint = new Uri(otelOpts.Endpoint!);
+                options.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+                if (!string.IsNullOrWhiteSpace(otelOpts.Headers))
+                {
+                    options.Headers = otelOpts.Headers;
+                }
+            }
+
+            services
+                .AddOpenTelemetry()
+                .ConfigureResource(r => r
+                    .AddService(otelOpts.ServiceName)
+                    .AddAttributes(new[] { new KeyValuePair<string, object>("deployment.environment", otelOpts.Env) }))
+                .WithTracing(tracing => tracing
+                    .AddSource(OtelSources.ApiName)
+                    .AddSource("Azure.*")  // captures Cosmos + Storage SDK activities
+                    .AddHttpClientInstrumentation()
+                    .AddOtlpExporter(ConfigureExporter))
+                .WithMetrics(metrics => metrics
+                    .AddMeter("Slypn.Api")
+                    .AddRuntimeInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddOtlpExporter(ConfigureExporter));
+
+            services.AddLogging(logging => logging.AddOpenTelemetry(o =>
+            {
+                o.SetResourceBuilder(resourceBuilder);
+                o.IncludeScopes = true;
+                o.IncludeFormattedMessage = true;
+                o.AddOtlpExporter(ConfigureExporter);
+            }));
+        }
     })
     .Build();
 

--- a/src/api/Slypn.Api/Slypn.Api.csproj
+++ b/src/api/Slypn.Api/Slypn.Api.csproj
@@ -17,8 +17,12 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/api/Slypn.Api/local.settings.sample.json
+++ b/src/api/Slypn.Api/local.settings.sample.json
@@ -16,7 +16,11 @@
     "Graph__TenantId": "",
     "Graph__ClientId": "",
     "Graph__ClientSecret": "",
-    "Graph__InviteRedirectUrl": "http://localhost:5173/"
+    "Graph__InviteRedirectUrl": "http://localhost:5173/",
+    "Otel__Endpoint": "",
+    "Otel__Headers": "",
+    "Otel__ServiceName": "slypn-api",
+    "Otel__Env": "dev"
   },
   "Host": {
     "CORS": "http://localhost:5173",


### PR DESCRIPTION
## Summary
Wires the .NET OpenTelemetry SDK into the Functions worker when `Otel__Endpoint` is configured. No-op (zero overhead) on a fresh clone with no Otel config — same pattern as Cosmos / Storage / Entra.

### Packages
- `OpenTelemetry.Extensions.Hosting 1.15.3`
- `OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.3` (the 1.10.0 CVE doesn't affect this version)
- `OpenTelemetry.Instrumentation.Http 1.15.1`
- `OpenTelemetry.Instrumentation.Runtime 1.15.1`
- Bumps `Microsoft.Extensions.Options.ConfigurationExtensions` to 9.0.0 to align with the transitive bump OTel pulls in.

### Config
- **`Infrastructure/OtelOptions.cs`** — `Endpoint`, `Headers` (OTLP convention, comma-separated key=value — `Authorization=Basic <b64>` for Grafana Cloud), `ServiceName` (default `slypn-api`), `Env` (default `dev`). `IsConfigured` = endpoint set.
- **`Infrastructure/OtelSources.cs`** — stable `ActivitySource` named `Slypn.Api` for any future custom spans.
- **`local.settings.sample.json`** — adds the four `Otel__*` placeholders; empty endpoint disables the SDK.

### `Program.cs`
When `OtelOptions.IsConfigured`:

| Pipeline | Sources / Instrumentations | Exporter |
|---|---|---|
| Tracing | `Slypn.Api`, `Azure.*` (Cosmos + Storage SDK activities), HttpClient | OTLP HTTP |
| Metrics | `Slypn.Api` meter, runtime metrics, HttpClient | OTLP HTTP |
| Logging | `AddOpenTelemetry` with resource + scopes + formatted messages | OTLP HTTP |

Resource includes `service.name` + `deployment.environment` attributes.

### Test plan
- [x] `dotnet build` clean.
- [x] `dotnet test` — 28 / 28 sanitiser tests still pass.
- [ ] End-to-end requires real Grafana Cloud config (manual setup from #33).
- [ ] CI green.

Closes #35