### PR TITLE
fix(auth): refresh CIAM signing keys on validation failure and use OIDC-discovered issuer

### DIFF
--- a/src/api/Slypn.Api/Infrastructure/EntraJwtValidator.cs
+++ b/src/api/Slypn.Api/Infrastructure/EntraJwtValidator.cs
@@ -36,23 +36,38 @@ public sealed class EntraJwtValidator : IJwtValidator
             throw new InvalidOperationException("EntraJwtValidator is not configured.");
 
         var config = await _configManager.GetConfigurationAsync(ct);
+        try
+        {
+            return _handler.ValidateToken(token, BuildParams(config), out _);
+        }
+        catch (SecurityTokenSignatureKeyNotFoundException)
+        {
+            // CIAM may have rotated signing keys since this instance last fetched the JWKS.
+            // Force a refresh and retry once so long-running instances self-heal.
+            _configManager.RequestRefresh();
+            var fresh = await _configManager.GetConfigurationAsync(ct);
+            return _handler.ValidateToken(token, BuildParams(fresh), out _);
+        }
+    }
 
-        // CIAM v2 tokens set `aud` to the bare application GUID, not the
-        // api:// URI. Accept both so either form works in configuration.
-        var audience  = _opts.Audience!;
-        var guidOnly  = audience.StartsWith("api://", StringComparison.OrdinalIgnoreCase)
-                            ? audience["api://".Length..]
-                            : audience;
-        var apiUri    = audience.StartsWith("api://", StringComparison.OrdinalIgnoreCase)
-                            ? audience
-                            : $"api://{audience}";
+    private TokenValidationParameters BuildParams(OpenIdConnectConfiguration config)
+    {
+        var audience = _opts.Audience!;
+        var guidOnly = audience.StartsWith("api://", StringComparison.OrdinalIgnoreCase)
+                           ? audience["api://".Length..] : audience;
+        var apiUri   = audience.StartsWith("api://", StringComparison.OrdinalIgnoreCase)
+                           ? audience : $"api://{audience}";
 
-        var validationParameters = new TokenValidationParameters
+        return new TokenValidationParameters
         {
             ValidateIssuer           = true,
-            ValidIssuers             = _opts.ValidIssuers.Length > 0 ? _opts.ValidIssuers : [ _opts.Authority!.TrimEnd('/') ],
+            // Use the issuer from the OIDC discovery doc, not the authority URL.
+            // For CIAM the discovery issuer uses the tenant-GUID subdomain
+            // (e.g. 3a825f01-....ciamlogin.com) while the configured authority
+            // uses the friendly name (slypn.ciamlogin.com) — they differ.
+            ValidIssuers             = _opts.ValidIssuers.Length > 0 ? _opts.ValidIssuers : [config.Issuer],
             ValidateAudience         = true,
-            ValidAudiences           = [ guidOnly, apiUri ],
+            ValidAudiences           = [guidOnly, apiUri],
             ValidateLifetime         = true,
             ValidateIssuerSigningKey = true,
             IssuerSigningKeys        = config.SigningKeys,
@@ -60,8 +75,5 @@ public sealed class EntraJwtValidator : IJwtValidator
             RoleClaimType            = "roles",
             NameClaimType            = "name",
         };
-
-        var principal = _handler.ValidateToken(token, validationParameters, out _);
-        return principal;
     }
 }


### PR DESCRIPTION
## Root cause

The deployed SWA's Azure Functions instance held a stale `ConfigurationManager` cache. CIAM had rotated the key material for `k9xmStQ8T9T4sE9pnCn_-u4yUss` since the instance last fetched the JWKS, so the cached key no longer matched what CIAM was using to sign tokens. Local worked (freshly started = fresh cache); production failed with IDX10517 on every authenticated request.

## Changes

**Retry-with-refresh on `SecurityTokenSignatureKeyNotFoundException`**
When signature validation fails because no key matches, call `_configManager.RequestRefresh()` and retry once with fresh keys. Long-running instances now self-heal after CIAM key rotations without needing a redeploy.

**Use `config.Issuer` for `ValidIssuers`**
The OIDC discovery doc for `slypn.ciamlogin.com` returns issuer `https://3a825f01-....ciamlogin.com/...` (tenant-GUID subdomain). The old code used the configured authority URL (friendly name) as the valid issuer — these differ and would have caused a follow-on 401 after the signing key issue was resolved.

**Extracted `BuildParams` helper**
Small refactor to avoid duplicating `TokenValidationParameters` construction in the retry path.

## Test plan

- [ ] Merge and wait for SWA deployment to complete
- [ ] Sign in on the production site and confirm API calls return 2xx
- [ ] Confirm local dev still works (SkipAuth mode unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)