### PR TITLE
perf(web): lazy-load auth-gated views + split MSAL/Faro into vendor chunks

### DIFF
--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -8,12 +8,16 @@ import EventsView from '@/views/EventsView.vue'
 import ResourcesView from '@/views/ResourcesView.vue'
 import NewsletterView from '@/views/NewsletterView.vue'
 import LoginView from '@/views/LoginView.vue'
-import AuthCallbackView from '@/views/AuthCallbackView.vue'
-import DashboardView from '@/views/DashboardView.vue'
-import EditorView from '@/views/EditorView.vue'
-import AdminView from '@/views/AdminView.vue'
 import NotFoundView from '@/views/NotFoundView.vue'
 import { useAuthStore } from '@/stores/auth'
+
+// Auth-gated views are dynamically imported so TipTap (used only by EditorView),
+// the Approvals queue (AdminView), and the dashboard never ship to anonymous
+// public visitors. Each import becomes its own chunk via Vite's code-splitting.
+const AuthCallbackView = () => import('@/views/AuthCallbackView.vue')
+const DashboardView    = () => import('@/views/DashboardView.vue')
+const EditorView       = () => import('@/views/EditorView.vue')
+const AdminView        = () => import('@/views/AdminView.vue')
 
 declare module 'vue-router' {
   interface RouteMeta {

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -13,6 +13,20 @@ export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Split heavy vendor libs into their own chunks so the public bundle
+        // (Home / Articles / Events / …) stays lean. MSAL is needed by the
+        // nav user menu so it loads on every page, but parsing it as its own
+        // chunk lets the HTTP cache reuse it across SPA navigations.
+        manualChunks: {
+          msal: ['@azure/msal-browser'],
+          faro: ['@grafana/faro-web-sdk', '@grafana/faro-web-tracing'],
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
Cuts initial-page JS by ~45 % by code-splitting the bundle. Public visitors no longer download TipTap (Editor only), the Approvals queue (Admin only), or the bits of MSAL/Faro the route they're on doesn't actually need.

### Changes
- **\`router/index.ts\`** — \`AuthCallbackView\`, \`DashboardView\`, \`EditorView\`, \`AdminView\` switch from eager imports to dynamic \`() => import(...)\`. Each becomes its own chunk.
- **\`vite.config.ts\`** — \`build.rollupOptions.output.manualChunks\` splits two vendor libs the public bundle used to pull in:
  - \`msal\` → \`@azure/msal-browser\`
  - \`faro\` → \`@grafana/faro-web-sdk\` + \`@grafana/faro-web-tracing\`
- MSAL stays on the critical path (nav user menu + route guards need it on every navigation), but as its own chunk it's cached independently so SPA route changes don't re-parse it.
- Faro is already consent-gated, so its chunk only downloads **after** the user clicks Accept on the cookie banner.

### Bundle sizes

| | Before | After |
|---|---|---|
| Single main chunk | **750 KB (226 KB gz)**, chunk warning | gone |
| \`index\` (every page) | — | **142 KB (51 KB gz)** |
| \`msal\` (every page) | — | 266 KB (65 KB gz) |
| \`faro\` (after consent) | — | 187 KB (58 KB gz) |
| \`EditorView\` (/editor only) | — | 333 KB (106 KB gz) |
| \`AdminView\` (/admin only) | — | 9 KB (3 KB gz) |
| \`DashboardView\` | — | 2 KB |
| \`AuthCallbackView\` | — | 0.5 KB |

Public-visitor initial JS drops from **750 KB → 408 KB** (~45 % less). No chunk warning.

### Test plan
- [x] \`npm run lint\` clean.
- [x] \`npm run build\` clean, no chunk warning.
- [ ] Manual: navigate around — first paint reads only \`index\` + \`msal\`; \`/editor\` lazy-loads its chunk on click.
- [ ] CI green.