### PR TITLE
fix(otel): wire Grafana OTLP telemetry (logs, traces, metrics)

### DIFF
--- a/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
+++ b/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
@@ -49,7 +49,6 @@ public sealed class AuthExtensionFunctions(
         try
         {
             var body = await req.ReadAsStringAsync() ?? string.Empty;
-            log.LogInformation("AllowSignup: raw body={Body}", body);
             var node = JsonNode.Parse(body);
             email = node?["data"]?["userDetails"]?["mail"]?.GetValue<string>()
                  ?? node?["data"]?["attributes"]?["email"]?.GetValue<string>();

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -37,7 +37,7 @@ var host = new HostBuilder()
             o.IncludeFormattedMessage = true;
             o.AddOtlpExporter(opts =>
             {
-                opts.Endpoint = new Uri(otelOpts.Endpoint!);
+                opts.Endpoint = new Uri(otelOpts.Endpoint!.TrimEnd('/') + "/v1/logs");
                 opts.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
                 if (!string.IsNullOrWhiteSpace(otelOpts.Headers))
                     opts.Headers = otelOpts.Headers;
@@ -94,9 +94,13 @@ var host = new HostBuilder()
 
         if (otelOpts.IsConfigured)
         {
-            void ConfigureExporter(OpenTelemetry.Exporter.OtlpExporterOptions options)
+            // OTel .NET 1.9+: setting Endpoint programmatically disables auto path-appending,
+            // so each signal needs its explicit /v1/* suffix.
+            var baseEndpoint = otelOpts.Endpoint!.TrimEnd('/');
+
+            void ConfigureExporter(string signalPath, OpenTelemetry.Exporter.OtlpExporterOptions options)
             {
-                options.Endpoint = new Uri(otelOpts.Endpoint!);
+                options.Endpoint = new Uri(baseEndpoint + signalPath);
                 options.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
                 if (!string.IsNullOrWhiteSpace(otelOpts.Headers))
                     options.Headers = otelOpts.Headers;
@@ -111,12 +115,12 @@ var host = new HostBuilder()
                     .AddSource(OtelSources.ApiName)
                     .AddSource("Azure.*")
                     .AddHttpClientInstrumentation()
-                    .AddOtlpExporter(ConfigureExporter))
+                    .AddOtlpExporter(opts => ConfigureExporter("/v1/traces", opts)))
                 .WithMetrics(metrics => metrics
                     .AddMeter("Slypn.Api")
                     .AddRuntimeInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddOtlpExporter(ConfigureExporter));
+                    .AddOtlpExporter(opts => ConfigureExporter("/v1/metrics", opts)));
         }
     })
     .Build();


### PR DESCRIPTION
## Summary

- Wires the Grafana Cloud OTLP gateway for logs, traces, and metrics in the isolated worker host
- Moves the log exporter into `ConfigureLogging` so it attaches to the Functions host's `ILoggerFactory`
- Fixes a silent 404 caused by OTel .NET 1.9+ disabling automatic signal-path appending when endpoints are set programmatically — each exporter now receives the explicit `/v1/logs`, `/v1/traces`, or `/v1/metrics` suffix

## Test plan

- [x] `slypn-api` appears as `service_name` in Grafana Prometheus (metrics flowing)
- [x] Loki labels (`service_name`, `deployment_environment`) populated (logs flowing)
- [x] No `[OTEL-EVENT] HttpRequestFailed` errors in func console after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)