### PR TITLE
feat(web): VITE_DEV_SKIP_AUTH — local-dev bypass for Vue route guards

### DIFF
--- a/src/web/.env.example
+++ b/src/web/.env.example
@@ -6,6 +6,13 @@ VITE_MSAL_AUTHORITY=https://slypn.ciamlogin.com/<tenant-id>/v2.0
 VITE_MSAL_CLIENT_ID=<spa-client-id>
 VITE_API_SCOPE=api://<api-client-id>/access_as_user
 
+# --- Local-dev escape hatch ------------------------------------------------
+# Pair this with AzureAd__SkipAuth=true in src/api/Slypn.Api/local.settings.json
+# to bypass Entra entirely. When "true", the Vue app auto-signs in as a
+# synthetic Admin/Contributor/Member so route guards open up immediately.
+# MUST be unset or "false" in any deployed environment.
+VITE_DEV_SKIP_AUTH=true
+
 # --- Grafana Faro (see docs/observability-setup.md) ------------------------
 # Faro is gated on cookie consent: even with these set, the SDK only
 # initialises once the user has clicked Accept on the cookie banner.

--- a/src/web/env.d.ts
+++ b/src/web/env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_FARO_URL?: string
   readonly VITE_FARO_APP_NAME?: string
   readonly VITE_FARO_ENV?: string
+  readonly VITE_DEV_SKIP_AUTH?: string
 }
 
 interface ImportMeta {

--- a/src/web/src/lib/msal.ts
+++ b/src/web/src/lib/msal.ts
@@ -17,6 +17,14 @@ export const apiScope = import.meta.env.VITE_API_SCOPE ?? ''
  */
 export const isAuthConfigured = Boolean(clientId && authority && apiScope)
 
+/**
+ * Local-dev escape hatch — pairs with the API's `AzureAd__SkipAuth=true`.
+ * When set, the auth store auto-signs in as a synthetic Admin/Contributor/
+ * Member, route guards open up, and `acquireToken()` returns null (the API
+ * won't check it in SkipAuth mode). MUST be false in any deployed env.
+ */
+export const isDevSkipAuth = import.meta.env.VITE_DEV_SKIP_AUTH === 'true'
+
 const msalConfig: Configuration = {
   auth: {
     clientId,

--- a/src/web/src/stores/auth.ts
+++ b/src/web/src/stores/auth.ts
@@ -9,10 +9,27 @@ import {
   buildSilentRequest,
   ensureMsalInitialized,
   isAuthConfigured,
+  isDevSkipAuth,
   msalInstance,
 } from '@/lib/msal'
 
 type IdTokenClaims = Record<string, unknown> & { roles?: string[] }
+
+function makeDevAccount(): AccountInfo {
+  return {
+    homeAccountId:  'dev-skip-auth',
+    environment:    'localhost',
+    tenantId:       '00000000-0000-0000-0000-000000000000',
+    username:       'dev@slypn.local',
+    localAccountId: 'dev-skip-auth',
+    name:           'Dev Admin',
+    idTokenClaims: {
+      name:  'Dev Admin',
+      oid:   '00000000-0000-0000-0000-000000000000',
+      roles: ['Admin', 'Contributor', 'Member'],
+    } as Record<string, unknown>,
+  } as AccountInfo
+}
 
 export const useAuthStore = defineStore('auth', () => {
   const account = ref<AccountInfo | null>(null)
@@ -20,7 +37,8 @@ export const useAuthStore = defineStore('auth', () => {
   const initialized = ref(false)
 
   const isAuthenticated = computed(() => account.value !== null)
-  const isConfigured = computed(() => isAuthConfigured)
+  /** UI is "configured" if either real Entra or the dev-skip flag is wired. */
+  const isConfigured = computed(() => isAuthConfigured || isDevSkipAuth)
 
   const roles = computed<string[]>(() => {
     const claims = account.value?.idTokenClaims as IdTokenClaims | undefined
@@ -35,12 +53,18 @@ export const useAuthStore = defineStore('auth', () => {
 
   /**
    * Drive MSAL through initialize + handleRedirectPromise and pick up an
-   * already-cached account if any. Safe to call multiple times.
+   * already-cached account if any. In dev-skip mode, synthesises an Admin
+   * principal so route guards open up immediately. Safe to call multiple times.
    */
   async function initialize() {
     if (initialized.value || initializing.value) return
     initializing.value = true
     try {
+      if (isDevSkipAuth) {
+        account.value = makeDevAccount()
+        initialized.value = true
+        return
+      }
       const redirectResult = await ensureMsalInitialized()
       if (redirectResult?.account) {
         msalInstance!.setActiveAccount(redirectResult.account)
@@ -59,8 +83,15 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function login(returnTo?: string) {
+    if (isDevSkipAuth) {
+      account.value = makeDevAccount()
+      if (returnTo && returnTo !== window.location.href) {
+        window.location.href = returnTo
+      }
+      return
+    }
     if (!msalInstance) {
-      throw new Error('Auth not configured — set VITE_MSAL_* env vars.')
+      throw new Error('Auth not configured — set VITE_MSAL_* env vars or VITE_DEV_SKIP_AUTH=true.')
     }
     await ensureMsalInitialized()
     await msalInstance.loginRedirect({
@@ -70,6 +101,11 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function logout() {
+    if (isDevSkipAuth) {
+      account.value = null
+      window.location.href = window.location.origin
+      return
+    }
     if (!msalInstance || !account.value) {
       account.value = null
       return
@@ -81,8 +117,10 @@ export const useAuthStore = defineStore('auth', () => {
    * Returns a bearer access token for the SLYPN API, or null if the user
    * isn't signed in / MSAL isn't configured. Falls back to interactive
    * sign-in if silent acquisition fails for an interaction-required reason.
+   * In dev-skip mode returns null — the API ignores the missing token.
    */
   async function acquireToken(): Promise<string | null> {
+    if (isDevSkipAuth) return null
     if (!msalInstance || !account.value) return null
     await ensureMsalInitialized()
     try {


### PR DESCRIPTION
## Summary
Pairs with the API's \`AzureAd__SkipAuth=true\` so the editor / admin surface area is reachable locally **without** wiring an Entra tenant. Open the site, the auth store auto-signs in as a synthetic Admin/Contributor/Member, and the route guards on \`/dashboard\`, \`/editor\`, \`/admin\` open up.

### What changed
- **\`src/web/src/lib/msal.ts\`** — new exported \`isDevSkipAuth = import.meta.env.VITE_DEV_SKIP_AUTH === 'true'\`. Independent of \`isAuthConfigured\`.
- **\`src/web/src/stores/auth.ts\`**:
  - \`makeDevAccount()\` synthesises an \`AccountInfo\` with name "Dev Admin", oid \`0000...\`, and roles claim \`["Admin", "Contributor", "Member"]\`.
  - \`initialize()\` — in dev-skip mode, sets the account directly and short-circuits MSAL. No network calls.
  - \`login()\` — sets the account, navigates to \`returnTo\`. No redirect dance.
  - \`logout()\` — clears account, lands at origin.
  - \`acquireToken()\` — returns null in dev-skip mode. API's \`SkipAuth\` accepts that.
  - \`isConfigured\` — true when **either** real Entra is wired **or** dev-skip is on, so LoginView's "not configured" banner stops shouting.
- **\`src/web/.env.example\`** — \`VITE_DEV_SKIP_AUTH=true\` placeholder + block comment explaining the pairing and the deployment caveat.
- **\`src/web/env.d.ts\`** — types the new env var.

### Usage

\`\`\`
src/web/.env.local                        VITE_DEV_SKIP_AUTH=true
src/api/Slypn.Api/local.settings.json     AzureAd__SkipAuth: "true"
scripts/start.ps1
# visit http://localhost:5173/admin or /editor — they open
\`\`\`

### Safety
\`VITE_DEV_SKIP_AUTH\` is a build-time Vite env var; it's only honoured when explicitly set. Production SWA app settings never set it, so prod always uses real Entra.

### Test plan
- [x] \`npm run lint\` clean.
- [x] \`npm run build\` clean.
- [ ] CI green.