### PR TITLE
fix(ci): separate concurrency groups for push and pull_request events

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -20,7 +20,11 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: swa-${{ github.ref }}
+  # Include the event name so that a push to main and a pull_request-closed
+  # event (which share github.ref = refs/heads/main) get separate slots and
+  # don't cancel each other. Multiple pushes to the same branch still cancel
+  # the earlier in-progress run as intended.
+  group: swa-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

Every production deploy since PR #95 has been silently cancelled.

When a PR is merged, GitHub fires two events simultaneously:
- `push` to `main` → triggers `build_and_deploy`
- `pull_request.closed` → triggers `close_pr_environment`

Both have `github.ref = refs/heads/main`, so both joined the same concurrency group (`swa-refs/heads/main`). With `cancel-in-progress: true`, whichever run was queued a few milliseconds later cancelled the other. PRs #96 and #97 both had their production deploys cancelled this way — the auth fixes they shipped never reached production.

## Fix

Append `${{ github.event_name }}` to the concurrency group key:
- Push: `swa-refs/heads/main-push`
- PR close: `swa-refs/heads/main-pull_request`

These no longer compete. Multiple rapid pushes to the same branch still cancel each other as intended.

## Test plan
- [ ] Merge and confirm the `push` run completes successfully (not cancelled)
- [ ] Confirm production site is running the latest code

🤖 Generated with [Claude Code](https://claude.com/claude-code)