### PR TITLE
feat(web): editor type picker — Article / Blog post toggle

### DIFF
--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -225,6 +225,35 @@ const tagsCsv = computed({
     </div>
 
     <div class="space-y-4 rounded-xl border border-slypn-100 bg-white p-6 shadow-sm">
+      <fieldset>
+        <legend class="text-sm font-medium text-slypn-800">Type</legend>
+        <div class="mt-2 inline-flex rounded-md border border-slypn-200 bg-white p-1">
+          <button
+            type="button"
+            :class="[
+              'rounded-md px-3 py-1.5 text-sm font-semibold transition-colors',
+              draft.type === 'article' ? 'bg-slypn-600 text-white' : 'text-slypn-700 hover:bg-slypn-50',
+            ]"
+            @click="draft.type = 'article'"
+          >
+            Article
+          </button>
+          <button
+            type="button"
+            :class="[
+              'rounded-md px-3 py-1.5 text-sm font-semibold transition-colors',
+              draft.type === 'blog' ? 'bg-slypn-600 text-white' : 'text-slypn-700 hover:bg-slypn-50',
+            ]"
+            @click="draft.type = 'blog'"
+          >
+            Blog post
+          </button>
+        </div>
+        <p class="mt-1 text-xs text-slypn-900/60">
+          Articles are longer, considered pieces. Blog posts are shorter updates.
+        </p>
+      </fieldset>
+
       <div>
         <label class="block text-sm font-medium text-slypn-800">Title</label>
         <input


### PR DESCRIPTION
## Summary
Trivial follow-up to the \`/api/blog\` wiring. The editor form now has a two-button toggle bound to \`draft.type\`. Autosave already passes it to the API, so blog drafts flow through the workflow end-to-end without a single curl invocation:

\`\`\`
Editor (type=blog) -> autosave -> /api/drafts/{id}
Submit             -> /api/drafts/{id}/submit -> Article in articles container with Type=blog
Admin publishes    -> Article moves to status=published (Type=blog preserved)
/blog              -> shows it
/articles          -> doesn't
\`\`\`

Toggle defaults to **Article**, placed at the top of the form above Title so the choice is set before anything else.

### Test plan
- [x] \`npm run lint\` clean.
- [x] \`npm run build\` clean.
- [ ] Manual: switch to Blog post, write something, submit, publish, see on \`/blog\` not \`/articles\`.
- [ ] CI green.