### PR TITLE
fix(swa): add navigationFallback so SPA routes don't 404

### DIFF
--- a/src/web/public/staticwebapp.config.json
+++ b/src/web/public/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*", "/favicon.png"]
+  }
+}


### PR DESCRIPTION
## Summary

- Azure SWA was missing `staticwebapp.config.json`, so any hard navigation to a Vue Router path (e.g. `/auth/callback` after MSAL redirect, or direct link to `/admin/events`) returned 404
- Adds `navigationFallback` rewrite to `index.html` for all paths except static assets

## Test plan

- [ ] Sign in from production URL completes without 404 on `/auth/callback`
- [ ] Direct navigation to `/events`, `/admin/events`, etc. loads the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)