### PR TITLE
fix(ci): ESM import in tailwind.config, nullable body in AllowSignup

### DIFF
--- a/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
+++ b/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
@@ -48,7 +48,7 @@ public sealed class AuthExtensionFunctions(
         string? email;
         try
         {
-            var body = await req.ReadAsStringAsync();
+            var body = await req.ReadAsStringAsync() ?? string.Empty;
             var node = JsonNode.Parse(body);
             email = node?["data"]?["userDetails"]?["mail"]?.GetValue<string>();
             log.LogInformation("AllowSignup: parsed email={Email}", email);

--- a/src/web/tailwind.config.ts
+++ b/src/web/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss'
+import typography from '@tailwindcss/typography'
 
 export default {
   content: ['./index.html', './src/**/*.{vue,ts,tsx}'],
@@ -26,5 +27,5 @@ export default {
       },
     },
   },
-  plugins: [require('@tailwindcss/typography')],
+  plugins: [typography],
 } satisfies Config


### PR DESCRIPTION
Fixes the two CI failures introduced by the merged PR #103:

- `tailwind.config.ts`: replace `require('@tailwindcss/typography')` with an ESM `import` to satisfy the `@typescript-eslint/no-require-imports` lint rule
- `AuthExtensionFunctions.cs`: null-coalesce `ReadAsStringAsync()` to suppress the nullable reference warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)