### PR TITLE
ci(swa): build-only fallback when AZURE_STATIC_WEB_APPS_API_TOKEN is unset

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -60,6 +60,10 @@ jobs:
           # and `dotnet build` for the Functions, so no preceding steps are
           # required.
           deployment_environment: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || '' }}
+          # Until the first Bicep deploy provisions the SWA + the secret is
+          # set in repo secrets, the action build-only and skips the upload
+          # instead of erroring. Remove this flag once the token is in place.
+          skip_deploy_on_missing_secrets: true
 
   close_pr_environment:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
@@ -71,3 +75,4 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           action: close
+          skip_deploy_on_missing_secrets: true


### PR DESCRIPTION
## Summary
Unblocks the SWA workflow from failing on every PR while the deployment token is still missing (i.e. until the first Bicep deploy provisions the SWA).

\`skip_deploy_on_missing_secrets: true\` flips the action into **build-only** mode when the token is absent — the workflow passes, no upload happens, the PR comment isn't posted. Once the token is added to repo secrets the action will start deploying again.

Remove the two \`skip_deploy_on_missing_secrets\` lines after the token is in place; everything else stays the same.

### Test plan
- [x] One-line change confirmed against the SWA action README.
- [ ] CI green (this PR's own SWA workflow run is the proof).