### PR TITLE
fix(auth): render friendly CIAM block page for uninvited sign-ups

### DIFF
--- a/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
+++ b/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
@@ -90,7 +90,8 @@ public sealed class AuthExtensionFunctions(
 
         log.LogInformation("AllowSignup: blocking uninvited email {Email}", email);
         return await Block(req,
-            "You haven't been invited to SLYPN. Please ask an admin to invite you.");
+            "You haven't been invited to SLYPN yet. Ask a SLYPN admin to send you an invite, then sign up with the same email address.",
+            title: "You need an invite");
     }
 
     private static string? ExtractBearer(HttpRequestData req)
@@ -109,18 +110,19 @@ public sealed class AuthExtensionFunctions(
         resp.Headers.Add("Content-Type", "application/json");
         await resp.WriteStringAsync(CiamJson(new JsonObject
         {
-            ["@odata.type"] = "microsoft.graph.attributeCollectionStartContinue",
+            ["@odata.type"] = "microsoft.graph.attributeCollectionStart.continueWithDefaultBehavior",
         }));
         return resp;
     }
 
-    private static async Task<HttpResponseData> Block(HttpRequestData req, string message)
+    private static async Task<HttpResponseData> Block(HttpRequestData req, string message, string title = "Sign-up unavailable")
     {
         var resp = req.CreateResponse(System.Net.HttpStatusCode.OK);
         resp.Headers.Add("Content-Type", "application/json");
         await resp.WriteStringAsync(CiamJson(new JsonObject
         {
-            ["@odata.type"] = "microsoft.graph.attributeCollectionStartShowBlockPage",
+            ["@odata.type"] = "microsoft.graph.attributeCollectionStart.showBlockPage",
+            ["title"]       = title,
             ["message"]     = message,
         }));
         return resp;


### PR DESCRIPTION
## Why
Uninvited users hit a raw Microsoft error page (`AADSTS1100001 / Underlying error code 1003003`) instead of our block message. The `OnAttributeCollectionStart` response used malformed action `@odata.type` strings, so CIAM couldn't parse the response and fell back to the generic error.

This was authored on the migration branch but landed after #108 was squash-merged, so it didn't make it onto `main`.

## Fix
Use the documented CIAM action contract in `AuthExtensionFunctions`:
- `microsoft.graph.attributeCollectionStart.continueWithDefaultBehavior` (was `…attributeCollectionStartContinue`)
- `microsoft.graph.attributeCollectionStart.showBlockPage` + a `title` (was `…attributeCollectionStartShowBlockPage`)

Uninvited users now get a friendly card — title **"You need an invite"** with a message to request an invite and sign up with the same email.

Verified against Microsoft's [OnAttributeCollectionStart return-data reference](https://learn.microsoft.com/en-us/entra/identity-platform/custom-extension-onattributecollectionstart-retrieve-return-data).

## Verification
`dotnet build` clean; API tests 28/28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)