### PR TITLE
ci(swa): build + deploy + PR-preview workflow for Azure Static Web Apps

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -1,0 +1,73 @@
+name: Azure Static Web Apps deploy
+
+# Production deploys on push to main; PR previews on every open / update.
+# SWA closes the preview environment when the PR is closed.
+#
+# Required repo secret (set after first Bicep deploy):
+#   AZURE_STATIC_WEB_APPS_API_TOKEN — the deployment token from the SWA
+#     resource (Azure portal -> swa-slypn-* -> Manage deployment token,
+#     or `az staticwebapp secrets list -n swa-slypn-prod -g rg-slypn-prod`).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: swa-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_deploy:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    name: Build + deploy
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          lfs: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: src/web/package-lock.json
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build + deploy to SWA
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: src/web
+          api_location: src/api/Slypn.Api
+          output_location: dist
+          # The action handles `npm ci` + `npm run build` for the Vue app
+          # and `dotnet build` for the Functions, so no preceding steps are
+          # required.
+          deployment_environment: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || '' }}
+
+  close_pr_environment:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close PR environment
+    steps:
+      - name: Close PR environment
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: close


### PR DESCRIPTION
## Summary
The workflow Bicep #38 was provisioning for. On push to \`main\` the SWA action builds the Vue app + the Functions API and ships both to the SWA resource. On PR open/sync/reopen it spins up an isolated **preview environment named \`pr-<number>\`** and posts the URL back as a PR comment (the action does that automatically). On PR close, a second job calls \`action: close\` to tear down the preview.

### Triggers
| Event | Outcome |
|---|---|
| \`push\` → \`main\` | Production deploy |
| \`pull_request\` [opened, synchronize, reopened] → \`main\` | Preview deploy at \`pr-<number>\` |
| \`pull_request\` [closed] | Preview environment closed |

### Other config
- \`concurrency: swa-\${{ github.ref }}\` with \`cancel-in-progress\` so quick re-push doesn't pile up SWA jobs (matches the \`ci.yml\` pattern).
- Permissions: \`contents:read\` + \`pull-requests:write\` so the action can edit the PR-preview comment.
- \`app_location: src/web\`, \`api_location: src/api/Slypn.Api\`, \`output_location: dist\`. The action handles \`npm ci\` + \`npm run build\` and \`dotnet build\` under the hood.

### Required repo secret
\`AZURE_STATIC_WEB_APPS_API_TOKEN\` — the deployment token from the SWA resource. Fetch via Azure portal (SWA → Manage deployment token) or:

\`\`\`bash
az staticwebapp secrets list -n swa-slypn-prod -g rg-slypn-prod
\`\`\`

Documented in the workflow header.

### Test plan
- [x] Workflow YAML lints clean (no editor errors).
- [ ] Requires the SWA + deployment token to actually run — exercised end-to-end in #42.
- [ ] CI green.

Closes #39