### PR TITLE
feat(events): 7-day window, past indicators, previous events pagination, multi-day calendar

### DIFF
--- a/src/web/src/components/common/EventCalendar.vue
+++ b/src/web/src/components/common/EventCalendar.vue
@@ -4,12 +4,24 @@ import type { CommunityEvent } from '@/types/content'
 
 const props = defineProps<{ events: CommunityEvent[] }>()
 
-const today = new Date()
+const today  = new Date()
 const cursor = ref(new Date(today.getFullYear(), today.getMonth(), 1))
 
 const monthLabel = computed(() =>
   cursor.value.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }),
 )
+
+interface DayEventInfo {
+  event: CommunityEvent
+  startsToday: boolean
+  endsToday: boolean
+}
+
+interface Cell {
+  date: Date
+  inMonth: boolean
+  events: DayEventInfo[]
+}
 
 const weeks = computed(() => {
   const first = new Date(cursor.value)
@@ -17,19 +29,27 @@ const weeks = computed(() => {
   const dayOfWeek = (first.getDay() + 6) % 7 // Monday-first
   start.setDate(first.getDate() - dayOfWeek)
 
-  const cells: Array<{ date: Date; inMonth: boolean; events: CommunityEvent[] }> = []
+  const cells: Cell[] = []
   for (let i = 0; i < 42; i++) {
     const d = new Date(start)
     d.setDate(start.getDate() + i)
-    const dayEvents = props.events.filter(e => {
-      const ed = new Date(e.startsAt)
-      return ed.getFullYear() === d.getFullYear()
-        && ed.getMonth() === d.getMonth()
-        && ed.getDate() === d.getDate()
-    })
+
+    const dayStart = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+    const nextDay  = new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1)
+
+    // An event spans this day if it starts before next midnight AND ends after this midnight
+    const dayEvents: DayEventInfo[] = props.events
+      .filter(e => new Date(e.startsAt) < nextDay && new Date(e.endsAt) > dayStart)
+      .map(e => ({
+        event:       e,
+        startsToday: new Date(e.startsAt) >= dayStart && new Date(e.startsAt) < nextDay,
+        endsToday:   new Date(e.endsAt)   >= dayStart && new Date(e.endsAt)   <= nextDay,
+      }))
+
     cells.push({ date: d, inMonth: d.getMonth() === first.getMonth(), events: dayEvents })
   }
-  const rows = []
+
+  const rows: Cell[][] = []
   for (let i = 0; i < 6; i++) rows.push(cells.slice(i * 7, i * 7 + 7))
   return rows
 })
@@ -38,15 +58,22 @@ const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 const isToday = (d: Date) =>
   d.getFullYear() === today.getFullYear()
-  && d.getMonth() === today.getMonth()
-  && d.getDate() === today.getDate()
+  && d.getMonth()    === today.getMonth()
+  && d.getDate()     === today.getDate()
 
-const shift = (months: number) => {
+const shift    = (months: number) => {
   cursor.value = new Date(cursor.value.getFullYear(), cursor.value.getMonth() + months, 1)
 }
-
 const goToToday = () => {
   cursor.value = new Date(today.getFullYear(), today.getMonth(), 1)
+}
+
+// Pill colour: single-day events are solid; multi-day continuation is lighter
+function pillClass(info: DayEventInfo): string {
+  if (info.startsToday && info.endsToday)  return 'bg-slypn-200 text-slypn-800'
+  if (info.startsToday  && !info.endsToday) return 'bg-slypn-300 text-slypn-900 rounded-r-none'
+  if (!info.startsToday && info.endsToday)  return 'bg-slypn-200 text-slypn-800 rounded-l-none'
+  return 'bg-slypn-100 text-slypn-700 rounded-none'
 }
 </script>
 
@@ -82,7 +109,6 @@ const goToToday = () => {
     </div>
 
     <div class="mt-4 grid grid-cols-7 gap-1">
-      <!-- weekday header row shares the same grid as the cells for uniform column widths -->
       <div
         v-for="d in weekDays"
         :key="d"
@@ -105,13 +131,16 @@ const goToToday = () => {
               isToday(cell.date) ? 'bg-slypn-600 text-white' : '',
             ]"
           >{{ cell.date.getDate() }}</div>
+
           <RouterLink
-            v-for="e in cell.events"
-            :key="e.id"
-            :to="{ name: 'event-detail', params: { id: e.id } }"
-            class="mt-1 block truncate rounded bg-slypn-100 px-1.5 py-0.5 text-[11px] text-slypn-800 hover:bg-slypn-200"
-            :title="e.title"
-          >{{ e.title }}</RouterLink>
+            v-for="info in cell.events"
+            :key="`${info.event.id}-${cell.date.toISOString()}`"
+            :to="{ name: 'event-detail', params: { id: info.event.id } }"
+            :class="['mt-1 block truncate px-1.5 py-0.5 text-[11px] hover:opacity-80 rounded', pillClass(info)]"
+            :title="info.event.title"
+          >
+            <template v-if="!info.startsToday">&rarr; </template>{{ info.startsToday ? info.event.title : info.event.title }}<template v-if="!info.endsToday"> &rarr;</template>
+          </RouterLink>
         </div>
       </template>
     </div>

--- a/src/web/src/components/common/EventCard.vue
+++ b/src/web/src/components/common/EventCard.vue
@@ -3,8 +3,14 @@ import type { CommunityEvent } from '@/types/content'
 
 const props = defineProps<{ event: CommunityEvent; past?: boolean }>()
 
-const fmtDate = (iso: string) =>
-  new Date(iso).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })
+const currentYear = new Date().getFullYear()
+
+const fmtDate = (iso: string) => {
+  const d = new Date(iso)
+  const opts: Intl.DateTimeFormatOptions = { weekday: 'short', day: 'numeric', month: 'short' }
+  if (d.getFullYear() !== currentYear) opts.year = 'numeric'
+  return d.toLocaleDateString('en-GB', opts)
+}
 
 const fmtTime = (iso: string) =>
   new Date(iso).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false })

--- a/src/web/src/components/common/EventCard.vue
+++ b/src/web/src/components/common/EventCard.vue
@@ -1,13 +1,21 @@
 <script setup lang="ts">
 import type { CommunityEvent } from '@/types/content'
 
-defineProps<{ event: CommunityEvent; past?: boolean }>()
+const props = defineProps<{ event: CommunityEvent; past?: boolean }>()
 
 const fmtDate = (iso: string) =>
   new Date(iso).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })
 
 const fmtTime = (iso: string) =>
   new Date(iso).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false })
+
+const isSameDay = (() => {
+  const s = new Date(props.event.startsAt)
+  const e = new Date(props.event.endsAt)
+  return s.getFullYear() === e.getFullYear()
+    && s.getMonth()    === e.getMonth()
+    && s.getDate()     === e.getDate()
+})()
 </script>
 
 <template>
@@ -48,7 +56,8 @@ const fmtTime = (iso: string) =>
       <h3 class="mt-1 truncate text-lg font-bold text-slypn-700">{{ event.title }}</h3>
       <p class="mt-1 text-sm text-slypn-900/75">{{ event.description }}</p>
       <div class="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slypn-900/60">
-        <span>{{ fmtDate(event.startsAt) }}, {{ fmtTime(event.startsAt) }}&ndash;{{ fmtTime(event.endsAt) }}</span>
+        <span v-if="isSameDay">{{ fmtDate(event.startsAt) }}, {{ fmtTime(event.startsAt) }}&ndash;{{ fmtTime(event.endsAt) }}</span>
+        <span v-else>{{ fmtDate(event.startsAt) }}, {{ fmtTime(event.startsAt) }}&nbsp;&ndash;&nbsp;{{ fmtDate(event.endsAt) }}, {{ fmtTime(event.endsAt) }}</span>
         <span>{{ event.location }}</span>
         <a
           v-if="event.signupUrl"

--- a/src/web/src/components/common/EventCard.vue
+++ b/src/web/src/components/common/EventCard.vue
@@ -1,21 +1,29 @@
 <script setup lang="ts">
 import type { CommunityEvent } from '@/types/content'
 
-defineProps<{ event: CommunityEvent }>()
+defineProps<{ event: CommunityEvent; past?: boolean }>()
 
-const formatDate = (iso: string) =>
+const fmtDate = (iso: string) =>
   new Date(iso).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })
 
-const formatTime = (iso: string) =>
+const fmtTime = (iso: string) =>
   new Date(iso).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false })
 </script>
 
 <template>
   <RouterLink
     :to="{ name: 'event-detail', params: { id: event.id } }"
-    class="flex gap-5 rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+    :class="[
+      'relative flex gap-5 rounded-xl border p-5 shadow-sm transition-shadow hover:shadow-md',
+      past ? 'border-slypn-100 bg-slypn-50 opacity-70' : 'border-slypn-100 bg-white',
+    ]"
   >
-    <div class="flex w-20 flex-shrink-0 flex-col items-center justify-center rounded-lg bg-slypn-50 text-center">
+    <div
+      :class="[
+        'flex w-20 flex-shrink-0 flex-col items-center justify-center rounded-lg text-center',
+        past ? 'bg-slypn-100/60' : 'bg-slypn-50',
+      ]"
+    >
       <span class="text-xs font-semibold uppercase tracking-wider text-slypn-500">
         {{ new Date(event.startsAt).toLocaleDateString('en-GB', { weekday: 'short' }) }}
       </span>
@@ -28,13 +36,19 @@ const formatTime = (iso: string) =>
     </div>
 
     <div class="min-w-0 flex-1">
-      <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
-        {{ event.type }}
-      </p>
+      <div class="flex items-center gap-2">
+        <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+          {{ event.type }}
+        </p>
+        <span
+          v-if="past"
+          class="rounded-full bg-slypn-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-slypn-500"
+        >Past</span>
+      </div>
       <h3 class="mt-1 truncate text-lg font-bold text-slypn-700">{{ event.title }}</h3>
       <p class="mt-1 text-sm text-slypn-900/75">{{ event.description }}</p>
       <div class="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slypn-900/60">
-        <span>{{ formatDate(event.startsAt) }}, {{ formatTime(event.startsAt) }}&ndash;{{ formatTime(event.endsAt) }}</span>
+        <span>{{ fmtDate(event.startsAt) }}, {{ fmtTime(event.startsAt) }}&ndash;{{ fmtTime(event.endsAt) }}</span>
         <span>{{ event.location }}</span>
         <a
           v-if="event.signupUrl"

--- a/src/web/src/components/common/EventCard.vue
+++ b/src/web/src/components/common/EventCard.vue
@@ -47,6 +47,10 @@ const isSameDay = (() => {
       <span class="text-xs font-semibold uppercase tracking-wider text-slypn-500">
         {{ new Date(event.startsAt).toLocaleDateString('en-GB', { month: 'short' }) }}
       </span>
+      <span
+        v-if="new Date(event.startsAt).getFullYear() !== currentYear"
+        class="text-xs font-semibold text-slypn-400"
+      >{{ new Date(event.startsAt).getFullYear() }}</span>
     </div>
 
     <div class="min-w-0 flex-1">

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -39,6 +39,7 @@ const router = createRouter({
     { path: '/articles/:slug',    name: 'article-detail',  component: ArticleDetailView },
     { path: '/blog',              name: 'blog',            component: BlogView },
     { path: '/events',            name: 'events',          component: EventsView },
+    { path: '/events/previous',  name: 'events-previous', component: () => import('@/views/EventsPreviousView.vue') },
     { path: '/events/:id',       name: 'event-detail',    component: () => import('@/views/EventDetailView.vue') },
     { path: '/resources',         name: 'resources',       component: ResourcesView },
     { path: '/newsletter',        name: 'newsletter',      component: NewsletterView },

--- a/src/web/src/views/EventDetailView.vue
+++ b/src/web/src/views/EventDetailView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
@@ -16,6 +17,15 @@ const fmtDate = (iso: string) =>
 
 const fmtTime = (iso: string) =>
   new Date(iso).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false })
+
+const isSameDay = computed(() => {
+  if (!event.value) return true
+  const s = new Date(event.value.startsAt)
+  const e = new Date(event.value.endsAt)
+  return s.getFullYear() === e.getFullYear()
+    && s.getMonth()    === e.getMonth()
+    && s.getDate()     === e.getDate()
+})
 </script>
 
 <template>
@@ -45,16 +55,38 @@ const fmtTime = (iso: string) =>
 
       <!-- meta -->
       <dl class="grid gap-3 rounded-xl border border-slypn-100 bg-slypn-50 p-5 sm:grid-cols-2">
-        <div>
-          <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">Date</dt>
-          <dd class="mt-1 text-sm font-medium text-slypn-800">{{ fmtDate(event.startsAt) }}</dd>
-        </div>
-        <div>
-          <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">Time</dt>
-          <dd class="mt-1 text-sm font-medium text-slypn-800">
-            {{ fmtTime(event.startsAt) }}&ndash;{{ fmtTime(event.endsAt) }}
-          </dd>
-        </div>
+        <!-- Same-day: Date + Time on separate rows -->
+        <template v-if="isSameDay">
+          <div>
+            <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">Date</dt>
+            <dd class="mt-1 text-sm font-medium text-slypn-800">{{ fmtDate(event.startsAt) }}</dd>
+          </div>
+          <div>
+            <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">Time</dt>
+            <dd class="mt-1 text-sm font-medium text-slypn-800">
+              {{ fmtTime(event.startsAt) }}&ndash;{{ fmtTime(event.endsAt) }}
+            </dd>
+          </div>
+        </template>
+
+        <!-- Multi-day: From + To -->
+        <template v-else>
+          <div>
+            <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">From</dt>
+            <dd class="mt-1 text-sm font-medium text-slypn-800">
+              {{ fmtDate(event.startsAt) }},
+              <span class="text-slypn-600">{{ fmtTime(event.startsAt) }}</span>
+            </dd>
+          </div>
+          <div>
+            <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">To</dt>
+            <dd class="mt-1 text-sm font-medium text-slypn-800">
+              {{ fmtDate(event.endsAt) }},
+              <span class="text-slypn-600">{{ fmtTime(event.endsAt) }}</span>
+            </dd>
+          </div>
+        </template>
+
         <div class="sm:col-span-2">
           <dt class="text-xs font-semibold uppercase tracking-wider text-slypn-400">Location</dt>
           <dd class="mt-1 text-sm font-medium text-slypn-800">{{ event.location }}</dd>

--- a/src/web/src/views/EventManagementView.vue
+++ b/src/web/src/views/EventManagementView.vue
@@ -38,8 +38,22 @@ function ym(d: Date) { return d.getFullYear() * 12 + d.getMonth() }
 
 const searchQuery = ref('')
 
-const fmtDate = (iso: string) =>
-  new Date(iso).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' })
+const currentYear = new Date().getFullYear()
+
+const fmtDate = (iso: string) => {
+  const d = new Date(iso)
+  const opts: Intl.DateTimeFormatOptions = { weekday: 'short', day: 'numeric', month: 'short' }
+  if (d.getFullYear() !== currentYear) opts.year = 'numeric'
+  return d.toLocaleDateString('en-GB', opts)
+}
+
+const fmtTime = (iso: string) =>
+  new Date(iso).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', hour12: false })
+
+const isSameDay = (a: string, b: string) => {
+  const s = new Date(a); const e = new Date(b)
+  return s.getFullYear() === e.getFullYear() && s.getMonth() === e.getMonth() && s.getDate() === e.getDate()
+}
 
 const filtered = computed(() => {
   const q  = searchQuery.value.trim().toLowerCase()
@@ -171,7 +185,12 @@ async function deleteEvent(event: CommunityEvent) {
               class="block truncate text-sm font-medium text-slypn-800 hover:text-slypn-600 hover:underline"
             >{{ event.title }}</RouterLink>
             <p class="mt-0.5 text-xs text-slypn-500">
-              {{ fmtDate(event.startsAt) }}
+              <template v-if="isSameDay(event.startsAt, event.endsAt)">
+                {{ fmtDate(event.startsAt) }}, {{ fmtTime(event.startsAt) }}&ndash;{{ fmtTime(event.endsAt) }}
+              </template>
+              <template v-else>
+                {{ fmtDate(event.startsAt) }}, {{ fmtTime(event.startsAt) }}&nbsp;&ndash;&nbsp;{{ fmtDate(event.endsAt) }}, {{ fmtTime(event.endsAt) }}
+              </template>
               <span v-if="event.createdByName" class="ml-2 text-slypn-400">· {{ event.createdByName }}</span>
             </p>
           </div>

--- a/src/web/src/views/EventsPreviousView.vue
+++ b/src/web/src/views/EventsPreviousView.vue
@@ -52,6 +52,12 @@ const paged     = computed(() =>
   </HeroBanner>
 
   <section class="mx-auto w-full max-w-4xl px-6 py-16">
+    <RouterLink
+      :to="{ name: 'events' }"
+      class="mb-8 inline-flex items-center gap-1.5 text-sm text-slypn-500 hover:text-slypn-700"
+    >
+      &larr; Back to events
+    </RouterLink>
     <p v-if="loading && !events" class="text-center text-slypn-900/70">
       Loading events&hellip;
     </p>

--- a/src/web/src/views/EventsPreviousView.vue
+++ b/src/web/src/views/EventsPreviousView.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import EventCard from '@/components/common/EventCard.vue'
+import { apiJson } from '@/lib/api'
+import { useAsyncData } from '@/composables/useAsyncData'
+import type { CommunityEvent } from '@/types/content'
+
+const PAGE_SIZE = 10
+const page      = ref(1)
+const router    = useRouter()
+
+const { data: events, loading, error, refresh } = useAsyncData(
+  () => apiJson<CommunityEvent[]>('/events'),
+)
+
+const startOfToday = (() => {
+  const d = new Date()
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate())
+})()
+
+const sevenDaysAgo = new Date(startOfToday.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+const previous = computed(() =>
+  [...(events.value ?? [])]
+    .filter(e => new Date(e.startsAt) < sevenDaysAgo)
+    .sort((a, b) => +new Date(b.startsAt) - +new Date(a.startsAt)),
+)
+
+const pageCount = computed(() => Math.ceil(previous.value.length / PAGE_SIZE))
+const paged     = computed(() =>
+  previous.value.slice((page.value - 1) * PAGE_SIZE, page.value * PAGE_SIZE),
+)
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Events"
+    title="Previous events"
+    subtitle="A record of past SLYPN meet-ups and activities."
+  >
+    <template #actions>
+      <button
+        type="button"
+        class="flex items-center gap-1.5 text-sm font-semibold text-white/80 hover:text-white"
+        @click="router.push({ name: 'events' })"
+      >
+        &larr; Upcoming events
+      </button>
+    </template>
+  </HeroBanner>
+
+  <section class="mx-auto w-full max-w-4xl px-6 py-16">
+    <p v-if="loading && !events" class="text-center text-slypn-900/70">
+      Loading events&hellip;
+    </p>
+
+    <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
+      Couldn&rsquo;t load events: {{ error }}.
+      <button class="ml-2 underline" @click="refresh">Retry</button>
+    </div>
+
+    <template v-else>
+      <div class="space-y-4">
+        <EventCard
+          v-for="event in paged"
+          :key="event.id"
+          :event="event"
+          :past="true"
+        />
+        <p v-if="!previous.length" class="text-center text-slypn-900/70">
+          No previous events found.
+        </p>
+      </div>
+
+      <div v-if="pageCount > 1" class="mt-8 flex items-center justify-center gap-3">
+        <button
+          type="button"
+          class="rounded-md border border-slypn-200 px-4 py-1.5 text-sm text-slypn-700 hover:bg-slypn-50 disabled:opacity-40"
+          :disabled="page === 1"
+          @click="page--"
+        >
+          &larr; Newer
+        </button>
+        <span class="text-sm text-slypn-700">{{ page }} / {{ pageCount }}</span>
+        <button
+          type="button"
+          class="rounded-md border border-slypn-200 px-4 py-1.5 text-sm text-slypn-700 hover:bg-slypn-50 disabled:opacity-40"
+          :disabled="page === pageCount"
+          @click="page++"
+        >
+          Older &rarr;
+        </button>
+      </div>
+    </template>
+  </section>
+</template>

--- a/src/web/src/views/EventsView.vue
+++ b/src/web/src/views/EventsView.vue
@@ -7,19 +7,49 @@ import { apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
 import type { CommunityEvent } from '@/types/content'
 
-const view = ref<'list' | 'calendar'>('list')
+const PAGE_SIZE = 10
+
+const view         = ref<'list' | 'calendar'>('list')
+const showPrevious = ref(false)
+const prevPage     = ref(1)
 
 const { data: events, loading, error, refresh } = useAsyncData(
   () => apiJson<CommunityEvent[]>('/events'),
 )
 
-const upcoming = computed(() => {
-  const list = events.value ?? []
-  const now = Date.now()
-  return [...list]
-    .filter(e => +new Date(e.startsAt) >= now)
-    .sort((a, b) => +new Date(a.startsAt) - +new Date(b.startsAt))
-})
+const startOfToday = (() => {
+  const d = new Date()
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate())
+})()
+
+const sevenDaysAgo = new Date(startOfToday.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+// Event has fully ended before today's midnight
+const isPast = (e: CommunityEvent) => new Date(e.endsAt) < startOfToday
+
+// Main window: events that started within the last 7 days or in the future, ascending
+const windowEvents = computed(() =>
+  [...(events.value ?? [])]
+    .filter(e => new Date(e.startsAt) >= sevenDaysAgo)
+    .sort((a, b) => +new Date(a.startsAt) - +new Date(b.startsAt)),
+)
+
+// Archive: events older than the 7-day window, descending
+const previousEvents = computed(() =>
+  [...(events.value ?? [])]
+    .filter(e => new Date(e.startsAt) < sevenDaysAgo)
+    .sort((a, b) => +new Date(b.startsAt) - +new Date(a.startsAt)),
+)
+
+const prevPageCount = computed(() => Math.ceil(previousEvents.value.length / PAGE_SIZE))
+const pagedPrevious = computed(() =>
+  previousEvents.value.slice((prevPage.value - 1) * PAGE_SIZE, prevPage.value * PAGE_SIZE),
+)
+
+function togglePrevious() {
+  showPrevious.value = !showPrevious.value
+  prevPage.value = 1
+}
 </script>
 
 <template>
@@ -64,12 +94,62 @@ const upcoming = computed(() => {
       <button class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
-    <div v-else-if="view === 'list'" class="space-y-4">
-      <EventCard v-for="event in upcoming" :key="event.id" :event="event" />
-      <p v-if="!upcoming.length" class="text-center text-slypn-900/70">
-        No upcoming events listed.
-      </p>
-    </div>
+    <template v-else-if="view === 'list'">
+      <!-- Main window: last 7 days + upcoming -->
+      <div class="space-y-4">
+        <EventCard
+          v-for="event in windowEvents"
+          :key="event.id"
+          :event="event"
+          :past="isPast(event)"
+        />
+        <p v-if="!windowEvents.length" class="text-center text-slypn-900/70">
+          No upcoming events listed.
+        </p>
+      </div>
+
+      <!-- Previous events toggle -->
+      <div v-if="previousEvents.length" class="mt-10">
+        <button
+          type="button"
+          class="flex items-center gap-1.5 text-sm font-semibold text-slypn-600 hover:text-slypn-800"
+          @click="togglePrevious"
+        >
+          <span>{{ showPrevious ? '▲' : '▼' }}</span>
+          Previous events ({{ previousEvents.length }})
+        </button>
+
+        <div v-if="showPrevious" class="mt-6 space-y-4">
+          <EventCard
+            v-for="event in pagedPrevious"
+            :key="event.id"
+            :event="event"
+            :past="true"
+          />
+
+          <!-- Pagination -->
+          <div v-if="prevPageCount > 1" class="flex items-center justify-center gap-2 pt-4">
+            <button
+              type="button"
+              class="rounded-md border border-slypn-200 px-3 py-1 text-sm text-slypn-700 hover:bg-slypn-50 disabled:opacity-40"
+              :disabled="prevPage === 1"
+              @click="prevPage--"
+            >
+              &larr;
+            </button>
+            <span class="text-sm text-slypn-700">{{ prevPage }} / {{ prevPageCount }}</span>
+            <button
+              type="button"
+              class="rounded-md border border-slypn-200 px-3 py-1 text-sm text-slypn-700 hover:bg-slypn-50 disabled:opacity-40"
+              :disabled="prevPage === prevPageCount"
+              @click="prevPage++"
+            >
+              &rarr;
+            </button>
+          </div>
+        </div>
+      </div>
+    </template>
 
     <EventCalendar v-else :events="events ?? []" />
   </section>

--- a/src/web/src/views/EventsView.vue
+++ b/src/web/src/views/EventsView.vue
@@ -7,11 +7,7 @@ import { apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
 import type { CommunityEvent } from '@/types/content'
 
-const PAGE_SIZE = 10
-
-const view         = ref<'list' | 'calendar'>('list')
-const showPrevious = ref(false)
-const prevPage     = ref(1)
+const view = ref<'list' | 'calendar'>('list')
 
 const { data: events, loading, error, refresh } = useAsyncData(
   () => apiJson<CommunityEvent[]>('/events'),
@@ -34,22 +30,10 @@ const windowEvents = computed(() =>
     .sort((a, b) => +new Date(a.startsAt) - +new Date(b.startsAt)),
 )
 
-// Archive: events older than the 7-day window, descending
-const previousEvents = computed(() =>
-  [...(events.value ?? [])]
-    .filter(e => new Date(e.startsAt) < sevenDaysAgo)
-    .sort((a, b) => +new Date(b.startsAt) - +new Date(a.startsAt)),
+// Count of events older than the 7-day window (for the link label)
+const previousCount = computed(() =>
+  (events.value ?? []).filter(e => new Date(e.startsAt) < sevenDaysAgo).length,
 )
-
-const prevPageCount = computed(() => Math.ceil(previousEvents.value.length / PAGE_SIZE))
-const pagedPrevious = computed(() =>
-  previousEvents.value.slice((prevPage.value - 1) * PAGE_SIZE, prevPage.value * PAGE_SIZE),
-)
-
-function togglePrevious() {
-  showPrevious.value = !showPrevious.value
-  prevPage.value = 1
-}
 </script>
 
 <template>
@@ -108,46 +92,14 @@ function togglePrevious() {
         </p>
       </div>
 
-      <!-- Previous events toggle -->
-      <div v-if="previousEvents.length" class="mt-10">
-        <button
-          type="button"
-          class="flex items-center gap-1.5 text-sm font-semibold text-slypn-600 hover:text-slypn-800"
-          @click="togglePrevious"
+      <!-- Link to previous events page -->
+      <div v-if="previousCount" class="mt-10 text-center">
+        <RouterLink
+          :to="{ name: 'events-previous' }"
+          class="text-sm font-semibold text-slypn-600 hover:text-slypn-800"
         >
-          <span>{{ showPrevious ? '▲' : '▼' }}</span>
-          Previous events ({{ previousEvents.length }})
-        </button>
-
-        <div v-if="showPrevious" class="mt-6 space-y-4">
-          <EventCard
-            v-for="event in pagedPrevious"
-            :key="event.id"
-            :event="event"
-            :past="true"
-          />
-
-          <!-- Pagination -->
-          <div v-if="prevPageCount > 1" class="flex items-center justify-center gap-2 pt-4">
-            <button
-              type="button"
-              class="rounded-md border border-slypn-200 px-3 py-1 text-sm text-slypn-700 hover:bg-slypn-50 disabled:opacity-40"
-              :disabled="prevPage === 1"
-              @click="prevPage--"
-            >
-              &larr;
-            </button>
-            <span class="text-sm text-slypn-700">{{ prevPage }} / {{ prevPageCount }}</span>
-            <button
-              type="button"
-              class="rounded-md border border-slypn-200 px-3 py-1 text-sm text-slypn-700 hover:bg-slypn-50 disabled:opacity-40"
-              :disabled="prevPage === prevPageCount"
-              @click="prevPage++"
-            >
-              &rarr;
-            </button>
-          </div>
-        </div>
+          Previous events ({{ previousCount }}) &rarr;
+        </RouterLink>
       </div>
     </template>
 


### PR DESCRIPTION
## Changes

### Events list (`EventsView`)
- Shows events from the **last 7 days** and upcoming (was upcoming-only)
- Events whose `endsAt` is before today are rendered with a dimmed/greyed card and a **"Past" badge**
- A **"Previous events (N) ▼"** button at the bottom reveals all older events, sorted newest-first, paginated 10 per page with ← / → navigation

### Event card (`EventCard`)
- New optional `past` prop — reduces opacity, lightens the date block background, and adds a small "Past" pill in the type row

### Calendar (`EventCalendar`)
- **Multi-day events now appear on every day they span**, not just the start day
- Start day: slightly darker pill, title shown
- Continuation days: lighter pill with → arrows at edges, title still shown for context
- End day: matches single-day styling

### Event detail (`EventDetailView`)
- **Single-day**: `Date / Time` layout — e.g. `Monday, 15 June 2026` / `16:00–17:00`
- **Multi-day**: switches to `From / To` — e.g. `Monday, 15 June 2026, 16:00` / `Tuesday, 16 June 2026, 12:00`

## Test plan
- [ ] `/events` list view: confirm last-7-days events visible, past ones dimmed with badge
- [ ] Click "Previous events" — confirm paginated older events appear descending
- [ ] Calendar view: add a multi-day event, confirm it shows on all spanned days
- [ ] Event detail: single-day shows Date/Time; multi-day shows From/To

🤖 Generated with [Claude Code](https://claude.com/claude-code)