### PR TITLE
feat(events): event management for contributors + auth hardening

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -64,6 +64,12 @@ jobs:
           # set in repo secrets, the action build-only and skips the upload
           # instead of erroring. Remove this flag once the token is in place.
           skip_deploy_on_missing_secrets: true
+        env:
+          # Vite bakes these into the JS bundle at build time.
+          # Set via: .\infra\setup.ps1 (GitHub secrets phase).
+          VITE_MSAL_AUTHORITY: ${{ secrets.VITE_MSAL_AUTHORITY }}
+          VITE_MSAL_CLIENT_ID: ${{ secrets.VITE_MSAL_CLIENT_ID }}
+          VITE_API_SCOPE: ${{ secrets.VITE_API_SCOPE }}
 
   close_pr_environment:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -1,0 +1,847 @@
+<#
+.SYNOPSIS
+  Full SLYPN environment bootstrap — Azure infrastructure and Entra External ID.
+
+.DESCRIPTION
+  Five phases, each independently skippable:
+
+  BICEP   Deploy infra/main.bicep, capture outputs, store Cosmos key and
+          Storage connection string.
+
+  ENTRA   Configure Entra External ID (CIAM):
+            – API app (slypn-api): roles, scope, Graph User.Invite.All, secret
+            – SPA app (slypn-web): PKCE, redirect URIs, pre-authorisation
+            – User flows: checked and reported
+            – Company branding HTML: uploaded to the storage static site
+
+  SWA     Wire both halves together: set all app settings on the Static Web App
+          (AzureAd, Graph, Cosmos, Storage) in one call.
+
+  GITHUB  Set repository secrets needed by GitHub Actions:
+            – AZURE_STATIC_WEB_APPS_API_TOKEN  (SWA deploy)
+            – VITE_MSAL_AUTHORITY / VITE_MSAL_CLIENT_ID / VITE_API_SCOPE
+              (passed to npm run build by azure-static-web-apps.yml)
+          Requires the GitHub CLI (gh). Skipped automatically if gh is absent.
+
+  LOCAL   Write src/web/.env.local and merge Entra values into
+          src/api/Slypn.Api/local.settings.json so the local dev environment
+          can authenticate against the real CIAM tenant.
+
+  All derived values are saved to infra/secrets.json (gitignored by the
+  existing "secrets.*" rule in .gitignore). Safe to re-run at any time —
+  every operation checks current state before making changes.
+
+.PARAMETER SkipBicep
+  Skip Azure infrastructure deployment (use cached outputs from secrets.json).
+
+.PARAMETER SkipEntra
+  Skip Entra External ID setup.
+
+.PARAMETER SkipSwa
+  Skip configuring SWA app settings. Implied when both -SkipBicep and
+  -SkipEntra are set and there is no cached SWA name.
+
+.PARAMETER SkipLocal
+  Skip writing local dev config files.
+
+.PARAMETER SkipBranding
+  Skip uploading the company branding HTML template to blob storage.
+
+.PARAMETER SkipGitHub
+  Skip the GitHub secrets phase. Also skipped automatically when the gh CLI
+  is not found on PATH.
+
+.PARAMETER RotateSecret
+  Force-rotate the Graph API client secret even if it is not near expiry.
+#>
+[CmdletBinding()]
+param(
+    [switch]$SkipBicep,
+    [switch]$SkipEntra,
+    [switch]$SkipSwa,
+    [switch]$SkipGitHub,
+    [switch]$SkipLocal,
+    [switch]$SkipBranding,
+    [switch]$RotateSecret
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$InformationPreference = 'Continue'
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+function Step([string]$m) { Write-Host "`n◆ $m" -ForegroundColor Cyan }
+function Ok  ([string]$m) { Write-Host "  ✓ $m" -ForegroundColor Green }
+function Info([string]$m) { Write-Host "  · $m" -ForegroundColor DarkGray }
+function Warn([string]$m) { Write-Host "  ! $m" -ForegroundColor Yellow }
+
+$repoRoot     = Split-Path -Parent $PSScriptRoot
+$scriptDir    = $PSScriptRoot
+$secretsPath  = Join-Path $scriptDir 'secrets.json'
+$templatePath = Join-Path $scriptDir 'signin-template.html'
+$bicepPath    = Join-Path $scriptDir 'main.bicep'
+$paramsPath   = Join-Path $scriptDir 'main.parameters.prod.json'
+$envLocalPath = Join-Path $repoRoot 'src' 'web' '.env.local'
+$localSettingsPath = Join-Path $repoRoot 'src' 'api' 'Slypn.Api' 'local.settings.json'
+$localSettingsSamplePath = Join-Path $repoRoot 'src' 'api' 'Slypn.Api' 'local.settings.sample.json'
+
+function Read-Secrets {
+    if (Test-Path $secretsPath) {
+        # ConvertFrom-Json -AsHashtable returns OrderedDictionary on PS 7.3+
+        # which lacks ContainsKey. Copy into a plain hashtable to normalise.
+        $raw = Get-Content $secretsPath -Raw | ConvertFrom-Json -AsHashtable
+        $ht  = @{}
+        foreach ($k in $raw.Keys) { $ht[$k] = $raw[$k] }
+        return $ht
+    }
+    return @{}
+}
+
+function Save-Secrets([hashtable]$secrets) {
+    $secrets | ConvertTo-Json -Depth 5 | Set-Content $secretsPath -Encoding UTF8
+}
+
+# Returns the cached value if present; otherwise prompts.
+function Ask([hashtable]$s, [string]$key, [string]$label, [string]$default = '') {
+    if ($s.Contains($key) -and -not [string]::IsNullOrWhiteSpace($s[$key])) {
+        Info "$label = $($s[$key])"
+        return $s[$key]
+    }
+    $hint = if ($default) { " [$default]" } else { '' }
+    $val  = Read-Host "  ? $label$hint"
+    if ([string]::IsNullOrWhiteSpace($val)) { $val = $default }
+    if (-not [string]::IsNullOrWhiteSpace($val)) { $s[$key] = $val }
+    return $val
+}
+
+# Call Microsoft Graph API. Acquires a fresh token every call.
+function Invoke-Graph([string]$Method, [string]$Path, [object]$Body = $null,
+                      [string]$ApiVersion = 'v1.0') {
+    $token  = (az account get-access-token --resource https://graph.microsoft.com `
+                 --query accessToken -o tsv 2>$null)
+    $params = @{
+        Method  = $Method
+        Uri     = "https://graph.microsoft.com/$ApiVersion$Path"
+        Headers = @{ Authorization = "Bearer $token"; 'Content-Type' = 'application/json' }
+    }
+    if ($null -ne $Body) { $params.Body = ($Body | ConvertTo-Json -Depth 10) }
+    Invoke-RestMethod @params
+}
+
+# Upload raw file bytes to a Graph navigation property (e.g. branding assets).
+function Invoke-GraphUpload([string]$Path, [string]$FilePath, [string]$ContentType,
+                            [string]$ApiVersion = 'v1.0') {
+    $token = (az account get-access-token --resource https://graph.microsoft.com `
+                --query accessToken -o tsv 2>$null)
+    $bytes = [IO.File]::ReadAllBytes($FilePath)
+    Invoke-RestMethod `
+        -Method Put `
+        -Uri    "https://graph.microsoft.com/$ApiVersion$Path" `
+        -Headers @{ Authorization = "Bearer $token"; 'Content-Type' = $ContentType } `
+        -Body   $bytes
+}
+
+# Compare two string arrays as unordered sets.
+function Compare-StringSets([string[]]$a, [string[]]$b) {
+    $sa = [System.Collections.Generic.HashSet[string]]([string[]]@($a | Where-Object { $_ }))
+    $sb = [System.Collections.Generic.HashSet[string]]([string[]]@($b | Where-Object { $_ }))
+    return $sa.SetEquals($sb)
+}
+
+# Ensure the active az subscription context matches $subscriptionId. Re-prompts
+# if we're currently in the CIAM tenant or wrong subscription.
+function Switch-ToSubscription([string]$subscriptionId) {
+    $current = az account show -o json 2>$null | ConvertFrom-Json
+    if ($current -and $current.id -eq $subscriptionId) {
+        return
+    }
+    # Try setting the subscription on the current login first.
+    az account set --subscription $subscriptionId 2>$null
+    if ($LASTEXITCODE -eq 0) { return }
+    # If that failed (e.g. we're in the CIAM tenant context), re-login.
+    Info 'Re-authenticating to Azure subscription...'
+    az login | Out-Null
+    az account set --subscription $subscriptionId | Out-Null
+}
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+Step 'Checking prerequisites'
+foreach ($tool in @('az')) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        throw "Required tool '$tool' is not installed or not on PATH."
+    }
+}
+Ok 'Azure CLI found'
+
+# ── Load secrets and gather inputs ────────────────────────────────────────────
+
+$s = Read-Secrets
+
+Write-Host "`nSLYPN  ·  Environment bootstrap" -ForegroundColor White
+Write-Host "────────────────────────────────" -ForegroundColor DarkGray
+Write-Host '  Cached values load from infra/secrets.json (press Enter to accept).' -ForegroundColor DarkGray
+
+# Bicep inputs
+if (-not $SkipBicep) {
+    $subscriptionId = Ask $s 'subscriptionId' 'Azure subscription ID'
+    $resourceGroup  = Ask $s 'resourceGroup'  'Resource group name' 'rg-slypn-prod'
+    $location       = Ask $s 'location'       'Azure region' 'uksouth'
+    $s['subscriptionId'] = $subscriptionId
+    $s['resourceGroup']  = $resourceGroup
+    $s['location']       = $location
+}
+
+# Entra inputs
+if (-not $SkipEntra) {
+    $tenantId     = Ask $s 'tenantId'     'CIAM tenant ID (GUID from Azure portal → Overview)'
+    $tenantDomain = Ask $s 'tenantDomain' 'CIAM tenant domain' 'slypn.ciamlogin.com'
+    $s['tenantId']     = $tenantId
+    $s['tenantDomain'] = $tenantDomain
+}
+
+# Prod URL — known after Bicep, but can be entered manually if skipping Bicep.
+if ($SkipBicep) {
+    $prodUrl = Ask $s 'prodUrl' 'Production SWA URL (https://... — blank if not yet deployed)'
+    if (-not [string]::IsNullOrWhiteSpace($prodUrl) -and -not $prodUrl.StartsWith('https://')) {
+        $prodUrl = "https://$prodUrl"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($prodUrl)) { $s['prodUrl'] = $prodUrl }
+}
+
+Save-Secrets $s
+
+# ── Phase 1 · Azure infrastructure (Bicep) ────────────────────────────────────
+
+if (-not $SkipBicep) {
+    Step 'Phase 1 · Azure infrastructure'
+
+    Switch-ToSubscription $subscriptionId
+
+    # Resource group
+    $rgExists = az group show --name $resourceGroup -o none 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Info "Creating resource group $resourceGroup in $location..."
+        az group create --name $resourceGroup --location $location | Out-Null
+        Ok "Created $resourceGroup"
+    } else {
+        Info "Resource group $resourceGroup exists"
+    }
+
+    # Bicep deployment
+    Info 'Deploying main.bicep (this may take a few minutes)...'
+    $deployResult = az deployment group create `
+        --resource-group $resourceGroup `
+        --template-file $bicepPath `
+        --parameters @$paramsPath `
+        --query 'properties.outputs' `
+        -o json | ConvertFrom-Json
+
+    $s['swaName']            = $deployResult.swaName.value
+    $s['prodUrl']            = $deployResult.swaUrl.value.TrimEnd('/')
+    $s['cosmosEndpoint']     = $deployResult.cosmosEndpoint.value
+    $s['cosmosAccountName']  = $deployResult.cosmosAccountName.value
+    $s['storageAccountName'] = $deployResult.storageAccountName.value
+    $s['mediaContainerName'] = $deployResult.mediaContainerName.value
+    $s['swaPrincipalId']     = $deployResult.swaPrincipalId.value
+    Save-Secrets $s
+    Ok "SWA deployed: $($s['prodUrl'])"
+
+    # Cosmos primary key (used until managed-identity auth is wired up)
+    Info 'Fetching Cosmos primary key...'
+    $cosmosKey = az cosmosdb keys list `
+        --name $s['cosmosAccountName'] `
+        --resource-group $resourceGroup `
+        --query 'primaryMasterKey' -o tsv
+    $s['cosmosKey'] = $cosmosKey
+    Save-Secrets $s
+    Ok 'Cosmos key stored'
+
+    # Storage connection string (used for BlobService until managed-identity)
+    Info 'Fetching Storage connection string...'
+    $storageConn = az storage account show-connection-string `
+        --name $s['storageAccountName'] `
+        --resource-group $resourceGroup `
+        --query 'connectionString' -o tsv
+    $s['storageConnectionString'] = $storageConn
+    Save-Secrets $s
+    Ok 'Storage connection string stored'
+
+    # Derive prodUrl if it wasn't set yet (e.g. SWA default hostname)
+    $prodUrl = $s['prodUrl']
+}
+
+# ── Phase 2 · Entra External ID ───────────────────────────────────────────────
+
+if (-not $SkipEntra) {
+    Step 'Phase 2 · Entra External ID'
+
+    # ── Login to CIAM tenant ──────────────────────────────────────────────────
+
+    # az login --tenant switches the active az context to the CIAM tenant,
+    # which is required so that subsequent az ad / az rest calls target the
+    # right directory. If the token is already cached (e.g. re-run) the CLI
+    # uses it silently without opening a browser.
+    $currentTenant = az account show --query 'tenantId' -o tsv 2>$null
+    if ($currentTenant -ne $tenantId) {
+        Info 'Switching to CIAM tenant...'
+        az login --tenant $tenantId --allow-no-subscriptions | Out-Null
+    }
+    Ok "Signed in to $tenantDomain"
+
+    # ── API app registration ──────────────────────────────────────────────────
+
+    Step 'Entra · API app — slypn-api'
+    $apiAppName = 'slypn-api'
+    $existing   = az ad app list --filter "displayName eq '$apiAppName'" --query '[0]' -o json 2>$null |
+                  ConvertFrom-Json
+    if ($existing) {
+        $apiClientId = $existing.appId
+        $apiObjectId = $existing.id
+        Info "Found  appId=$apiClientId"
+    } else {
+        $created     = az ad app create --display-name $apiAppName --sign-in-audience AzureADMyOrg -o json |
+                       ConvertFrom-Json
+        $apiClientId = $created.appId
+        $apiObjectId = $created.id
+        Ok "Created  appId=$apiClientId"
+    }
+    $s['apiClientId'] = $apiClientId
+    $s['apiObjectId'] = $apiObjectId
+    Save-Secrets $s
+
+    # App ID URI
+    $appIdUri    = "api://$apiClientId"
+    $currentUris = @(az ad app show --id $apiObjectId --query 'identifierUris' -o json | ConvertFrom-Json)
+    if ($currentUris -contains $appIdUri) {
+        Info "App ID URI already set"
+    } else {
+        az ad app update --id $apiObjectId --identifier-uris $appIdUri | Out-Null
+        Ok $appIdUri
+    }
+
+    # ── access_as_user scope ──────────────────────────────────────────────────
+
+    Step 'Entra · OAuth scope — access_as_user'
+    $apiApp         = Invoke-Graph GET "/applications/$apiObjectId"
+    $existingScopes = @($apiApp.api.oauth2PermissionScopes)
+    $hit            = $existingScopes | Where-Object { $_.value -eq 'access_as_user' }
+
+    if ($hit) {
+        $scopeId = $hit.id
+        if (-not $hit.isEnabled) {
+            $enabledCopy = @{
+                id                      = $hit.id
+                value                   = $hit.value
+                type                    = $hit.type
+                adminConsentDisplayName = $hit.adminConsentDisplayName
+                adminConsentDescription = $hit.adminConsentDescription
+                userConsentDisplayName  = $hit.userConsentDisplayName
+                userConsentDescription  = $hit.userConsentDescription
+                isEnabled               = $true
+            }
+            $others = @($existingScopes) | Where-Object { $_.id -ne $scopeId }
+            Invoke-Graph PATCH "/applications/$apiObjectId" @{
+                api = @{ oauth2PermissionScopes = @($others) + @($enabledCopy) }
+            } | Out-Null
+            Ok "Re-enabled  id=$scopeId"
+        } else {
+            Info "Already enabled  id=$scopeId"
+        }
+    } else {
+        $scopeId  = [Guid]::NewGuid().ToString()
+        $newScope = @{
+            id                      = $scopeId
+            value                   = 'access_as_user'
+            type                    = 'User'
+            adminConsentDisplayName = 'Access SLYPN API as a user'
+            adminConsentDescription = 'Allows the app to access the SLYPN API on behalf of the signed-in user.'
+            userConsentDisplayName  = 'Access SLYPN on your behalf'
+            userConsentDescription  = 'Allows this app to access SLYPN on your behalf.'
+            isEnabled               = $true
+        }
+        Invoke-Graph PATCH "/applications/$apiObjectId" @{
+            api = @{ oauth2PermissionScopes = @($existingScopes) + @($newScope) }
+        } | Out-Null
+        Ok "Created  id=$scopeId"
+    }
+    $s['apiScopeId'] = $scopeId
+    Save-Secrets $s
+
+    # ── App roles ─────────────────────────────────────────────────────────────
+
+    Step 'Entra · App roles — Admin, Contributor, Member'
+    $apiApp        = Invoke-Graph GET "/applications/$apiObjectId"
+    $existingRoles = @($apiApp.appRoles)
+    $rolesToAdd    = @()
+    $rolesToEnable = @()
+
+    foreach ($roleName in @('Admin', 'Contributor', 'Member')) {
+        $hit = $existingRoles | Where-Object { $_.value -eq $roleName }
+        if ($hit) {
+            $s["role${roleName}Id"] = $hit.id
+            if (-not $hit.isEnabled) { $rolesToEnable += $hit.id; Info "$roleName disabled — will re-enable" }
+            else { Info "$roleName  id=$($hit.id)" }
+        } else {
+            $roleId = if ($s.Contains("role${roleName}Id") -and $s["role${roleName}Id"]) `
+                         { $s["role${roleName}Id"] } else { [Guid]::NewGuid().ToString() }
+            $s["role${roleName}Id"] = $roleId
+            $rolesToAdd += @{
+                id                 = $roleId
+                displayName        = $roleName
+                description        = "SLYPN $roleName role"
+                value              = $roleName
+                allowedMemberTypes = @('User', 'Application')
+                isEnabled          = $true
+            }
+        }
+    }
+
+    if ($rolesToAdd.Count -gt 0 -or $rolesToEnable.Count -gt 0) {
+        $updatedRoles = $existingRoles | ForEach-Object {
+            if ($rolesToEnable -contains $_.id) {
+                $copy = $_ | Select-Object -Property *; $copy.isEnabled = $true; $copy
+            } else { $_ }
+        }
+        Invoke-Graph PATCH "/applications/$apiObjectId" @{
+            appRoles = @($updatedRoles) + $rolesToAdd
+        } | Out-Null
+        if ($rolesToAdd.Count -gt 0) {
+            Ok "Created: $(($rolesToAdd | ForEach-Object { $_.displayName }) -join ', ')"
+        }
+        if ($rolesToEnable.Count -gt 0) { Ok "Re-enabled $($rolesToEnable.Count) role(s)" }
+    }
+    Save-Secrets $s
+
+    # ── API service principal ─────────────────────────────────────────────────
+
+    Step 'Entra · API service principal'
+    $apiSpList = az ad sp list --filter "appId eq '$apiClientId'" -o json 2>$null | ConvertFrom-Json
+    if (-not $apiSpList -or $apiSpList.Count -eq 0) {
+        az ad sp create --id $apiClientId | Out-Null
+        $apiSpList = az ad sp list --filter "appId eq '$apiClientId'" -o json | ConvertFrom-Json
+    }
+    $apiSpId      = $apiSpList[0].id
+    $s['apiSpId'] = $apiSpId
+    Save-Secrets $s
+    Ok "objectId=$apiSpId"
+
+    # ── Graph User.Invite.All permission ─────────────────────────────────────
+
+    Step 'Entra · Graph User.Invite.All (invitation emails)'
+    $graphAppId       = '00000003-0000-0000-c000-000000000000'
+    $userInviteRoleId = '09850681-111b-4a89-9bed-3f2cae46d706'
+    $graphSp          = az ad sp show --id $graphAppId -o json | ConvertFrom-Json
+    $graphSpId        = $graphSp.id
+
+    $assignments    = Invoke-Graph GET "/servicePrincipals/$apiSpId/appRoleAssignments"
+    $alreadyGranted = $assignments.value |
+        Where-Object { $_.resourceId -eq $graphSpId -and $_.appRoleId -eq $userInviteRoleId }
+
+    if ($alreadyGranted) {
+        Info 'User.Invite.All already granted'
+    } else {
+        Invoke-Graph POST "/servicePrincipals/$graphSpId/appRoleAssignedTo" @{
+            principalId = $apiSpId
+            resourceId  = $graphSpId
+            appRoleId   = $userInviteRoleId
+        } | Out-Null
+        Ok 'User.Invite.All granted with admin consent'
+    }
+
+    # ── Graph client secret ───────────────────────────────────────────────────
+
+    Step 'Entra · Graph client secret'
+
+    # Look up by display name, not stored key ID — the ID in secrets.json can
+    # go stale (e.g. after a failed run or a tenant switch bug). This also
+    # catches and cleans up any accidental duplicates.
+    $apiApp        = Invoke-Graph GET "/applications/$apiObjectId"
+    $managed       = @($apiApp.passwordCredentials) |
+                     Where-Object { $_.displayName -eq 'slypn-graph-invite' }
+    $needsSecret   = $RotateSecret.IsPresent
+
+    if (-not $needsSecret) {
+        if ($managed.Count -gt 1) {
+            Warn "$($managed.Count) duplicate secrets found — will clean up and rotate"
+            $needsSecret = $true
+        } elseif ($managed.Count -eq 1) {
+            $expiry = [datetime]$managed[0].endDateTime
+            if ($expiry -gt (Get-Date).AddDays(30)) {
+                Info "Exists, expires $($expiry.ToString('yyyy-MM-dd'))"
+                $s['graphClientSecretId'] = $managed[0].keyId
+            } else {
+                Warn "Expires $($expiry.ToString('yyyy-MM-dd')) — rotating"
+                $needsSecret = $true
+            }
+        } else {
+            $needsSecret = $true
+        }
+    }
+
+    if ($needsSecret) {
+        # Remove every slypn-graph-invite credential on the app before creating
+        # a fresh one — prevents accumulation regardless of what secrets.json holds.
+        foreach ($cred in $managed) {
+            try {
+                Invoke-Graph POST "/applications/$apiObjectId/removePassword" `
+                    @{ keyId = $cred.keyId } | Out-Null
+                Info "Removed old secret $($cred.keyId)"
+            } catch {
+                Warn "Could not remove secret $($cred.keyId): $_"
+            }
+        }
+        $s.Remove('graphClientSecretId')
+        $s.Remove('graphClientSecretExpiry')
+        $s.Remove('graphClientSecret')
+
+        $result = Invoke-Graph POST "/applications/$apiObjectId/addPassword" @{
+            passwordCredential = @{
+                displayName = 'slypn-graph-invite'
+                endDateTime = (Get-Date).AddYears(2).ToString('o')
+            }
+        }
+        $s['graphClientSecretId']     = $result.keyId
+        $s['graphClientSecretExpiry'] = $result.endDateTime.ToString('yyyy-MM-dd')
+        $s['graphClientSecret']       = $result.secretText
+        Save-Secrets $s
+        Ok "Created, expires $($result.endDateTime.ToString('yyyy-MM-dd'))"
+        Warn 'Secret saved to infra/secrets.json. Remove it once it is in SWA app settings.'
+    }
+
+    # ── SPA app registration ──────────────────────────────────────────────────
+
+    Step 'Entra · SPA app — slypn-web'
+    $spaAppName  = 'slypn-web'
+    $existingSpa = az ad app list --filter "displayName eq '$spaAppName'" --query '[0]' -o json 2>$null |
+                   ConvertFrom-Json
+
+    if ($existingSpa) {
+        $spaClientId = $existingSpa.appId
+        $spaObjectId = $existingSpa.id
+        Info "Found  appId=$spaClientId"
+    } else {
+        $created     = az ad app create --display-name $spaAppName --sign-in-audience AzureADMyOrg -o json |
+                       ConvertFrom-Json
+        $spaClientId = $created.appId
+        $spaObjectId = $created.id
+        Ok "Created  appId=$spaClientId"
+    }
+    $s['spaClientId'] = $spaClientId
+    $s['spaObjectId'] = $spaObjectId
+    Save-Secrets $s
+
+    # Redirect URIs — prod omitted if URL not yet known.
+    $redirectUris = @('http://localhost:5173/auth/callback')
+    $pUrl = if ($s.Contains('prodUrl')) { $s['prodUrl'] } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($pUrl)) {
+        $redirectUris = @("$pUrl/auth/callback") + $redirectUris
+    }
+
+    $spaApp           = Invoke-Graph GET "/applications/$spaObjectId"
+    $currentRedirects = @($spaApp.spa.redirectUris)
+    if (Compare-StringSets $redirectUris $currentRedirects) {
+        Info "Redirect URIs already correct"
+    } else {
+        Invoke-Graph PATCH "/applications/$spaObjectId" @{
+            spa = @{ redirectUris = $redirectUris }
+        } | Out-Null
+        Ok "Redirect URIs: $($redirectUris -join '  ')"
+    }
+
+    # SPA service principal
+    $spaSpList = az ad sp list --filter "appId eq '$spaClientId'" -o json 2>$null | ConvertFrom-Json
+    if (-not $spaSpList -or $spaSpList.Count -eq 0) {
+        az ad sp create --id $spaClientId | Out-Null
+    }
+
+    # Required permissions
+    $spaApp     = Invoke-Graph GET "/applications/$spaObjectId"
+    $currentRRA = @($spaApp.requiredResourceAccess)
+    $apiEntry   = $currentRRA | Where-Object { $_.resourceAppId -eq $apiClientId }
+    $scopeOk    = $apiEntry -and ($apiEntry.resourceAccess |
+                  Where-Object { $_.id -eq $scopeId -and $_.type -eq 'Scope' })
+
+    if (-not $scopeOk) {
+        $filtered = $currentRRA | Where-Object { $_.resourceAppId -ne $apiClientId }
+        $newRRA   = @($filtered) + @(@{
+            resourceAppId  = $apiClientId
+            resourceAccess = @(@{ id = $scopeId; type = 'Scope' })
+        })
+        Invoke-Graph PATCH "/applications/$spaObjectId" @{
+            requiredResourceAccess = $newRRA
+        } | Out-Null
+        Ok 'API scope added to SPA required permissions'
+    } else {
+        Info 'SPA required permissions already correct'
+    }
+
+    # Pre-authorise SPA
+    $apiApp         = Invoke-Graph GET "/applications/$apiObjectId"
+    $preAuth        = @($apiApp.api.preAuthorizedApplications)
+    $alreadyPreAuth = $preAuth | Where-Object {
+        $_.appId -eq $spaClientId -and ($_.delegatedPermissionIds -contains $scopeId)
+    }
+
+    if (-not $alreadyPreAuth) {
+        $filtered   = $preAuth | Where-Object { $_.appId -ne $spaClientId }
+        $newPreAuth = @($filtered) + @(@{
+            appId                  = $spaClientId
+            delegatedPermissionIds = @($scopeId)
+        })
+        Invoke-Graph PATCH "/applications/$apiObjectId" @{
+            api = @{
+                oauth2PermissionScopes    = @($apiApp.api.oauth2PermissionScopes)
+                preAuthorizedApplications = $newPreAuth
+            }
+        } | Out-Null
+        Ok 'SPA pre-authorised (users skip consent prompt)'
+    } else {
+        Info 'SPA already pre-authorised'
+    }
+
+    # ── User flows ────────────────────────────────────────────────────────────
+
+    Step 'Entra · User flows'
+    try {
+        $flows = Invoke-Graph GET '/identity/authenticationEventsFlows' -ApiVersion 'beta'
+        if ($flows.value -and $flows.value.Count -gt 0) {
+            Ok "$($flows.value.Count) user flow(s) found:"
+            $flows.value | ForEach-Object { Info "  $($_.displayName)" }
+        } else {
+            Warn 'No user flows found — create one in the CIAM portal:'
+            Warn '  External Identities → User flows → New user flow'
+            Warn '  Type:               Sign in and sign up'
+            Warn '  Identity providers: Email with password'
+            Warn '  Enable:             Self-service password reset'
+            Warn "  Associated app:     slypn-web ($spaClientId)"
+        }
+    } catch {
+        # The authenticationEventsFlows beta API requires the
+        # EnableMsGraphAuthenticationEventListener feature, which is not
+        # enabled on all CIAM tenants. This is a read-only check — safe to
+        # ignore. Verify user flows manually in the CIAM portal.
+        Info 'User flows API not available on this tenant — check manually:'
+        Info '  Entra admin centre → External Identities → User flows'
+    }
+
+    # ── Company branding HTML ─────────────────────────────────────────────────
+
+    if (-not $SkipBranding -and (Test-Path $templatePath)) {
+        Step 'Entra · Company branding HTML'
+
+        # Upload the HTML file content directly to Microsoft via the Graph
+        # branding API. CIAM does not allow external URIs for custom HTML
+        # (see aka.ms/entra-branding), so the file must be sent as bytes here.
+        $brandingPath = "/organization/$tenantId/branding/localizations/0/customHTML"
+        try {
+            Invoke-GraphUpload $brandingPath $templatePath 'text/html' | Out-Null
+            Ok 'Custom HTML uploaded to CIAM branding'
+        } catch {
+            $statusCode = $_.Exception.Response.StatusCode.value__
+            Warn "Graph branding upload failed (HTTP $statusCode)."
+            Warn 'Custom HTML branding may require a paid Entra External ID tier.'
+            Warn 'Check: Entra admin centre → External Identities → Company Branding'
+        }
+    }
+
+    # Make variables available for downstream phases.
+    $tenantId     = $s['tenantId']
+    $tenantDomain = $s['tenantDomain']
+    $apiClientId  = $s['apiClientId']
+    $spaClientId  = $s['spaClientId']
+    $scopeId      = $s['apiScopeId']
+}
+
+# Re-read any values that were populated during Bicep or Entra phases.
+$tenantId      = $s['tenantId']
+$tenantDomain  = $s['tenantDomain']
+$apiClientId   = $s['apiClientId']
+$spaClientId   = $s['spaClientId']
+$prodUrl       = $s['prodUrl']
+$swaName       = $s['swaName']
+$graphSecret   = $s['graphClientSecret']
+$authority     = if ($tenantId -and $tenantDomain) { "https://$tenantDomain/$tenantId/v2.0" } else { '' }
+$apiScopeStr   = if ($apiClientId) { "api://$apiClientId/access_as_user" } else { '' }
+
+# ── Phase 3 · SWA app settings ────────────────────────────────────────────────
+
+if (-not $SkipSwa -and $swaName) {
+    Step 'Phase 3 · SWA app settings'
+
+    if ($s.Contains('subscriptionId')) { Switch-ToSubscription $s['subscriptionId'] }
+
+    $rg = $s['resourceGroup']
+
+    # Build the full settings map — only include keys where we have a value.
+    $settings = [ordered]@{}
+    if ($authority)                              { $settings['AzureAd__Authority']        = $authority }
+    if ($apiClientId)                            { $settings['AzureAd__Audience']         = "api://$apiClientId" }
+    if ($tenantId)                               { $settings['AzureAd__TenantId']         = $tenantId }
+                                                   $settings['AzureAd__SkipAuth']         = 'false'
+    if ($graphSecret)                            { $settings['Graph__ClientSecret']       = $graphSecret }
+    if ($prodUrl)                                { $settings['Graph__InviteRedirectUrl']  = "$prodUrl/" }
+    if ($s['cosmosEndpoint'])                    { $settings['Cosmos__Endpoint']          = $s['cosmosEndpoint'] }
+    if ($s['cosmosKey'])                         { $settings['Cosmos__Key']               = $s['cosmosKey'] }
+                                                   $settings['Cosmos__Database']          = 'slypn'
+    if ($s['storageConnectionString'])           { $settings['Storage__ConnectionString'] = $s['storageConnectionString'] }
+                                                   $settings['Storage__MediaContainer']   = 'media'
+                                                   $settings['Otel__ServiceName']         = 'slypn-api'
+                                                   $settings['Otel__Env']                 = 'prod'
+
+    $settingArgs = $settings.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }
+    az staticwebapp appsettings set `
+        --name $swaName `
+        --resource-group $rg `
+        --setting-names @settingArgs | Out-Null
+
+    Ok "Applied $($settings.Count) setting(s) to $swaName"
+} elseif (-not $SkipSwa) {
+    Warn 'SWA name not known — skipping app settings (run with -SkipBicep after first deploy to apply)'
+}
+
+# ── Phase 4 · GitHub secrets ──────────────────────────────────────────────────
+
+if (-not $SkipGitHub) {
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Warn 'GitHub CLI (gh) not found — skipping GitHub secrets phase.'
+        Warn 'Install from https://cli.github.com, then re-run with -SkipBicep -SkipEntra -SkipSwa -SkipLocal'
+    } else {
+        Step 'Phase 4 · GitHub secrets'
+
+        # Derive default repo from git remote, falling back to stored value.
+        $gitRemoteUrl = git remote get-url origin 2>$null
+        $defaultRepo  = if ($gitRemoteUrl -match 'github\.com[:/](.+?)(?:\.git)?$') `
+                            { $Matches[1] } else { '' }
+        $gitHubRepo   = Ask $s 'gitHubRepo' 'GitHub repo (owner/repo)' $defaultRepo
+        $s['gitHubRepo'] = $gitHubRepo
+        Save-Secrets $s
+
+        # Authenticate if needed.
+        gh auth status 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Info 'Logging in to GitHub CLI...'
+            gh auth login
+        }
+        Ok "Authenticated to GitHub"
+
+        # Helper: set a secret and report idempotently.
+        function Set-GhSecret([string]$name, [string]$value) {
+            if ([string]::IsNullOrWhiteSpace($value)) { Warn "Skipping $name — value not available"; return }
+            $value | gh secret set $name --repo $gitHubRepo
+            if ($LASTEXITCODE -eq 0) { Ok $name } else { Warn "Failed to set $name" }
+        }
+
+        # SWA deployment token — fetch fresh from Azure each run.
+        if ($swaName -and $s['resourceGroup']) {
+            if ($s.Contains('subscriptionId')) { Switch-ToSubscription $s['subscriptionId'] }
+            $swaToken = az staticwebapp secrets list `
+                --name $swaName `
+                --resource-group $s['resourceGroup'] `
+                --query 'properties.apiKey' -o tsv
+            Set-GhSecret 'AZURE_STATIC_WEB_APPS_API_TOKEN' $swaToken
+        } else {
+            Warn 'SWA not known — skipping AZURE_STATIC_WEB_APPS_API_TOKEN'
+        }
+
+        # VITE_ build-time env vars consumed by azure-static-web-apps.yml.
+        Set-GhSecret 'VITE_MSAL_AUTHORITY' $authority
+        Set-GhSecret 'VITE_MSAL_CLIENT_ID' $spaClientId
+        Set-GhSecret 'VITE_API_SCOPE'      $apiScopeStr
+    }
+}
+
+# ── Phase 5 · Local dev configuration ─────────────────────────────────────────
+
+if (-not $SkipLocal -and $authority -and $spaClientId -and $apiScopeStr) {
+    Step 'Phase 5 · Local dev configuration'
+
+    # .env.local
+    $envLines = @(
+        '# Auto-generated by infra/setup.ps1 — do not commit.'
+        "VITE_MSAL_AUTHORITY=$authority"
+        "VITE_MSAL_CLIENT_ID=$spaClientId"
+        "VITE_API_SCOPE=$apiScopeStr"
+        'VITE_DEV_SKIP_AUTH=false'
+    )
+
+    # Preserve any non-VITE_ vars already in the file (e.g. VITE_FARO_*).
+    if (Test-Path $envLocalPath) {
+        $existing = Get-Content $envLocalPath |
+            Where-Object { $_ -notmatch '^#' -and $_ -match '=' } |
+            Where-Object { $_ -notmatch '^VITE_MSAL_|^VITE_API_SCOPE|^VITE_DEV_SKIP_AUTH' }
+        if ($existing) { $envLines += $existing }
+    }
+
+    $envLines | Set-Content $envLocalPath -Encoding UTF8
+    Ok "Wrote $envLocalPath"
+
+    # local.settings.json — create from sample if absent, then patch Entra/Graph fields.
+    if (-not (Test-Path $localSettingsPath)) {
+        if (Test-Path $localSettingsSamplePath) {
+            Copy-Item $localSettingsSamplePath $localSettingsPath
+            Info 'Created local.settings.json from sample'
+        } else {
+            Warn 'local.settings.sample.json not found — cannot create local.settings.json'
+        }
+    }
+
+    if (Test-Path $localSettingsPath) {
+        $ls = Get-Content $localSettingsPath -Raw | ConvertFrom-Json -AsHashtable
+
+        $ls['Values']['AzureAd__Authority'] = $authority
+        $ls['Values']['AzureAd__Audience']  = "api://$apiClientId"
+        $ls['Values']['AzureAd__TenantId']  = $tenantId
+        $ls['Values']['AzureAd__SkipAuth']  = 'false'
+        # Set Graph secret for local invitation testing if available.
+        if ($graphSecret) {
+            $ls['Values']['Graph__ClientSecret'] = $graphSecret
+        }
+        $ls['Values']['Graph__InviteRedirectUrl'] = 'http://localhost:5173/'
+
+        $ls | ConvertTo-Json -Depth 5 | Set-Content $localSettingsPath -Encoding UTF8
+        Ok "Updated $localSettingsPath (Entra/Graph fields; Cosmos/Storage unchanged)"
+    }
+} elseif (-not $SkipLocal -and (-not $authority -or -not $spaClientId -or -not $apiScopeStr)) {
+    Warn 'Entra values not available — skipping local dev config (run without -SkipEntra first)'
+}
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+Save-Secrets $s
+
+Write-Host ''
+Write-Host '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━' -ForegroundColor White
+Write-Host ' SLYPN · Setup complete' -ForegroundColor White
+Write-Host '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━' -ForegroundColor White
+
+if ($authority) {
+    Write-Host ''
+    Write-Host ' src/web/.env.local' -ForegroundColor Yellow
+    Write-Host "   VITE_MSAL_AUTHORITY=$authority"
+    Write-Host "   VITE_MSAL_CLIENT_ID=$spaClientId"
+    Write-Host "   VITE_API_SCOPE=$apiScopeStr"
+    Write-Host "   VITE_DEV_SKIP_AUTH=false"
+}
+
+if ($swaName -and $authority) {
+    Write-Host ''
+    Write-Host " SWA app settings applied to $swaName" -ForegroundColor Yellow
+    if ($graphSecret) {
+        Warn "  Remove graphClientSecret from infra/secrets.json now that it is in SWA settings."
+    }
+}
+
+if ($s.Contains('gitHubRepo') -and -not $SkipGitHub) {
+    Write-Host ''
+    Write-Host " GitHub secrets set on $($s['gitHubRepo'])" -ForegroundColor Yellow
+    Write-Host '   AZURE_STATIC_WEB_APPS_API_TOKEN'
+    Write-Host '   VITE_MSAL_AUTHORITY  ·  VITE_MSAL_CLIENT_ID  ·  VITE_API_SCOPE'
+}
+
+
+Write-Host ''
+Write-Host ' infra/secrets.json holds all IDs and the Graph client secret.' -ForegroundColor DarkGray
+Write-Host ' It is git-ignored. Back it up to a password manager or Key Vault.' -ForegroundColor DarkGray
+Write-Host ''

--- a/infra/signin-template.html
+++ b/infra/signin-template.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Sign in · SLYPN</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Montserrat:wght@700;800&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #EAF4FF;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px 16px;
+    }
+
+    .card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 40px 40px 36px;
+      width: 100%;
+      max-width: 440px;
+      box-shadow: 0 4px 32px rgba(21, 101, 192, 0.10);
+    }
+
+    /* ── Brand header ─────────────────────────────────────── */
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+    .brand-name {
+      font-family: 'Montserrat', Inter, sans-serif;
+      font-size: 22px;
+      font-weight: 800;
+      color: #1E3A5F;
+      letter-spacing: -0.5px;
+    }
+    .tagline {
+      font-size: 13px;
+      color: #4E9BFF;
+      margin-bottom: 28px;
+    }
+
+    /* ── Microsoft injects the form into #api ─────────────── */
+    #api { width: 100%; }
+
+    /* Headings Microsoft adds */
+    #api h1, #api h2 {
+      font-family: 'Montserrat', Inter, sans-serif !important;
+      font-size: 20px !important;
+      font-weight: 700 !important;
+      color: #1E3A5F !important;
+      margin-bottom: 20px !important;
+    }
+
+    /* Labels */
+    #api label {
+      display: block !important;
+      font-size: 13px !important;
+      font-weight: 500 !important;
+      color: #152844 !important;
+      margin-bottom: 5px !important;
+    }
+
+    /* Text / email / password inputs */
+    #api input[type="text"],
+    #api input[type="email"],
+    #api input[type="password"] {
+      display: block !important;
+      width: 100% !important;
+      border: 1.5px solid #D5E8FF !important;
+      border-radius: 8px !important;
+      padding: 10px 14px !important;
+      font-size: 14px !important;
+      font-family: 'Inter', sans-serif !important;
+      color: #0C1929 !important;
+      background: #fff !important;
+      outline: none !important;
+      transition: border-color 0.15s, box-shadow 0.15s !important;
+      margin-bottom: 16px !important;
+    }
+    #api input[type="text"]:focus,
+    #api input[type="email"]:focus,
+    #api input[type="password"]:focus {
+      border-color: #1565C0 !important;
+      box-shadow: 0 0 0 3px rgba(21, 101, 192, 0.14) !important;
+    }
+
+    /* Primary / submit buttons */
+    #api .sendButton,
+    #api button[type="submit"],
+    #api input[type="submit"],
+    #api .button.primary {
+      display: block !important;
+      width: 100% !important;
+      background: #1565C0 !important;
+      color: #fff !important;
+      border: none !important;
+      border-radius: 8px !important;
+      padding: 11px 20px !important;
+      font-size: 14px !important;
+      font-weight: 600 !important;
+      font-family: 'Inter', sans-serif !important;
+      cursor: pointer !important;
+      transition: background 0.15s !important;
+      margin-top: 4px !important;
+    }
+    #api .sendButton:hover,
+    #api button[type="submit"]:hover,
+    #api input[type="submit"]:hover {
+      background: #1E3A5F !important;
+    }
+
+    /* Secondary / cancel buttons */
+    #api .button.secondary,
+    #api button.secondary {
+      display: block !important;
+      width: 100% !important;
+      background: transparent !important;
+      color: #1565C0 !important;
+      border: 1.5px solid #D5E8FF !important;
+      border-radius: 8px !important;
+      padding: 10px 20px !important;
+      font-size: 14px !important;
+      font-weight: 500 !important;
+      cursor: pointer !important;
+      margin-top: 8px !important;
+    }
+
+    /* Links (forgot password, etc.) */
+    #api a {
+      color: #1565C0 !important;
+      font-size: 13px !important;
+      text-decoration: underline !important;
+      text-underline-offset: 2px !important;
+    }
+
+    /* Divider between local + social providers */
+    #api .divider { margin: 20px 0 !important; }
+
+    /* Social / federated provider buttons */
+    #api .provider { margin-bottom: 8px !important; }
+
+    /* Error / validation messages */
+    #api .error,
+    #api .validationError,
+    #api p.error { color: #dc2626 !important; font-size: 12px !important; }
+
+    /* Intro paragraph text */
+    #api p { font-size: 13px !important; color: #4E6B8C !important; margin-bottom: 14px !important; }
+
+    @media (max-width: 480px) {
+      .card { padding: 28px 20px 24px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="brand">
+      <svg width="30" height="30" viewBox="0 0 32 32" aria-hidden="true" fill="#1E90FF">
+        <path d="M16 4c-3.2 2.4-5 5.4-5 8.5 0 1.6.6 3 1.7 4H10c-.7 0-1 .5-.6 1.1l5.7 7.6c.4.5 1.1.5 1.5 0l5.8-7.6c.4-.6.1-1.1-.6-1.1h-2.7c1-1 1.7-2.4 1.7-4 0-3-1.8-6.1-5-8.5z"/>
+      </svg>
+      <span class="brand-name">SLYPN</span>
+    </div>
+    <p class="tagline">South London Younger Parkinson's Network</p>
+
+    <!-- Microsoft injects the sign-in / sign-up form here -->
+    <div id="api"></div>
+  </div>
+
+  <script>
+    /**
+     * Fix autocomplete attributes after Microsoft injects the form.
+     * Without this, password managers can't distinguish multiple accounts
+     * on the same ciamlogin.com domain.
+     */
+    function fixAutocomplete() {
+      // Email / sign-in name field
+      var emailEl =
+        document.getElementById('signInName') ||
+        document.querySelector('#api input[type="email"]') ||
+        document.querySelector('#api input[name="signInName"]') ||
+        document.querySelector('#api input[name="email"]');
+
+      if (emailEl && !emailEl._acFixed) {
+        emailEl.setAttribute('autocomplete', 'username email');
+        emailEl.setAttribute('name', 'username');
+        emailEl._acFixed = true;
+      }
+
+      // Password field
+      var pwEl =
+        document.getElementById('password') ||
+        document.querySelector('#api input[type="password"]');
+
+      if (pwEl && !pwEl._acFixed) {
+        pwEl.setAttribute('autocomplete', 'current-password');
+        pwEl.setAttribute('name', 'password');
+        pwEl._acFixed = true;
+      }
+
+      // New-password field (sign-up / password-reset pages)
+      var newPwEl = document.getElementById('newPassword');
+      if (newPwEl && !newPwEl._acFixed) {
+        newPwEl.setAttribute('autocomplete', 'new-password');
+        newPwEl.setAttribute('name', 'new-password');
+        newPwEl._acFixed = true;
+      }
+      var confirmPwEl = document.getElementById('reenterPassword');
+      if (confirmPwEl && !confirmPwEl._acFixed) {
+        confirmPwEl.setAttribute('autocomplete', 'new-password');
+        confirmPwEl.setAttribute('name', 'new-password-confirm');
+        confirmPwEl._acFixed = true;
+      }
+    }
+
+    fixAutocomplete();
+
+    var apiDiv = document.getElementById('api');
+    if (apiDiv && window.MutationObserver) {
+      new MutationObserver(fixAutocomplete)
+        .observe(apiDiv, { childList: true, subtree: true, attributes: false });
+    }
+  </script>
+</body>
+</html>

--- a/src/api/Slypn.Api/Functions/EventsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/EventsFunctions.cs
@@ -14,6 +14,22 @@ namespace Slypn.Api.Functions;
 
 public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunctions> log)
 {
+    [Function("GetEvent")]
+    [OpenApiOperation(operationId: "events.get", tags: new[] { "events" }, Summary = "Get event", Description = "Returns a single event by id.")]
+    [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Event id.")]
+    public async Task<HttpResponseData> GetEvent(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "events/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        try
+        {
+            var ev = await repo.GetEventByIdAsync(id, ct);
+            if (ev is null) return await NotFound(req, "Event not found.");
+            return await Ok(req, ev, ev.Etag);
+        }
+        catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
+    }
+
     [Function("GetEvents")]
     [OpenApiOperation(operationId: "events.list", tags: new[] { "events" }, Summary = "List events", Description = "Returns events with an optional upcoming filter.")]
     [OpenApiParameter(name: "upcoming", In = ParameterLocation.Query, Required = false, Type = typeof(string), Description = "Set to true to return only upcoming events.")]
@@ -27,12 +43,13 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     }
 
     [Function("CreateEvent")]
-    [RequireRole("Admin")]
-    [OpenApiOperation(operationId: "events.create", tags: new[] { "events" }, Summary = "Create event", Description = "Creates a new event.")]
+    [RequireRole("Admin", "Contributor")]
+    [OpenApiOperation(operationId: "events.create", tags: new[] { "events" }, Summary = "Create event", Description = "Creates a new event. Admins and Contributors may create events.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(EventInput), Required = true, Description = "Event payload.")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "events")] HttpRequestData req,
+        FunctionContext context,
         CancellationToken ct)
     {
         if (!repo.SupportsWrites) return await WritesDisabled(req);
@@ -40,50 +57,65 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
         if (err is not null) return err;
         try
         {
-            var ev = await repo.CreateEventAsync(input!, ct);
+            var ev = await repo.CreateEventAsync(
+                input!,
+                context.GetUserOid(),
+                context.GetUserName(),
+                ct);
             return await Created(req, ev, ev.Etag);
         }
         catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }
 
     [Function("ReplaceEvent")]
-    [RequireRole("Admin")]
-    [OpenApiOperation(operationId: "events.replace", tags: new[] { "events" }, Summary = "Replace event", Description = "Replaces an existing event.")]
+    [RequireRole("Admin", "Contributor")]
+    [OpenApiOperation(operationId: "events.replace", tags: new[] { "events" }, Summary = "Replace event", Description = "Replaces an existing event. Admins may edit any event; Contributors may only edit their own.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Event id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(EventInput), Required = true, Description = "Event payload.")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "events/{id}")] HttpRequestData req,
-        string id, CancellationToken ct)
+        string id, FunctionContext context, CancellationToken ct)
     {
         if (!repo.SupportsWrites) return await WritesDisabled(req);
         var (input, err) = await ReadValidatedAsync<EventInput>(req, ct);
         if (err is not null) return err;
+
+        var existing = await repo.GetEventByIdAsync(id, ct);
+        if (existing is null) return await NotFound(req, "Event not found.");
+        if (!context.IsAdmin() && existing.CreatedBy != context.GetUserOid())
+            return await Forbidden(req, "You can only edit your own events.");
+
         try
         {
-            var ev = await repo.ReplaceEventAsync(id, input!, IfMatch(req), ct);
+            var ev = await repo.ReplaceEventAsync(
+                id, existing.YearMonth, input!,
+                existing.CreatedBy, existing.CreatedByName,
+                IfMatch(req), ct);
             return await Ok(req, ev, ev.Etag);
         }
         catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }
     }
 
     [Function("DeleteEvent")]
-    [RequireRole("Admin")]
-    [OpenApiOperation(operationId: "events.delete", tags: new[] { "events" }, Summary = "Delete event", Description = "Deletes an event using its id and partition key yearMonth.")]
+    [RequireRole("Admin", "Contributor")]
+    [OpenApiOperation(operationId: "events.delete", tags: new[] { "events" }, Summary = "Delete event", Description = "Deletes an event. Admins may delete any event; Contributors may only delete their own.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Event id.")]
-    [OpenApiParameter(name: "yearMonth", In = ParameterLocation.Query, Required = true, Type = typeof(string), Description = "Event partition key in YYYY-MM format.")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "events/{id}")] HttpRequestData req,
-        string id, CancellationToken ct)
+        string id, FunctionContext context, CancellationToken ct)
     {
         if (!repo.SupportsWrites) return await WritesDisabled(req);
-        var yearMonth = QueryParam(req, "yearMonth");
-        if (string.IsNullOrWhiteSpace(yearMonth))
-            return await BadRequest(req, "DELETE /api/events/{id} requires ?yearMonth=YYYY-MM.");
+
+        var existing = await repo.GetEventByIdAsync(id, ct);
+        if (existing is null) return await NotFound(req, "Event not found.");
+        if (!context.IsAdmin() && existing.CreatedBy != context.GetUserOid())
+            return await Forbidden(req, "You can only delete your own events.");
+
         try
         {
-            await repo.DeleteEventAsync(id, yearMonth, IfMatch(req), ct);
+            await repo.DeleteEventAsync(id, existing.YearMonth, IfMatch(req), ct);
             return NoContent(req);
         }
         catch (CosmosException ex) { return await MapCosmosException(req, ex, log); }

--- a/src/api/Slypn.Api/Functions/FunctionHelpers.cs
+++ b/src/api/Slypn.Api/Functions/FunctionHelpers.cs
@@ -70,6 +70,12 @@ internal static class FunctionHelpers
     public static HttpResponseData NoContent(HttpRequestData req) =>
         req.CreateResponse(HttpStatusCode.NoContent);
 
+    public static async Task<HttpResponseData> NotFound(HttpRequestData req, string message = "Not found.")
+        => await Reject(req, HttpStatusCode.NotFound, message);
+
+    public static async Task<HttpResponseData> Forbidden(HttpRequestData req, string message = "Forbidden.")
+        => await Reject(req, HttpStatusCode.Forbidden, message);
+
     public static async Task<HttpResponseData> BadRequest(HttpRequestData req, string message)
     {
         var resp = req.CreateResponse(HttpStatusCode.BadRequest);

--- a/src/api/Slypn.Api/Infrastructure/EntraJwtValidator.cs
+++ b/src/api/Slypn.Api/Infrastructure/EntraJwtValidator.cs
@@ -37,12 +37,22 @@ public sealed class EntraJwtValidator : IJwtValidator
 
         var config = await _configManager.GetConfigurationAsync(ct);
 
+        // CIAM v2 tokens set `aud` to the bare application GUID, not the
+        // api:// URI. Accept both so either form works in configuration.
+        var audience  = _opts.Audience!;
+        var guidOnly  = audience.StartsWith("api://", StringComparison.OrdinalIgnoreCase)
+                            ? audience["api://".Length..]
+                            : audience;
+        var apiUri    = audience.StartsWith("api://", StringComparison.OrdinalIgnoreCase)
+                            ? audience
+                            : $"api://{audience}";
+
         var validationParameters = new TokenValidationParameters
         {
             ValidateIssuer           = true,
             ValidIssuers             = _opts.ValidIssuers.Length > 0 ? _opts.ValidIssuers : [ _opts.Authority!.TrimEnd('/') ],
             ValidateAudience         = true,
-            ValidAudience            = _opts.Audience,
+            ValidAudiences           = [ guidOnly, apiUri ],
             ValidateLifetime         = true,
             ValidateIssuerSigningKey = true,
             IssuerSigningKeys        = config.SigningKeys,

--- a/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
@@ -148,4 +148,11 @@ public static class FunctionContextExtensions
 
     public static string? GetUserOid(this FunctionContext context) =>
         context.GetPrincipal()?.FindFirst("oid")?.Value;
+
+    public static string? GetUserName(this FunctionContext context) =>
+        context.GetPrincipal()?.FindFirst("name")?.Value
+        ?? context.GetPrincipal()?.FindFirst("preferred_username")?.Value;
+
+    public static bool IsAdmin(this FunctionContext context) =>
+        context.GetPrincipal()?.FindAll("roles").Any(c => c.Value == "Admin") ?? false;
 }

--- a/src/api/Slypn.Api/Models/CommunityEvent.cs
+++ b/src/api/Slypn.Api/Models/CommunityEvent.cs
@@ -10,7 +10,9 @@ public sealed record CommunityEvent(
     DateTimeOffset EndsAt,
     string Location,
     string Description,
-    string? SignupUrl)
+    string? SignupUrl,
+    string? CreatedBy     = null,
+    string? CreatedByName = null)
 {
     /// <summary>Partition key for the events container — "yyyy-MM" of StartsAt (UTC).</summary>
     public string YearMonth => StartsAt.UtcDateTime.ToString("yyyy-MM");

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -74,6 +74,15 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
         return await CollectAsync<CommunityEvent>(cosmos.Events, query, new QueryRequestOptions(), ct);
     }
 
+    public async Task<CommunityEvent?> GetEventByIdAsync(string id, CancellationToken ct)
+    {
+        if (!cosmos.IsConfigured) return null;
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.id = @id")
+            .WithParameter("@id", id);
+        var results = await CollectAsync<CommunityEvent>(cosmos.Events, query, new QueryRequestOptions(), ct);
+        return results.FirstOrDefault();
+    }
+
     public async Task<IReadOnlyList<Resource>> ListResourcesAsync(CancellationToken ct)
     {
         if (!cosmos.IsConfigured) return mock.Resources;
@@ -140,39 +149,56 @@ public sealed class ContentRepository(ICosmosService cosmos, IMockDataService mo
     }
 
     // ---- Events writes --------------------------------------------------------
-    public async Task<CommunityEvent> CreateEventAsync(EventInput input, CancellationToken ct)
+    public async Task<CommunityEvent> CreateEventAsync(EventInput input, string? createdByOid, string? createdByName, CancellationToken ct)
     {
         EnsureWrites();
         var ev = new CommunityEvent(
-            Id:          Guid.NewGuid().ToString("N"),
-            Title:       input.Title,
-            Type:        input.Type,
-            StartsAt:    input.StartsAt,
-            EndsAt:      input.EndsAt,
-            Location:    input.Location,
-            Description: input.Description,
-            SignupUrl:   input.SignupUrl);
+            Id:            Guid.NewGuid().ToString("N"),
+            Title:         input.Title,
+            Type:          input.Type,
+            StartsAt:      input.StartsAt,
+            EndsAt:        input.EndsAt,
+            Location:      input.Location,
+            Description:   input.Description,
+            SignupUrl:     input.SignupUrl,
+            CreatedBy:     createdByOid,
+            CreatedByName: createdByName);
         var resp = await cosmos.Events.CreateItemAsync(ev, new PartitionKey(ev.YearMonth), cancellationToken: ct);
         return resp.Resource with { Etag = resp.ETag };
     }
 
-    public async Task<CommunityEvent> ReplaceEventAsync(string id, EventInput input, string? ifMatch, CancellationToken ct)
+    public async Task<CommunityEvent> ReplaceEventAsync(string id, string oldYearMonth, EventInput input, string? createdByOid, string? createdByName, string? ifMatch, CancellationToken ct)
     {
         EnsureWrites();
         var ev = new CommunityEvent(
-            Id:          id,
-            Title:       input.Title,
-            Type:        input.Type,
-            StartsAt:    input.StartsAt,
-            EndsAt:      input.EndsAt,
-            Location:    input.Location,
-            Description: input.Description,
-            SignupUrl:   input.SignupUrl);
-        var resp = await cosmos.Events.ReplaceItemAsync(ev, id,
-            new PartitionKey(ev.YearMonth),
-            new ItemRequestOptions { IfMatchEtag = ifMatch },
-            ct);
-        return resp.Resource with { Etag = resp.ETag };
+            Id:            id,
+            Title:         input.Title,
+            Type:          input.Type,
+            StartsAt:      input.StartsAt,
+            EndsAt:        input.EndsAt,
+            Location:      input.Location,
+            Description:   input.Description,
+            SignupUrl:     input.SignupUrl,
+            CreatedBy:     createdByOid,
+            CreatedByName: createdByName);
+
+        if (ev.YearMonth == oldYearMonth)
+        {
+            // Same partition — in-place replace
+            var resp = await cosmos.Events.ReplaceItemAsync(ev, id,
+                new PartitionKey(oldYearMonth),
+                new ItemRequestOptions { IfMatchEtag = ifMatch }, ct);
+            return resp.Resource with { Etag = resp.ETag };
+        }
+        else
+        {
+            // Partition key changed — delete old doc, create new one
+            await cosmos.Events.DeleteItemAsync<CommunityEvent>(id,
+                new PartitionKey(oldYearMonth),
+                new ItemRequestOptions { IfMatchEtag = ifMatch }, ct);
+            var resp = await cosmos.Events.CreateItemAsync(ev, new PartitionKey(ev.YearMonth), cancellationToken: ct);
+            return resp.Resource with { Etag = resp.ETag };
+        }
     }
 
     public async Task DeleteEventAsync(string id, string yearMonth, string? ifMatch, CancellationToken ct)

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -19,6 +19,7 @@ public interface IContentRepository
     Task<IReadOnlyList<Article>>        ListBlogPostsAsync(string? status, CancellationToken ct);
     Task<Article?>                      GetArticleBySlugAsync(string slug, CancellationToken ct);
     Task<IReadOnlyList<CommunityEvent>> ListEventsAsync(bool upcomingOnly, CancellationToken ct);
+    Task<CommunityEvent?>               GetEventByIdAsync(string id, CancellationToken ct);
     Task<IReadOnlyList<Resource>>       ListResourcesAsync(CancellationToken ct);
     Task<IReadOnlyList<Newsletter>>     ListNewslettersAsync(CancellationToken ct);
 
@@ -27,8 +28,8 @@ public interface IContentRepository
     Task<Article>     ReplaceArticleAsync    (string id, ArticleInput input, string? ifMatch, CancellationToken ct);
     Task              DeleteArticleAsync     (string id, string status, string? ifMatch, CancellationToken ct);
 
-    Task<CommunityEvent> CreateEventAsync    (EventInput input, CancellationToken ct);
-    Task<CommunityEvent> ReplaceEventAsync   (string id, EventInput input, string? ifMatch, CancellationToken ct);
+    Task<CommunityEvent> CreateEventAsync    (EventInput input, string? createdByOid, string? createdByName, CancellationToken ct);
+    Task<CommunityEvent> ReplaceEventAsync   (string id, string oldYearMonth, EventInput input, string? createdByOid, string? createdByName, string? ifMatch, CancellationToken ct);
     Task                 DeleteEventAsync    (string id, string yearMonth, string? ifMatch, CancellationToken ct);
 
     Task<Resource>   CreateResourceAsync     (ResourceInput input, CancellationToken ct);

--- a/src/web/eslint.config.js
+++ b/src/web/eslint.config.js
@@ -8,7 +8,7 @@ export default [
   },
   {
     name: 'slypn/files-to-ignore',
-    ignores: ['**/dist/**', '**/node_modules/**', '**/.vite/**'],
+    ignores: ['**/dist/**', '**/node_modules/**', '**/.vite/**', '**/*.cjs', '**/*.mjs'],
   },
   ...pluginVue.configs['flat/essential'],
   ...vueTsEslintConfig(),

--- a/src/web/src/components/common/EventCalendar.vue
+++ b/src/web/src/components/common/EventCalendar.vue
@@ -44,13 +44,24 @@ const isToday = (d: Date) =>
 const shift = (months: number) => {
   cursor.value = new Date(cursor.value.getFullYear(), cursor.value.getMonth() + months, 1)
 }
+
+const goToToday = () => {
+  cursor.value = new Date(today.getFullYear(), today.getMonth(), 1)
+}
 </script>
 
 <template>
-  <div class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
+  <div class="w-full rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
     <div class="flex items-center justify-between">
       <h3 class="font-display text-xl font-bold text-slypn-700">{{ monthLabel }}</h3>
       <div class="flex gap-1">
+        <button
+          type="button"
+          class="rounded-md border border-slypn-200 px-3 py-1 text-sm text-slypn-700 hover:bg-slypn-50"
+          @click="goToToday"
+        >
+          Today
+        </button>
         <button
           type="button"
           class="rounded-md border border-slypn-200 px-3 py-1 text-sm text-slypn-700 hover:bg-slypn-50"
@@ -70,25 +81,37 @@ const shift = (months: number) => {
       </div>
     </div>
 
-    <div class="mt-4 grid grid-cols-7 gap-1 text-center text-xs font-semibold uppercase tracking-wider text-slypn-500">
-      <div v-for="d in weekDays" :key="d">{{ d }}</div>
-    </div>
+    <div class="mt-4 grid grid-cols-7 gap-1">
+      <!-- weekday header row shares the same grid as the cells for uniform column widths -->
+      <div
+        v-for="d in weekDays"
+        :key="d"
+        class="text-center text-xs font-semibold uppercase tracking-wider text-slypn-500"
+      >{{ d }}</div>
 
-    <div class="mt-1 grid grid-cols-7 gap-1">
       <template v-for="(row, ri) in weeks" :key="ri">
         <div
           v-for="cell in row"
           :key="cell.date.toISOString()"
           :class="[
-            'min-h-[88px] rounded-md border p-1.5 text-left text-xs',
+            'h-[88px] overflow-hidden rounded-md border p-1.5 text-left text-xs',
             cell.inMonth ? 'border-slypn-100 bg-white' : 'border-slypn-50 bg-slypn-50/40 text-slypn-900/40',
             isToday(cell.date) ? 'ring-2 ring-slypn-500' : '',
           ]"
         >
-          <div class="font-semibold">{{ cell.date.getDate() }}</div>
-          <div v-for="e in cell.events" :key="e.id" class="mt-1 truncate rounded bg-slypn-100 px-1.5 py-0.5 text-[11px] text-slypn-800" :title="e.title">
-            {{ e.title }}
-          </div>
+          <div
+            :class="[
+              'inline-flex h-5 w-5 items-center justify-center rounded-full font-semibold',
+              isToday(cell.date) ? 'bg-slypn-600 text-white' : '',
+            ]"
+          >{{ cell.date.getDate() }}</div>
+          <RouterLink
+            v-for="e in cell.events"
+            :key="e.id"
+            :to="{ name: 'event-detail', params: { id: e.id } }"
+            class="mt-1 block truncate rounded bg-slypn-100 px-1.5 py-0.5 text-[11px] text-slypn-800 hover:bg-slypn-200"
+            :title="e.title"
+          >{{ e.title }}</RouterLink>
         </div>
       </template>
     </div>

--- a/src/web/src/components/common/EventCard.vue
+++ b/src/web/src/components/common/EventCard.vue
@@ -11,8 +11,14 @@ const formatTime = (iso: string) =>
 </script>
 
 <template>
-  <article class="flex gap-5 rounded-xl border border-slypn-100 bg-white p-5 shadow-sm">
+  <RouterLink
+    :to="{ name: 'event-detail', params: { id: event.id } }"
+    class="flex gap-5 rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+  >
     <div class="flex w-20 flex-shrink-0 flex-col items-center justify-center rounded-lg bg-slypn-50 text-center">
+      <span class="text-xs font-semibold uppercase tracking-wider text-slypn-500">
+        {{ new Date(event.startsAt).toLocaleDateString('en-GB', { weekday: 'short' }) }}
+      </span>
       <span class="font-display text-2xl font-extrabold text-slypn-700">
         {{ new Date(event.startsAt).getDate() }}
       </span>
@@ -39,5 +45,5 @@ const formatTime = (iso: string) =>
         >Sign up</a>
       </div>
     </div>
-  </article>
+  </RouterLink>
 </template>

--- a/src/web/src/components/common/EventFormDialog.vue
+++ b/src/web/src/components/common/EventFormDialog.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { apiFetch } from '@/lib/api'
+import type { CommunityEvent } from '@/types/content'
+
+const props = defineProps<{
+  open: boolean
+  event: CommunityEvent | null   // null = add, populated = edit
+}>()
+
+const emit = defineEmits<{
+  close: []
+  saved: [event: CommunityEvent]
+}>()
+
+const EVENT_TYPES = ['Coffee meet-up', 'Drinks', 'Fundraising', 'Q&A', 'Carer session', 'Activity'] as const
+
+// ── form state ────────────────────────────────────────────────────────────────
+
+const title       = ref('')
+const type        = ref<string>('Coffee meet-up')
+const startsAt    = ref('')
+const endsAt      = ref('')
+const location    = ref('')
+const description = ref('')
+const signupUrl   = ref('')
+const submitting  = ref(false)
+const error       = ref<string | null>(null)
+
+function toDatetimeLocal(iso: string): string {
+  const d = new Date(iso)
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`
+}
+
+// Populate form whenever the dialog opens or the event prop changes
+watch(
+  () => [props.open, props.event] as const,
+  ([open, ev]) => {
+    if (!open) return
+    error.value = null
+    if (ev) {
+      title.value       = ev.title
+      type.value        = ev.type
+      startsAt.value    = toDatetimeLocal(ev.startsAt)
+      endsAt.value      = toDatetimeLocal(ev.endsAt)
+      location.value    = ev.location
+      description.value = ev.description
+      signupUrl.value   = ev.signupUrl ?? ''
+    } else {
+      title.value       = ''
+      type.value        = 'Coffee meet-up'
+      startsAt.value    = ''
+      endsAt.value      = ''
+      location.value    = ''
+      description.value = ''
+      signupUrl.value   = ''
+    }
+  },
+  { immediate: true },
+)
+
+// ── submit ────────────────────────────────────────────────────────────────────
+
+async function submit() {
+  if (submitting.value) return
+  error.value = null
+  submitting.value = true
+
+  const body = JSON.stringify({
+    title:       title.value.trim(),
+    type:        type.value,
+    startsAt:    new Date(startsAt.value).toISOString(),
+    endsAt:      new Date(endsAt.value).toISOString(),
+    location:    location.value.trim(),
+    description: description.value.trim(),
+    signupUrl:   signupUrl.value.trim() || undefined,
+  })
+
+  try {
+    const isEdit = props.event !== null
+    const url    = isEdit ? `/events/${props.event!.id}` : '/events'
+    const method = isEdit ? 'PUT' : 'POST'
+    const headers: Record<string, string> = {}
+    if (isEdit && props.event!._etag) headers['If-Match'] = `"${props.event!._etag}"`
+
+    const resp = await apiFetch(url, { method, body, headers })
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '')
+      throw new Error(`${resp.status} ${resp.statusText}${text ? ` — ${text}` : ''}`)
+    }
+    const saved = await resp.json() as CommunityEvent
+    emit('saved', saved)
+    emit('close')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="dialog">
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 px-4 py-12"
+        @click.self="emit('close')"
+      >
+        <div class="w-full max-w-xl rounded-2xl bg-white shadow-2xl">
+          <!-- header -->
+          <div class="flex items-center justify-between border-b border-slypn-100 px-6 py-4">
+            <h2 class="font-display text-lg font-bold text-slypn-700">
+              {{ event ? 'Edit event' : 'Add event' }}
+            </h2>
+            <button
+              type="button"
+              class="rounded-md p-1 text-slypn-400 hover:bg-slypn-50 hover:text-slypn-600"
+              aria-label="Close"
+              @click="emit('close')"
+            >&times;</button>
+          </div>
+
+          <!-- form -->
+          <form class="space-y-4 px-6 py-5" @submit.prevent="submit">
+            <div>
+              <label class="block text-sm font-medium text-slypn-800">Title</label>
+              <input
+                v-model="title"
+                type="text"
+                required
+                maxlength="200"
+                class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+              />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-slypn-800">Type</label>
+              <select
+                v-model="type"
+                required
+                class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+              >
+                <option v-for="t in EVENT_TYPES" :key="t" :value="t">{{ t }}</option>
+              </select>
+            </div>
+
+            <div class="grid grid-cols-2 gap-4">
+              <div>
+                <label class="block text-sm font-medium text-slypn-800">Starts at</label>
+                <input
+                  v-model="startsAt"
+                  type="datetime-local"
+                  required
+                  class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-slypn-800">Ends at</label>
+                <input
+                  v-model="endsAt"
+                  type="datetime-local"
+                  required
+                  class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-slypn-800">Location</label>
+              <input
+                v-model="location"
+                type="text"
+                required
+                maxlength="200"
+                class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+              />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-slypn-800">Description</label>
+              <textarea
+                v-model="description"
+                required
+                maxlength="2000"
+                rows="4"
+                class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+              />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-slypn-800">
+                Sign-up URL <span class="font-normal text-slypn-400">(optional)</span>
+              </label>
+              <input
+                v-model="signupUrl"
+                type="url"
+                class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+              />
+            </div>
+
+            <p v-if="error" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">{{ error }}</p>
+
+            <!-- actions -->
+            <div class="flex justify-end gap-3 border-t border-slypn-100 pt-4">
+              <button
+                type="button"
+                class="rounded-md border border-slypn-200 px-4 py-2 text-sm font-medium text-slypn-700 hover:bg-slypn-50"
+                @click="emit('close')"
+              >Cancel</button>
+              <button
+                type="submit"
+                class="rounded-md bg-slypn-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700 disabled:opacity-50"
+                :disabled="submitting || !title || !startsAt || !endsAt || !location || !description"
+              >
+                {{ submitting ? 'Saving…' : (event ? 'Save changes' : 'Add event') }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.dialog-enter-active, .dialog-leave-active { transition: opacity 0.15s ease; }
+.dialog-enter-from, .dialog-leave-to { opacity: 0; }
+</style>

--- a/src/web/src/components/common/MonthRangePicker.vue
+++ b/src/web/src/components/common/MonthRangePicker.vue
@@ -1,0 +1,217 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+const props = defineProps<{ start: Date; end: Date }>()
+const emit  = defineEmits<{ change: [start: Date, end: Date] }>()
+
+const now = new Date()
+const thisYear  = now.getFullYear()
+const thisMonth = now.getMonth()
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function ym(year: number, month: number) { return year * 12 + month }
+function ymOfDate(d: Date) { return ym(d.getFullYear(), d.getMonth()) }
+function dateOfYM(v: number): Date { return new Date(Math.floor(v / 12), v % 12, 1) }
+
+// ── state ────────────────────────────────────────────────────────────────────
+
+const open       = ref(false)
+const pickerYear = ref(props.start.getFullYear())
+const phase      = ref<'start' | 'end'>('start')  // which click we're waiting for
+const anchorYM   = ref(0)                          // first-click ym while picking end
+const hoverYM    = ref<number | null>(null)
+
+// ── effective range (committed or live preview) ───────────────────────────────
+
+const committedS = computed(() => ymOfDate(props.start))
+const committedE = computed(() => ymOfDate(props.end))
+
+const previewS = computed(() => {
+  if (phase.value !== 'end') return committedS.value
+  const h = hoverYM.value ?? anchorYM.value
+  return Math.min(anchorYM.value, h)
+})
+const previewE = computed(() => {
+  if (phase.value !== 'end') return committedE.value
+  const h = hoverYM.value ?? anchorYM.value
+  return Math.max(anchorYM.value, h)
+})
+
+// ── interaction ───────────────────────────────────────────────────────────────
+
+function openPicker() {
+  pickerYear.value = props.start.getFullYear()
+  phase.value      = 'start'
+  hoverYM.value    = null
+  open.value       = true
+}
+
+function closePicker() {
+  open.value    = false
+  phase.value   = 'start'
+  hoverYM.value = null
+}
+
+function pick(year: number, month: number) {
+  const clicked = ym(year, month)
+  if (phase.value === 'start') {
+    anchorYM.value = clicked
+    phase.value    = 'end'
+  } else {
+    const s = Math.min(anchorYM.value, clicked)
+    const e = Math.max(anchorYM.value, clicked)
+    emit('change', dateOfYM(s), dateOfYM(e))
+    closePicker()
+  }
+}
+
+// ── cell styling ──────────────────────────────────────────────────────────────
+
+function bandClass(year: number, month: number): string {
+  const m = ym(year, month)
+  const s = previewS.value
+  const e = previewE.value
+  if (s === e) return ''
+  if (m === s)              return 'absolute inset-y-0 left-1/2 right-0 bg-slypn-100'
+  if (m === e)              return 'absolute inset-y-0 left-0 right-1/2 bg-slypn-100'
+  if (m > s && m < e)       return 'absolute inset-0 bg-slypn-100'
+  return ''
+}
+
+function isCurrent(year: number, month: number) {
+  return year === thisYear && month === thisMonth
+}
+
+function btnClass(year: number, month: number): string {
+  const m = ym(year, month)
+  const s = previewS.value
+  const e = previewE.value
+  const current = isCurrent(year, month)
+
+  if (m === s || m === e)
+    return `bg-slypn-600 text-white rounded-full font-semibold${current ? ' ring-2 ring-offset-1 ring-slypn-400' : ''}`
+  if (m > s && m < e)
+    return `text-slypn-800${current ? ' font-semibold underline decoration-slypn-500 decoration-2 underline-offset-2' : ''}`
+  return `text-slypn-700 hover:bg-slypn-50 rounded-full${current ? ' ring-1 ring-slypn-400' : ''}`
+}
+
+function selectThisMonth() {
+  pick(thisYear, thisMonth)
+}
+
+// ── trigger label ─────────────────────────────────────────────────────────────
+
+const label = computed(() => {
+  const fmt = (d: Date) => d.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })
+  return `${fmt(props.start)} – ${fmt(props.end)}`
+})
+
+const hint = computed(() =>
+  phase.value === 'end' ? 'Select end month' : 'Select start month',
+)
+</script>
+
+<template>
+  <div class="relative">
+    <!-- Trigger -->
+    <button
+      type="button"
+      class="flex w-full items-center justify-between rounded-md border border-slypn-200 bg-white px-3 py-2 text-left text-sm shadow-sm hover:bg-slypn-50"
+      @click="open ? closePicker() : openPicker()"
+    >
+      <span>
+        <span class="block text-[10px] font-semibold uppercase tracking-widest text-slypn-400">Date range</span>
+        <span class="font-medium text-slypn-700">{{ label }}</span>
+      </span>
+      <svg class="h-4 w-4 text-slypn-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      </svg>
+    </button>
+
+    <!-- Backdrop -->
+    <div v-if="open" class="fixed inset-0 z-10" @click="closePicker" />
+
+    <!-- Picker panel -->
+    <div
+      v-if="open"
+      class="absolute left-0 top-full z-20 mt-2 rounded-xl border border-slypn-200 bg-white shadow-xl"
+    >
+      <!-- Two year panels -->
+      <div class="flex divide-x divide-slypn-100 p-4">
+
+        <!-- Left year -->
+        <div class="w-44 pr-4">
+          <div class="mb-3 flex items-center justify-between">
+            <button
+              type="button"
+              class="rounded p-1 text-slypn-500 hover:bg-slypn-50"
+              @click="pickerYear--"
+            >&larr;</button>
+            <span class="text-sm font-semibold text-slypn-700">{{ pickerYear }}</span>
+            <!-- spacer keeps header symmetric -->
+            <span class="w-6" />
+          </div>
+          <div class="grid grid-cols-3">
+            <div
+              v-for="(m, i) in MONTHS"
+              :key="i"
+              class="relative py-0.5"
+              @mouseenter="hoverYM = ym(pickerYear, i)"
+              @mouseleave="hoverYM = null"
+            >
+              <div :class="bandClass(pickerYear, i)" />
+              <button
+                type="button"
+                :class="['relative z-10 w-full py-1.5 text-center text-sm', btnClass(pickerYear, i)]"
+                @click="pick(pickerYear, i)"
+              >{{ m }}</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right year -->
+        <div class="w-44 pl-4">
+          <div class="mb-3 flex items-center justify-between">
+            <span class="w-6" />
+            <span class="text-sm font-semibold text-slypn-700">{{ pickerYear + 1 }}</span>
+            <button
+              type="button"
+              class="rounded p-1 text-slypn-500 hover:bg-slypn-50"
+              @click="pickerYear++"
+            >&rarr;</button>
+          </div>
+          <div class="grid grid-cols-3">
+            <div
+              v-for="(m, i) in MONTHS"
+              :key="i"
+              class="relative py-0.5"
+              @mouseenter="hoverYM = ym(pickerYear + 1, i)"
+              @mouseleave="hoverYM = null"
+            >
+              <div :class="bandClass(pickerYear + 1, i)" />
+              <button
+                type="button"
+                :class="['relative z-10 w-full py-1.5 text-center text-sm', btnClass(pickerYear + 1, i)]"
+                @click="pick(pickerYear + 1, i)"
+              >{{ m }}</button>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Footer: hint + this-month shortcut -->
+      <div class="flex items-center justify-between border-t border-slypn-100 px-4 py-2.5">
+        <span class="text-xs text-slypn-400">{{ hint }}</span>
+        <button
+          type="button"
+          class="rounded-md bg-slypn-50 px-2.5 py-1 text-xs font-medium text-slypn-600 hover:bg-slypn-100"
+          @click="selectThisMonth"
+        >This month</button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -105,6 +105,9 @@ async function onSignOut() {
             <li v-if="auth.isContributor || auth.isAdmin">
               <RouterLink to="/editor" class="block px-4 py-2 hover:bg-slypn-50" @click="userMenuOpen = false">Editor</RouterLink>
             </li>
+            <li v-if="auth.isContributor || auth.isAdmin">
+              <RouterLink to="/admin/events" class="block px-4 py-2 hover:bg-slypn-50" @click="userMenuOpen = false">Event management</RouterLink>
+            </li>
             <li v-if="auth.isAdmin">
               <RouterLink to="/admin" class="block px-4 py-2 hover:bg-slypn-50" @click="userMenuOpen = false">Admin</RouterLink>
             </li>
@@ -149,6 +152,20 @@ async function onSignOut() {
         >
           {{ item.label }}
         </RouterLink>
+        <RouterLink
+          v-if="auth.isContributor || auth.isAdmin"
+          to="/admin/events"
+          class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+          active-class="bg-slypn-50"
+          @click="mobileOpen = false"
+        >Event management</RouterLink>
+        <RouterLink
+          v-if="auth.isAdmin"
+          to="/admin"
+          class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+          active-class="bg-slypn-50"
+          @click="mobileOpen = false"
+        >Admin</RouterLink>
         <button
           v-if="!auth.isAuthenticated"
           class="mt-1 rounded-md bg-slypn-600 px-3 py-2 text-center text-base font-semibold text-white hover:bg-slypn-700"

--- a/src/web/src/lib/msal.ts
+++ b/src/web/src/lib/msal.ts
@@ -62,3 +62,20 @@ export function ensureMsalInitialized(): Promise<AuthenticationResult | null> {
 export function buildSilentRequest(account: AccountInfo): SilentRequest {
   return { account, scopes: [apiScope] }
 }
+
+/**
+ * Remove stale MSAL interaction-state keys from sessionStorage and reset the
+ * init promise so handleRedirectPromise runs again on the next call.
+ *
+ * These keys accumulate when a redirect flow is interrupted (browser back,
+ * closed tab, navigation away mid-flow). The next loginRedirect call then
+ * throws interaction_in_progress even though no flow is actually running.
+ */
+export function clearMsalInteractionState(): void {
+  for (const key of Object.keys(sessionStorage)) {
+    if (key.includes('.interaction.status') || key.includes('interaction.status')) {
+      sessionStorage.removeItem(key)
+    }
+  }
+  initPromise = null
+}

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -17,7 +17,8 @@ import { useAuthStore } from '@/stores/auth'
 const AuthCallbackView = () => import('@/views/AuthCallbackView.vue')
 const DashboardView    = () => import('@/views/DashboardView.vue')
 const EditorView       = () => import('@/views/EditorView.vue')
-const AdminView        = () => import('@/views/AdminView.vue')
+const AdminView             = () => import('@/views/AdminView.vue')
+const EventManagementView   = () => import('@/views/EventManagementView.vue')
 
 declare module 'vue-router' {
   interface RouteMeta {
@@ -38,6 +39,7 @@ const router = createRouter({
     { path: '/articles/:slug',    name: 'article-detail',  component: ArticleDetailView },
     { path: '/blog',              name: 'blog',            component: BlogView },
     { path: '/events',            name: 'events',          component: EventsView },
+    { path: '/events/:id',       name: 'event-detail',    component: () => import('@/views/EventDetailView.vue') },
     { path: '/resources',         name: 'resources',       component: ResourcesView },
     { path: '/newsletter',        name: 'newsletter',      component: NewsletterView },
     { path: '/login',             name: 'login',           component: LoginView },
@@ -49,6 +51,8 @@ const router = createRouter({
       meta: { requiresAuth: true, requiresRole: ['Admin', 'Contributor'] } },
     { path: '/admin', name: 'admin', component: AdminView,
       meta: { requiresAuth: true, requiresRole: ['Admin'] } },
+    { path: '/admin/events', name: 'admin-events', component: EventManagementView,
+      meta: { requiresAuth: true, requiresRole: ['Admin', 'Contributor'] } },
 
     { path: '/:pathMatch(.*)*',   name: 'not-found',       component: NotFoundView },
   ],

--- a/src/web/src/stores/auth.ts
+++ b/src/web/src/stores/auth.ts
@@ -1,12 +1,14 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import {
+  BrowserAuthError,
   InteractionRequiredAuthError,
   type AccountInfo,
 } from '@azure/msal-browser'
 import {
   apiScope,
   buildSilentRequest,
+  clearMsalInteractionState,
   ensureMsalInitialized,
   isAuthConfigured,
   isDevSkipAuth,
@@ -21,18 +23,21 @@ type IdTokenClaims = Record<string, unknown> & { roles?: string[] }
  * token. Decode the JWT payload (no signature check — verification happens at
  * the API) to pull roles out for UI gating.
  */
-function decodeJwtRoles(token: string): string[] {
+function decodeJwtPayload(token: string): { roles: string[]; oid: string | null } {
   try {
     const segment = token.split('.')[1]
-    if (!segment) return []
-    const padded = segment.replace(/-/g, '+').replace(/_/g, '/')
+    if (!segment) return { roles: [], oid: null }
+    const padded  = segment.replace(/-/g, '+').replace(/_/g, '/')
     const padding = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4))
-    const payload = JSON.parse(atob(padded + padding)) as { roles?: unknown }
-    return Array.isArray(payload.roles)
-      ? payload.roles.filter((r): r is string => typeof r === 'string')
-      : []
+    const payload = JSON.parse(atob(padded + padding)) as { roles?: unknown; oid?: unknown }
+    return {
+      roles: Array.isArray(payload.roles)
+        ? payload.roles.filter((r): r is string => typeof r === 'string')
+        : [],
+      oid: typeof payload.oid === 'string' ? payload.oid : null,
+    }
   } catch {
-    return []
+    return { roles: [], oid: null }
   }
 }
 
@@ -55,8 +60,14 @@ function makeDevAccount(): AccountInfo {
 export const useAuthStore = defineStore('auth', () => {
   const account = ref<AccountInfo | null>(null)
   const apiRoles = ref<string[]>([])
+  const apiOid   = ref<string | null>(null)
   const initializing = ref(false)
   const initialized = ref(false)
+
+  // Shared promise so concurrent callers (e.g. router guard + component mount)
+  // all await the same in-flight initialization instead of getting an instant
+  // no-op return that leaves isAuthenticated false.
+  let _initPromise: Promise<void> | null = null
 
   const isAuthenticated = computed(() => account.value !== null)
   /** UI is "configured" if either real Entra or the dev-skip flag is wired. */
@@ -76,38 +87,62 @@ export const useAuthStore = defineStore('auth', () => {
   const displayName = computed(() =>
     (account.value?.name ?? account.value?.username ?? '').trim() || 'Member')
 
+  // OID from the API access token — matches what the API stores in CreatedBy
+  const oid = computed<string | null>(() => {
+    if (isDevSkipAuth) return '00000000-0000-0000-0000-000000000000'
+    return apiOid.value ?? ((account.value?.idTokenClaims as Record<string, unknown>)?.oid as string | undefined) ?? null
+  })
+
   /**
    * Drive MSAL through initialize + handleRedirectPromise and pick up an
    * already-cached account if any. In dev-skip mode, synthesises an Admin
    * principal so route guards open up immediately. Safe to call multiple times.
    */
-  async function initialize() {
-    if (initialized.value || initializing.value) return
-    initializing.value = true
-    try {
-      if (isDevSkipAuth) {
-        account.value = makeDevAccount()
-        initialized.value = true
-        return
-      }
-      const redirectResult = await ensureMsalInitialized()
-      if (redirectResult?.account) {
-        msalInstance!.setActiveAccount(redirectResult.account)
-        account.value = redirectResult.account
-      } else if (msalInstance) {
-        const cached = msalInstance.getAllAccounts()[0]
-        if (cached) {
-          msalInstance.setActiveAccount(cached)
-          account.value = cached
+  async function initialize(): Promise<void> {
+    if (initialized.value) return
+    if (_initPromise) return _initPromise
+
+    _initPromise = (async () => {
+      initializing.value = true
+      try {
+        if (isDevSkipAuth) {
+          account.value = makeDevAccount()
+          initialized.value = true
+          return
         }
+
+        // handleRedirectPromise can throw (expired code, state mismatch, etc.).
+        // On error, clear the stale interaction state and fall through to the
+        // cached-account lookup so existing sessions still work.
+        let redirectResult = null
+        try {
+          redirectResult = await ensureMsalInitialized()
+        } catch {
+          clearMsalInteractionState()
+        }
+
+        if (redirectResult?.account) {
+          msalInstance!.setActiveAccount(redirectResult.account)
+          account.value = redirectResult.account
+        } else if (msalInstance) {
+          const cached = msalInstance.getAllAccounts()[0]
+          if (cached) {
+            msalInstance.setActiveAccount(cached)
+            account.value = cached
+          }
+        }
+
+        if (account.value) {
+          await refreshApiRoles()
+        }
+        initialized.value = true
+      } finally {
+        initializing.value = false
+        _initPromise = null
       }
-      if (account.value) {
-        await refreshApiRoles()
-      }
-      initialized.value = true
-    } finally {
-      initializing.value = false
-    }
+    })()
+
+    return _initPromise
   }
 
   async function login(returnTo?: string) {
@@ -122,22 +157,38 @@ export const useAuthStore = defineStore('auth', () => {
       throw new Error('Auth not configured — set VITE_MSAL_* env vars or VITE_DEV_SKIP_AUTH=true.')
     }
     await ensureMsalInitialized()
-    await msalInstance.loginRedirect({
-      scopes: [apiScope],
-      redirectStartPage: returnTo ?? window.location.href,
-    })
+    try {
+      await msalInstance.loginRedirect({
+        scopes: [apiScope],
+        redirectStartPage: returnTo ?? window.location.href,
+      })
+    } catch (err) {
+      if (err instanceof BrowserAuthError && err.errorCode === 'interaction_in_progress') {
+        // Stale interaction state from an interrupted redirect — clear it and retry once.
+        clearMsalInteractionState()
+        await ensureMsalInitialized()
+        await msalInstance.loginRedirect({
+          scopes: [apiScope],
+          redirectStartPage: returnTo ?? window.location.href,
+        })
+        return
+      }
+      throw err
+    }
   }
 
   async function logout() {
     if (isDevSkipAuth) {
-      account.value = null
+      account.value  = null
       apiRoles.value = []
+      apiOid.value   = null
       window.location.href = window.location.origin
       return
     }
     if (!msalInstance || !account.value) {
-      account.value = null
+      account.value  = null
       apiRoles.value = []
+      apiOid.value   = null
       return
     }
     await msalInstance.logoutRedirect({ account: account.value })
@@ -155,8 +206,10 @@ export const useAuthStore = defineStore('auth', () => {
       return
     }
     try {
-      const result = await msalInstance.acquireTokenSilent(buildSilentRequest(account.value))
-      apiRoles.value = decodeJwtRoles(result.accessToken)
+      const result   = await msalInstance.acquireTokenSilent(buildSilentRequest(account.value))
+      const decoded  = decodeJwtPayload(result.accessToken)
+      apiRoles.value = decoded.roles
+      if (decoded.oid) apiOid.value = decoded.oid
     } catch {
       apiRoles.value = []
     }
@@ -173,8 +226,10 @@ export const useAuthStore = defineStore('auth', () => {
     if (!msalInstance || !account.value) return null
     await ensureMsalInitialized()
     try {
-      const result = await msalInstance.acquireTokenSilent(buildSilentRequest(account.value))
-      apiRoles.value = decodeJwtRoles(result.accessToken)
+      const result   = await msalInstance.acquireTokenSilent(buildSilentRequest(account.value))
+      const decoded  = decodeJwtPayload(result.accessToken)
+      apiRoles.value = decoded.roles
+      if (decoded.oid) apiOid.value = decoded.oid
       return result.accessToken
     } catch (err) {
       if (err instanceof InteractionRequiredAuthError) {
@@ -195,6 +250,7 @@ export const useAuthStore = defineStore('auth', () => {
     isContributor,
     isMember,
     displayName,
+    oid,
     initialize,
     login,
     logout,

--- a/src/web/src/types/content.ts
+++ b/src/web/src/types/content.ts
@@ -44,6 +44,9 @@ export interface CommunityEvent {
   location: string
   description: string
   signupUrl?: string
+  createdBy?: string
+  createdByName?: string
+  _etag?: string
 }
 
 export type ResourceCategory =

--- a/src/web/src/views/AdminView.vue
+++ b/src/web/src/views/AdminView.vue
@@ -57,7 +57,7 @@ async function submit() {
   <HeroBanner
     eyebrow="Admin"
     title="SLYPN administration"
-    subtitle="Invite members, manage roles, and (soon) approve pending content."
+    subtitle="Invite members, manage roles, and approve pending content."
   />
 
   <section class="mx-auto max-w-3xl space-y-6 px-6 py-16">
@@ -129,6 +129,19 @@ async function submit() {
           </p>
         </div>
       </form>
+    </article>
+
+    <article class="rounded-xl border border-slypn-100 bg-white p-6 shadow-sm">
+      <h2 class="font-display text-xl font-bold text-slypn-700">Event management</h2>
+      <p class="mt-2 text-sm text-slypn-900/75">Add events to the community calendar and remove old ones.</p>
+      <div class="mt-4">
+        <RouterLink
+          to="/admin/events"
+          class="inline-flex items-center rounded-md bg-slypn-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700"
+        >
+          Manage events &rarr;
+        </RouterLink>
+      </div>
     </article>
 
     <ApprovalsQueue />

--- a/src/web/src/views/EventDetailView.vue
+++ b/src/web/src/views/EventDetailView.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+import { apiJson } from '@/lib/api'
+import { useAsyncData } from '@/composables/useAsyncData'
+import type { CommunityEvent } from '@/types/content'
+
+const route  = useRoute()
+const router = useRouter()
+
+const { data: event, loading, error } = useAsyncData(
+  () => apiJson<CommunityEvent>(`/events/${route.params.id}`),
+)
+
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })
+
+const fmtTime = (iso: string) =>
+  new Date(iso).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false })
+</script>
+
+<template>
+  <div class="mx-auto w-full max-w-3xl px-6 py-12">
+
+    <button
+      type="button"
+      class="mb-8 flex items-center gap-1.5 text-sm text-slypn-500 hover:text-slypn-700"
+      @click="router.back()"
+    >
+      &larr; Back
+    </button>
+
+    <p v-if="loading" class="text-center text-slypn-900/60">Loading…</p>
+
+    <p v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
+      Couldn&rsquo;t load event: {{ error }}
+    </p>
+
+    <article v-else-if="event" class="space-y-6">
+      <!-- type badge -->
+      <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+        {{ event.type }}
+      </p>
+
+      <h1 class="text-3xl font-extrabold text-slypn-700 sm:text-4xl">{{ event.title }}</h1>
+
+      <!-- meta -->
+      <dl class="grid gap-3 rounded-xl border border-slypn-100 bg-slypn-50 p-5 sm:grid-cols-2">
+        <div>
+          <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">Date</dt>
+          <dd class="mt-1 text-sm font-medium text-slypn-800">{{ fmtDate(event.startsAt) }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">Time</dt>
+          <dd class="mt-1 text-sm font-medium text-slypn-800">
+            {{ fmtTime(event.startsAt) }}&ndash;{{ fmtTime(event.endsAt) }}
+          </dd>
+        </div>
+        <div class="sm:col-span-2">
+          <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">Location</dt>
+          <dd class="mt-1 text-sm font-medium text-slypn-800">{{ event.location }}</dd>
+        </div>
+      </dl>
+
+      <!-- description -->
+      <p class="text-base leading-relaxed text-slypn-900/80">{{ event.description }}</p>
+
+      <!-- sign up -->
+      <a
+        v-if="event.signupUrl"
+        :href="event.signupUrl"
+        target="_blank"
+        rel="noopener"
+        class="inline-block rounded-md bg-slypn-600 px-6 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700"
+      >
+        Sign up &rarr;
+      </a>
+    </article>
+
+  </div>
+</template>

--- a/src/web/src/views/EventManagementView.vue
+++ b/src/web/src/views/EventManagementView.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import MonthRangePicker from '@/components/common/MonthRangePicker.vue'
+import EventFormDialog from '@/components/common/EventFormDialog.vue'
+import { apiFetch, apiJson } from '@/lib/api'
+import { useAsyncData } from '@/composables/useAsyncData'
+import { useAuthStore } from '@/stores/auth'
+import type { CommunityEvent } from '@/types/content'
+
+const auth = useAuthStore()
+
+// ── event list ────────────────────────────────────────────────────────────────
+
+const { data: events, loading, error: loadError, refresh } = useAsyncData(
+  () => apiJson<CommunityEvent[]>('/events'),
+)
+
+// ── date range — default −2 / +2 months ──────────────────────────────────────
+
+function monthOffset(n: number): Date {
+  const d = new Date()
+  d.setDate(1); d.setHours(0, 0, 0, 0); d.setMonth(d.getMonth() + n)
+  return d
+}
+
+const rangeStart = ref(monthOffset(-2))
+const rangeEnd   = ref(monthOffset(2))
+
+function onRangeChange(start: Date, end: Date) {
+  rangeStart.value = start
+  rangeEnd.value   = end
+}
+
+function ym(d: Date) { return d.getFullYear() * 12 + d.getMonth() }
+
+// ── search + filter ───────────────────────────────────────────────────────────
+
+const searchQuery = ref('')
+
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' })
+
+const filtered = computed(() => {
+  const q  = searchQuery.value.trim().toLowerCase()
+  const lo = ym(rangeStart.value)
+  const hi = ym(rangeEnd.value)
+  return [...(events.value ?? [])]
+    .filter(e => {
+      const d = new Date(e.startsAt)
+      if (ym(d) < lo || ym(d) > hi) return false
+      if (!q) return true
+      return (
+        e.title.toLowerCase().includes(q)       ||
+        e.type.toLowerCase().includes(q)        ||
+        e.location.toLowerCase().includes(q)    ||
+        e.description.toLowerCase().includes(q) ||
+        fmtDate(e.startsAt).toLowerCase().includes(q)
+      )
+    })
+    .sort((a, b) => +new Date(a.startsAt) - +new Date(b.startsAt))
+})
+
+// ── permissions ───────────────────────────────────────────────────────────────
+
+function canEdit(event: CommunityEvent): boolean {
+  return auth.isAdmin || event.createdBy === auth.oid
+}
+
+// ── dialog ────────────────────────────────────────────────────────────────────
+
+const dialogOpen  = ref(false)
+const dialogEvent = ref<CommunityEvent | null>(null)
+
+function openAdd() {
+  dialogEvent.value = null
+  dialogOpen.value  = true
+}
+
+function openEdit(event: CommunityEvent) {
+  dialogEvent.value = event
+  dialogOpen.value  = true
+}
+
+function onSaved() {
+  refresh()
+}
+
+// ── delete ────────────────────────────────────────────────────────────────────
+
+const deleting    = ref<string | null>(null)
+const deleteError = ref<string | null>(null)
+
+async function deleteEvent(event: CommunityEvent) {
+  if (!confirm(`Delete "${event.title}"?\n\nThis cannot be undone.`)) return
+  deleting.value    = event.id
+  deleteError.value = null
+  try {
+    const headers: Record<string, string> = {}
+    if (event._etag) headers['If-Match'] = `"${event._etag}"`
+    const resp = await apiFetch(`/events/${event.id}`, { method: 'DELETE', headers })
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '')
+      throw new Error(`${resp.status} ${resp.statusText}${body ? ` — ${body}` : ''}`)
+    }
+    refresh()
+  } catch (err) {
+    deleteError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    deleting.value = null
+  }
+}
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Admin"
+    title="Event management"
+    subtitle="Add, edit, and remove community events. Contributors may manage their own events; admins can manage all."
+  />
+
+  <section class="mx-auto w-full max-w-3xl space-y-6 px-6 py-16">
+
+    <!-- Manage events -->
+    <article class="rounded-xl border border-slypn-100 bg-white p-6 shadow-sm">
+      <div class="flex items-center justify-between">
+        <h2 class="font-display text-xl font-bold text-slypn-700">Manage events</h2>
+        <button
+          type="button"
+          class="rounded-md bg-slypn-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700"
+          @click="openAdd"
+        >+ Add event</button>
+      </div>
+      <p class="mt-2 text-sm text-slypn-900/75">
+        Admins can edit or delete any event. Contributors can only edit or delete events they created.
+      </p>
+
+      <!-- Search + date range -->
+      <div class="mt-5 space-y-3">
+        <input
+          v-model="searchQuery"
+          type="search"
+          placeholder="Search by title, location, type, or date (e.g. Jun, 2025)…"
+          class="w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+        />
+        <div class="flex items-center gap-2">
+          <div class="flex-1">
+            <MonthRangePicker :start="rangeStart" :end="rangeEnd" @change="onRangeChange" />
+          </div>
+          <span class="shrink-0 text-xs text-slypn-400">{{ filtered.length }} event{{ filtered.length === 1 ? '' : 's' }}</span>
+        </div>
+      </div>
+
+      <!-- Event list -->
+      <p v-if="loading" class="mt-4 text-sm text-slypn-900/60">Loading events…</p>
+      <p v-else-if="loadError" class="mt-4 rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
+        Couldn&rsquo;t load events: {{ loadError }}.
+        <button class="ml-1 underline" @click="refresh">Retry</button>
+      </p>
+      <p v-else-if="!filtered.length" class="mt-4 text-sm text-slypn-900/60">No events match.</p>
+
+      <ul v-else class="mt-3 divide-y divide-slypn-100">
+        <li
+          v-for="event in filtered"
+          :key="event.id"
+          class="flex items-center justify-between gap-4 py-3"
+        >
+          <div class="min-w-0 flex-1">
+            <RouterLink
+              :to="{ name: 'event-detail', params: { id: event.id } }"
+              class="block truncate text-sm font-medium text-slypn-800 hover:text-slypn-600 hover:underline"
+            >{{ event.title }}</RouterLink>
+            <p class="mt-0.5 text-xs text-slypn-500">
+              {{ fmtDate(event.startsAt) }}
+              <span v-if="event.createdByName" class="ml-2 text-slypn-400">· {{ event.createdByName }}</span>
+            </p>
+          </div>
+
+          <div v-if="canEdit(event)" class="flex shrink-0 gap-2">
+            <button
+              type="button"
+              class="rounded-md border border-slypn-200 px-3 py-1.5 text-xs font-medium text-slypn-600 hover:bg-slypn-50"
+              @click="openEdit(event)"
+            >Edit</button>
+            <button
+              type="button"
+              class="rounded-md border border-rose-200 px-3 py-1.5 text-xs font-semibold text-rose-600 hover:bg-rose-50 disabled:opacity-40"
+              :disabled="deleting === event.id"
+              @click="deleteEvent(event)"
+            >{{ deleting === event.id ? 'Deleting…' : 'Delete' }}</button>
+          </div>
+        </li>
+      </ul>
+
+      <p v-if="deleteError" class="mt-3 rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">{{ deleteError }}</p>
+    </article>
+
+  </section>
+
+  <!-- Add/edit dialog -->
+  <EventFormDialog
+    :open="dialogOpen"
+    :event="dialogEvent"
+    @close="dialogOpen = false"
+    @saved="onSaved"
+  />
+</template>

--- a/src/web/src/views/EventsView.vue
+++ b/src/web/src/views/EventsView.vue
@@ -54,7 +54,7 @@ const upcoming = computed(() => {
     </template>
   </HeroBanner>
 
-  <section class="mx-auto max-w-4xl px-6 py-16">
+  <section class="mx-auto w-full max-w-4xl px-6 py-16">
     <p v-if="loading && !events" class="text-center text-slypn-900/70">
       Loading events&hellip;
     </p>


### PR DESCRIPTION
## Summary

- Full events CRUD (create/edit/delete) for Admin and Contributor roles — EventManagementView, EventFormDialog, MonthRangePicker, event detail page, updated EventsView/EventCalendar/EventCard
- /admin/events route now accessible to Contributor role (was Admin-only)
- JWT audience validator accepts bare GUID and api:// URI so CIAM v2 tokens validate correctly
- Fix interaction_in_progress MSAL error by clearing stale sessionStorage on BrowserAuthError retry
- Fix initialize() race condition: return shared promise instead of undefined when already in progress; catch handleRedirectPromise errors and fall back to cached-account lookup
- Add infra/setup.ps1 — full one-shot environment bootstrap (Bicep deploy, Entra CIAM app registrations, SWA app settings, GitHub secrets, local dev config)
- Pass VITE_MSAL_* secrets to SWA build step so production bundles have auth configured

## Test plan

- [ ] Lint passes (npm run lint)
- [ ] Build passes (npm run build)
- [ ] API tests pass (dotnet test — 28/28)
- [ ] Contributor can access /admin/events and create/edit/delete events
- [ ] Admin can access /admin/events
- [ ] Sign in and sign out flow works without interaction_in_progress error
- [ ] API returns 200 (not 401) for authenticated contributor adding an event
- [ ] SWA deploy picks up VITE_MSAL_* from GitHub secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)