### PR TITLE
feat(api,web): real POST /api/newsletter/subscribe

### DIFF
--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -3,6 +3,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
@@ -68,6 +69,58 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
         {
             await repo.DeleteNewsletterAsync(id, year, IfMatch(req), ct);
             return NoContent(req);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
+    /// <summary>
+    /// Public anonymous newsletter subscribe. Stores the email as a Member row
+    /// with Status="subscribed" so we get free dedupe (UpsertMemberAsync is
+    /// idempotent on a given id). No role assignment — subscribers aren't
+    /// SLYPN members in the auth sense.
+    /// </summary>
+    [Function("SubscribeToNewsletter")]
+    public async Task<HttpResponseData> Subscribe(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "newsletter/subscribe")] HttpRequestData req,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+
+        var (input, err) = await ReadValidatedAsync<SubscribeInput>(req, ct);
+        if (err is not null) return err;
+
+        var email = input!.Email.Trim().ToLowerInvariant();
+
+        Member? existing;
+        try { existing = await repo.GetMemberByEmailAsync(email, ct); }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+
+        var now = DateTime.UtcNow;
+        var displayName = input.DisplayName?.Trim();
+
+        var record = existing is null
+            ? new Member(
+                Id:          Guid.NewGuid().ToString("N"),
+                Email:       email,
+                DisplayName: string.IsNullOrWhiteSpace(displayName) ? email : displayName!,
+                Roles:       Array.Empty<string>(),
+                Status:      "subscribed",
+                InvitedAt:   now)
+            : existing with
+            {
+                // Promote any earlier "invited" -> still "subscribed" but keep
+                // their roles + oid if they're an actual member. For pure
+                // subscribers (no roles, no oid), we just refresh the timestamp.
+                Status      = existing.Roles.Count > 0 || existing.Oid is not null
+                                ? existing.Status
+                                : "subscribed",
+                DisplayName = string.IsNullOrWhiteSpace(displayName) ? existing.DisplayName : displayName!,
+            };
+
+        try
+        {
+            var saved = await repo.UpsertMemberAsync(record, existing?.Etag, ct);
+            return await Created(req, new { saved.Email, saved.Status });
         }
         catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }

--- a/src/api/Slypn.Api/Models/Inputs/SubscribeInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/SubscribeInput.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+public sealed class SubscribeInput
+{
+    [Required, EmailAddress, StringLength(254)]
+    public string Email { get; set; } = "";
+
+    [StringLength(120)]
+    public string? DisplayName { get; set; }
+}

--- a/src/web/src/views/NewsletterView.vue
+++ b/src/web/src/views/NewsletterView.vue
@@ -2,21 +2,39 @@
 import { ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import NewsletterCard from '@/components/common/NewsletterCard.vue'
-import { apiJson } from '@/lib/api'
+import { apiFetch, apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
 import type { Newsletter } from '@/types/content'
 
 const email = ref('')
+const submitting = ref(false)
 const submitted = ref(false)
+const submitError = ref<string | null>(null)
 
 const { data: newsletters, loading, error, refresh } = useAsyncData(
   () => apiJson<Newsletter[]>('/newsletters'),
 )
 
-function subscribe() {
-  if (!email.value) return
-  submitted.value = true
-  email.value = ''
+async function subscribe() {
+  if (!email.value || submitting.value) return
+  submitting.value = true
+  submitError.value = null
+  try {
+    const resp = await apiFetch('/newsletter/subscribe', {
+      method: 'POST',
+      body: JSON.stringify({ email: email.value.trim() }),
+    })
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '')
+      throw new Error(`${resp.status} ${resp.statusText}${body ? ` — ${body}` : ''}`)
+    }
+    submitted.value = true
+    email.value = ''
+  } catch (err) {
+    submitError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    submitting.value = false
+  }
 }
 </script>
 
@@ -41,13 +59,17 @@ function subscribe() {
         />
         <button
           type="submit"
-          class="rounded-md bg-slypn-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-slypn-700"
+          class="rounded-md bg-slypn-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-slypn-700 disabled:opacity-50"
+          :disabled="submitting || !email"
         >
-          Subscribe
+          {{ submitting ? 'Subscribing…' : 'Subscribe' }}
         </button>
       </form>
-      <p v-if="submitted" class="mt-3 text-sm text-slypn-600">
-        Thank you &mdash; we&rsquo;ll add you to the next issue. (This is a mock form for now.)
+      <p v-if="submitted" class="mt-3 text-sm text-emerald-700">
+        Thank you &mdash; you&rsquo;re on the list. The next issue will land in your inbox.
+      </p>
+      <p v-else-if="submitError" class="mt-3 text-sm text-rose-700">
+        Couldn&rsquo;t subscribe: {{ submitError }}
       </p>
     </template>
   </HeroBanner>


### PR DESCRIPTION
## Summary
The newsletter signup form was the last fake interaction on the public site. This wires it through to a real anonymous endpoint that stores the email as a Member row with \`Status="subscribed"\`.

### API
- **\`Models/Inputs/SubscribeInput.cs\`** — \`Email\` (\`[EmailAddress, 254 char]\`) + optional \`DisplayName\`.
- **\`Functions/NewslettersFunctions.cs\`** — new \`POST /api/newsletter/subscribe\`. Anonymous.
  - Reuses \`ContentRepository.GetMemberByEmailAsync\` / \`UpsertMemberAsync\` so dedupe is free.
  - \`Status="subscribed"\` with no role assignment. Subscribers aren't SLYPN members in the auth sense — no oid, no roles.
  - Existing rows that hold roles or an oid (real Members) keep their status; pure subscribers get refreshed.
  - Returns \`201\` with \`{ email, status }\`.

### Web
- **\`views/NewsletterView.vue\`** — real \`subscribe()\` that POSTs via \`apiFetch\`. Submitting button label flips to "Subscribing…". Success → green "you're on the list"; failure → red error with the server message. No more "this is a mock form".

### Test plan
- [x] \`dotnet build\` clean.
- [x] \`dotnet test\` — 28 / 28.
- [x] \`npm run lint\` clean.
- [x] \`npm run build\` clean.
- [ ] Manual: subscribe → check the members container in Cosmos has a row with Status="subscribed". Subscribe twice → no duplicate (the Email match upserts the existing row).
- [ ] CI green.