### PR TITLE
ci(infra): path-filtered Bicep build validation

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,40 @@
+name: Infra
+
+# Bicep validation. Path-filtered so the rest of the repo doesn't pay for it.
+# Catches syntax + parameter type issues before they hit `az deployment group create`.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra.yml'
+
+concurrency:
+  group: infra-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bicep:
+    name: Bicep build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bicep CLI
+        run: az bicep install
+
+      - name: Bicep version
+        run: az bicep version
+
+      - name: Bicep build (main.bicep)
+        run: az bicep build --file infra/main.bicep --outfile $RUNNER_TEMP/main.json
+
+      - name: Show generated ARM size
+        run: |
+          wc -c "$RUNNER_TEMP/main.json"


### PR DESCRIPTION
## Summary
New \`.github/workflows/infra.yml\` runs \`az bicep build infra/main.bicep\` on every PR and push that touches \`infra/**\` (or the workflow itself). Other paths skip the job entirely so the rest of the repo doesn't pay for it.

### What it catches
Bicep syntax + parameter typing breakage before they reach \`az deployment group create\`. **Doesn't talk to Azure** (no service principal needed) — pure local template compilation.

### Why a separate file
Workflow-level path filters apply to every job in the file, so adding the infra job to \`ci.yml\` would also gate \`web\` + \`api\` on infra changes. A separate workflow keeps the trigger semantics clean.

### Test plan
- [x] Workflow YAML lints clean.
- [ ] The PR itself doesn't touch infra/, so this job **should not run** on this PR — confirming the path filter works correctly.
- [x] Existing \`web\` + \`api\` + SWA jobs continue running.