### PR TITLE
fix(auth): set requestedAccessTokenVersion=2 on API app registration

### DIFF
--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -321,6 +321,19 @@ if (-not $SkipEntra) {
         Ok $appIdUri
     }
 
+    # requestedAccessTokenVersion = 2 — CIAM must issue v2 access tokens so
+    # they include a `kid` header. Without this the API validator fails with
+    # "kid is missing" because v1 tokens use a different signing key format.
+    $apiApp = Invoke-Graph GET "/applications/$apiObjectId"
+    if ($apiApp.api.requestedAccessTokenVersion -ne 2) {
+        Invoke-Graph PATCH "/applications/$apiObjectId" @{
+            api = @{ requestedAccessTokenVersion = 2 }
+        } | Out-Null
+        Ok 'requestedAccessTokenVersion set to 2'
+    } else {
+        Info 'requestedAccessTokenVersion already 2'
+    }
+
     # ── access_as_user scope ──────────────────────────────────────────────────
 
     Step 'Entra · OAuth scope — access_as_user'


### PR DESCRIPTION
## Summary

CIAM was issuing v1-format access tokens (no `kid` header in JWT). The API validator fetches signing keys from the v2 OIDC discovery doc, which don't match v1 token signatures — every authenticated API call in production returned 401.

Setting `requestedAccessTokenVersion: 2` on the API app registration forces CIAM to issue v2 tokens with a `kid` header so signature validation succeeds.

**Immediate fix:** run this one-liner against the CIAM tenant to unblock production without waiting for CI:
```powershell
az login --tenant 3a825f01-6e4d-4603-abc7-2ae96417a61e --allow-no-subscriptions
$token = az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv
$objId = az ad app show --id 7a63774b-8210-4648-8cd5-c73fa9ecd388 --query id -o tsv
Invoke-RestMethod -Method Patch -Uri "https://graph.microsoft.com/v1.0/applications/$objId" -Headers @{ Authorization = "Bearer $token"; 'Content-Type' = 'application/json' } -Body '{"api":{"requestedAccessTokenVersion":2}}'
```

## Test plan

- [ ] After applying the fix, add event from `/admin/events` returns 200 (not 401)
- [ ] `setup.ps1` sets `requestedAccessTokenVersion: 2` idempotently on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)