### PR TITLE
fix(auth): read roles from API access token; simplify Graph invite config

### DIFF
--- a/docs/auth-setup.md
+++ b/docs/auth-setup.md
@@ -107,7 +107,7 @@ Two registrations live in the SLYPN External ID tenant: one for the Vue SPA (pub
 
 1. **Identity → Applications → App registrations → New registration**.
 2. Name: `slypn-api`.
-3. Supported account types: **Accounts in this organizational directory only**.
+3. Supported account types: **Single tenant only - slypn** (this is the current label for "Accounts in this organizational directory only").
 4. Redirect URI: leave empty.
 5. **Register**.
 
@@ -134,7 +134,7 @@ After registration:
 
 1. **Identity → Applications → App registrations → New registration**.
 2. Name: `slypn-spa`.
-3. Supported account types: **Accounts in this organizational directory only**.
+3. Supported account types: **Single tenant only - slypn** (this is the current label for "Accounts in this organizational directory only").
 4. Redirect URI: **Single-page application (SPA)** → `http://localhost:5173/auth/callback`.
 5. **Register**.
 
@@ -155,6 +155,21 @@ After registration:
 2. Pick yourself and assign the **Administrator** role.
 3. Repeat for any additional admins / contributors. New customers who self-sign-up via the user flow start with no app role; the **Invite Member** flow in #24 grants them `Member` automatically.
 
+### 6.4 Grant Microsoft Graph invitation permission
+
+The `slypn-api` app calls the Graph `POST /v1.0/invitations` endpoint to send B2B invitation emails to new members. It needs `User.Invite.All` and a client secret.
+
+1. In the SLYPN External ID tenant: **Identity → Applications → App registrations → `slypn-api` → API permissions → Add a permission → Microsoft Graph → Application permissions**.
+2. Search for and tick **`User.Invite.All`**. Add permissions.
+3. Click **Grant admin consent for SLYPN** (the yellow warning banner). Confirm.
+4. **Certificates & secrets → Client secrets → New client secret** — description: `graph-invitations`, expiry: 24 months.
+5. Copy the secret **Value** immediately — it's hidden once you leave the page.
+6. Add it to your local settings:
+   ```
+   "Graph__ClientSecret": "<value>"
+   ```
+   Tenant ID and client ID come from the `AzureAd__TenantId` and `AzureAd__Audience` settings already in `local.settings.json`; you don't need to set separate `Graph__TenantId` / `Graph__ClientId` values.
+
 ---
 
 ## 7. Values to capture for code wiring
@@ -167,8 +182,9 @@ After steps 1–6 you should have the following — none go in source control, a
 | Vue SPA | `VITE_MSAL_CLIENT_ID` | `spaClientId` |
 | Vue SPA | `VITE_API_SCOPE` | `api://<apiClientId>/access_as_user` |
 | Functions API | `AzureAd__Authority` | `https://slypn.ciamlogin.com/<tenantId>/v2.0` |
-| Functions API | `AzureAd__Audience` | `api://<apiClientId>` |
+| Functions API | `AzureAd__Audience` | `<apiClientId>` (bare GUID — CIAM access tokens set `aud` to the client ID, not the `api://` URI) |
 | Functions API | `AzureAd__ValidIssuers__0` | `https://slypn.ciamlogin.com/<tenantId>/v2.0` |
+| Functions API | `AzureAd__ValidIssuers__1` | `https://<tenantId>.ciamlogin.com/<tenantId>/v2.0` (CIAM also issues tokens with this tenant-ID-subdomain issuer) |
 | Functions API | `AzureAd__TenantId` | `<tenantId>` |
 
 Sample placeholder values land in `src/web/.env.example` and `src/api/Slypn.Api/local.settings.sample.json` alongside the MSAL.js wiring in #21 and the JWT middleware in #22.

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -114,6 +114,20 @@ function Resolve-WinExe($name) {
 Write-Step 'Starting Vite (web)'
 $npmExe = Resolve-WinExe 'npm'
 if (-not $npmExe) { Write-Err 'npm.cmd not on PATH'; exit 1 }
+
+$viteBinary = Join-Path $WebDir 'node_modules/.bin/vite.cmd'
+if (-not (Test-Path $viteBinary)) {
+    Write-Step 'Installing web dependencies (npm ci)'
+    Push-Location $WebDir
+    & $npmExe ci --no-audit --no-fund
+    $npmExit = $LASTEXITCODE
+    Pop-Location
+    if ($npmExit -ne 0) {
+        Write-Err 'npm ci failed. See the output above for details.'
+        exit 1
+    }
+}
+
 $webProc = Start-Process -FilePath $npmExe -ArgumentList 'run', 'dev' `
     -WorkingDirectory $WebDir `
     -RedirectStandardOutput $webLog `

--- a/src/api/Slypn.Api/Infrastructure/EntraJwtValidator.cs
+++ b/src/api/Slypn.Api/Infrastructure/EntraJwtValidator.cs
@@ -11,7 +11,10 @@ public sealed class EntraJwtValidator : IJwtValidator
 {
     private readonly EntraOptions _opts;
     private readonly ConfigurationManager<OpenIdConnectConfiguration>? _configManager;
-    private readonly JwtSecurityTokenHandler _handler = new();
+    // MapInboundClaims=false keeps JWT claim names verbatim (e.g. "roles")
+    // so RoleClaimType="roles" resolves correctly. The default true remaps
+    // "roles" to the long-form ClaimTypes.Role URI, breaking IsInRole checks.
+    private readonly JwtSecurityTokenHandler _handler = new() { MapInboundClaims = false };
 
     public EntraJwtValidator(IOptions<EntraOptions> options)
     {

--- a/src/api/Slypn.Api/Infrastructure/GraphOptions.cs
+++ b/src/api/Slypn.Api/Infrastructure/GraphOptions.cs
@@ -13,11 +13,8 @@ public sealed class GraphOptions
     /// <summary>Client secret for client-credentials auth against Microsoft Graph.</summary>
     public string? ClientSecret { get; set; }
 
-    /// <summary>Where invitees land after accepting. Should be the production SWA URL in prod.</summary>
-    public string InviteRedirectUrl { get; set; } = "http://localhost:5173/";
+    /// <summary>Where invitees land after accepting. Must be an HTTPS URL — Graph rejects http://localhost.</summary>
+    public string InviteRedirectUrl { get; set; } = "https://thankful-tree-090006c03.7.azurestaticapps.net/";
 
-    public bool IsConfigured =>
-        !string.IsNullOrWhiteSpace(TenantId)     &&
-        !string.IsNullOrWhiteSpace(ClientId)     &&
-        !string.IsNullOrWhiteSpace(ClientSecret);
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(ClientSecret);
 }

--- a/src/api/Slypn.Api/Services/GraphInviteService.cs
+++ b/src/api/Slypn.Api/Services/GraphInviteService.cs
@@ -12,10 +12,12 @@ namespace Slypn.Api.Services;
 /// </summary>
 public sealed class GraphInviteService(
     IOptions<GraphOptions> options,
+    IOptions<EntraOptions> entraOptions,
     IHttpClientFactory httpFactory,
     ILogger<GraphInviteService> logger) : IInviteService
 {
     private readonly GraphOptions _opts = options.Value;
+    private readonly EntraOptions _entra = entraOptions.Value;
 
     public bool IsConfigured => _opts.IsConfigured;
 
@@ -57,14 +59,16 @@ public sealed class GraphInviteService(
 
     private async Task<string?> AcquireTokenAsync(HttpClient http, CancellationToken ct)
     {
+        var tenantId = string.IsNullOrWhiteSpace(_opts.TenantId) ? _entra.TenantId : _opts.TenantId;
+        var clientId = string.IsNullOrWhiteSpace(_opts.ClientId) ? _entra.Audience  : _opts.ClientId;
         var form = new FormUrlEncodedContent(new[]
         {
-            KeyValuePair.Create("client_id",     _opts.ClientId!),
+            KeyValuePair.Create("client_id",     clientId!),
             KeyValuePair.Create("client_secret", _opts.ClientSecret!),
             KeyValuePair.Create("scope",         "https://graph.microsoft.com/.default"),
             KeyValuePair.Create("grant_type",    "client_credentials"),
         });
-        var tokenUrl = $"https://login.microsoftonline.com/{_opts.TenantId}/oauth2/v2.0/token";
+        var tokenUrl = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token";
         using var resp = await http.PostAsync(tokenUrl, form, ct);
         var body = await resp.Content.ReadAsStringAsync(ct);
         if (!resp.IsSuccessStatusCode)

--- a/src/api/Slypn.Api/local.settings.sample.json
+++ b/src/api/Slypn.Api/local.settings.sample.json
@@ -13,8 +13,6 @@
     "AzureAd__Audience": "",
     "AzureAd__TenantId": "",
     "AzureAd__SkipAuth": "true",
-    "Graph__TenantId": "",
-    "Graph__ClientId": "",
     "Graph__ClientSecret": "",
     "Graph__InviteRedirectUrl": "http://localhost:5173/",
     "Otel__Endpoint": "",

--- a/src/web/src/stores/auth.ts
+++ b/src/web/src/stores/auth.ts
@@ -15,6 +15,27 @@ import {
 
 type IdTokenClaims = Record<string, unknown> & { roles?: string[] }
 
+/**
+ * App roles live on the slypn-api app registration, so the `roles` claim only
+ * appears in the access token issued for that audience — not in the SPA's ID
+ * token. Decode the JWT payload (no signature check — verification happens at
+ * the API) to pull roles out for UI gating.
+ */
+function decodeJwtRoles(token: string): string[] {
+  try {
+    const segment = token.split('.')[1]
+    if (!segment) return []
+    const padded = segment.replace(/-/g, '+').replace(/_/g, '/')
+    const padding = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4))
+    const payload = JSON.parse(atob(padded + padding)) as { roles?: unknown }
+    return Array.isArray(payload.roles)
+      ? payload.roles.filter((r): r is string => typeof r === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
 function makeDevAccount(): AccountInfo {
   return {
     homeAccountId:  'dev-skip-auth',
@@ -33,6 +54,7 @@ function makeDevAccount(): AccountInfo {
 
 export const useAuthStore = defineStore('auth', () => {
   const account = ref<AccountInfo | null>(null)
+  const apiRoles = ref<string[]>([])
   const initializing = ref(false)
   const initialized = ref(false)
 
@@ -41,6 +63,9 @@ export const useAuthStore = defineStore('auth', () => {
   const isConfigured = computed(() => isAuthConfigured || isDevSkipAuth)
 
   const roles = computed<string[]>(() => {
+    if (apiRoles.value.length > 0) return apiRoles.value
+    // Dev-skip mode parks roles on the synthetic account's idTokenClaims since
+    // there's no real access token to decode.
     const claims = account.value?.idTokenClaims as IdTokenClaims | undefined
     return Array.isArray(claims?.roles) ? claims!.roles! : []
   })
@@ -76,6 +101,9 @@ export const useAuthStore = defineStore('auth', () => {
           account.value = cached
         }
       }
+      if (account.value) {
+        await refreshApiRoles()
+      }
       initialized.value = true
     } finally {
       initializing.value = false
@@ -103,14 +131,35 @@ export const useAuthStore = defineStore('auth', () => {
   async function logout() {
     if (isDevSkipAuth) {
       account.value = null
+      apiRoles.value = []
       window.location.href = window.location.origin
       return
     }
     if (!msalInstance || !account.value) {
       account.value = null
+      apiRoles.value = []
       return
     }
     await msalInstance.logoutRedirect({ account: account.value })
+  }
+
+  /**
+   * Silently fetch an access token for the SLYPN API and harvest its `roles`
+   * claim. Failures (no cached account, interaction required, etc.) leave
+   * apiRoles empty rather than throw — the UI just degrades to no-role view.
+   */
+  async function refreshApiRoles() {
+    if (isDevSkipAuth) return
+    if (!msalInstance || !account.value) {
+      apiRoles.value = []
+      return
+    }
+    try {
+      const result = await msalInstance.acquireTokenSilent(buildSilentRequest(account.value))
+      apiRoles.value = decodeJwtRoles(result.accessToken)
+    } catch {
+      apiRoles.value = []
+    }
   }
 
   /**
@@ -125,6 +174,7 @@ export const useAuthStore = defineStore('auth', () => {
     await ensureMsalInitialized()
     try {
       const result = await msalInstance.acquireTokenSilent(buildSilentRequest(account.value))
+      apiRoles.value = decodeJwtRoles(result.accessToken)
       return result.accessToken
     } catch (err) {
       if (err instanceof InteractionRequiredAuthError) {

--- a/src/web/src/views/AdminView.vue
+++ b/src/web/src/views/AdminView.vue
@@ -18,16 +18,10 @@ const allRoles: Role[] = ['Admin', 'Contributor', 'Member']
 
 const email = ref('')
 const displayName = ref('')
-const roles = ref<Role[]>(['Member'])
+const role = ref<Role>('Member')
 const submitting = ref(false)
 const error = ref<string | null>(null)
 const success = ref<InviteResponseOk | null>(null)
-
-function toggleRole(r: Role) {
-  const i = roles.value.indexOf(r)
-  if (i >= 0) roles.value.splice(i, 1)
-  else roles.value.push(r)
-}
 
 async function submit() {
   if (submitting.value) return
@@ -40,7 +34,7 @@ async function submit() {
       body: JSON.stringify({
         email: email.value.trim(),
         displayName: displayName.value.trim(),
-        roles: roles.value,
+        roles: [role.value],
       }),
     })
     if (!resp.ok) {
@@ -50,7 +44,7 @@ async function submit() {
     success.value = await resp.json() as InviteResponseOk
     email.value = ''
     displayName.value = ''
-    roles.value = ['Member']
+    role.value = 'Member'
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err)
   } finally {
@@ -71,7 +65,7 @@ async function submit() {
       <h2 class="font-display text-xl font-bold text-slypn-700">Invite a member</h2>
       <p class="mt-2 text-sm text-slypn-900/75">
         Sends an Entra External ID invitation. The recipient gets an email with a link
-        to sign up; when they accept they&rsquo;ll be granted the role(s) you choose.
+        to sign up; when they accept they&rsquo;ll be granted the role you choose.
       </p>
 
       <form class="mt-6 space-y-4" @submit.prevent="submit">
@@ -94,19 +88,19 @@ async function submit() {
           />
         </div>
         <fieldset>
-          <legend class="text-sm font-medium text-slypn-800">Roles</legend>
-          <div class="mt-2 flex flex-wrap gap-2">
+          <legend class="text-sm font-medium text-slypn-800">Role</legend>
+          <div class="mt-2 inline-flex rounded-md border border-slypn-200 bg-white p-1">
             <button
               v-for="r in allRoles"
               :key="r"
               type="button"
               :class="[
-                'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
-                roles.includes(r)
-                  ? 'border-slypn-600 bg-slypn-600 text-white'
-                  : 'border-slypn-200 bg-white text-slypn-700 hover:bg-slypn-50',
+                'rounded-md px-4 py-1.5 text-sm font-medium transition-colors',
+                role === r
+                  ? 'bg-slypn-600 text-white'
+                  : 'text-slypn-700 hover:bg-slypn-50',
               ]"
-              @click="toggleRole(r)"
+              @click="role = r"
             >
               {{ r }}
             </button>
@@ -116,7 +110,7 @@ async function submit() {
         <button
           type="submit"
           class="rounded-md bg-slypn-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700 disabled:opacity-50"
-          :disabled="submitting || !email || !displayName || roles.length === 0"
+          :disabled="submitting || !email || !displayName"
         >
           {{ submitting ? 'Inviting…' : 'Send invitation' }}
         </button>


### PR DESCRIPTION
## Summary

- **Auth roles**: `EntraJwtValidator` now uses `MapInboundClaims=false` so the `roles` JWT claim is kept verbatim and `RoleClaimType` resolution works correctly (the default remaps `roles` to the long-form `ClaimTypes.Role` URI, silently breaking `[RequireRole]`)
- **Admin UI**: role picker simplified from multi-select to single-select (roles are mutually exclusive)
- **Graph invites**: `GraphInviteService` falls back to `AzureAd__TenantId` / `AzureAd__Audience` for token acquisition — only `Graph__ClientSecret` now needs to be set to enable invitations
- **Docs**: `auth-setup.md` §6.4 documents how to grant `User.Invite.All` and create the client secret
- **start.ps1**: auto-runs `npm ci` if `node_modules` is absent

## Test plan

- [ ] Sign in as Admin — `/admin` renders; `[RequireRole("Admin")]` endpoints return 200 not 401
- [ ] Invite a member via the form — response shows `inviteSent: true` and a `redeemUrl` (requires `Graph__ClientSecret` in local.settings.json)
- [ ] Invite with Graph unconfigured (empty secret) — falls back cleanly to `graph-not-configured` message, no crash
- [ ] `.\scripts\start.ps1` from a clean checkout (no node_modules) — installs deps automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)