### PR TITLE
fix(auth): read sign-up email from authenticationContext.user

### DIFF
--- a/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
+++ b/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
@@ -47,17 +47,25 @@ public sealed class AuthExtensionFunctions(
         }
 
         // 2. Parse the CIAM event body — identity checks + the email to gate on.
-        // onAttributeCollectionStart fires before the form is submitted, so
-        // data.attributes is empty — the email lives in data.userDetails.mail.
+        // For onAttributeCollectionStart the registering email lives under
+        // data.authenticationContext.user (mail, or the email identity's
+        // issuerAssignedId). Older/other shapes are kept as fallbacks.
         string? email, calloutTenant, calloutExtensionId;
+        string body;
         try
         {
-            var body = await req.ReadAsStringAsync() ?? string.Empty;
+            body = await req.ReadAsStringAsync() ?? string.Empty;
             var data = JsonNode.Parse(body)?["data"];
-            calloutTenant      = data?["tenantId"]?.GetValue<string>();
-            calloutExtensionId = data?["customAuthenticationExtensionId"]?.GetValue<string>();
-            email = data?["userDetails"]?["mail"]?.GetValue<string>()
-                 ?? data?["attributes"]?["email"]?.GetValue<string>();
+            calloutTenant      = Str(data?["tenantId"]);
+            calloutExtensionId = Str(data?["customAuthenticationExtensionId"]);
+
+            var user = data?["authenticationContext"]?["user"];
+            email = Str(user?["mail"])
+                 ?? FirstIdentityEmail(user?["identities"])
+                 ?? Str(data?["userSignUpInfo"]?["attributes"]?["email"]?["value"])
+                 ?? FirstIdentityEmail(data?["userSignUpInfo"]?["identities"])
+                 ?? Str(data?["userDetails"]?["mail"])
+                 ?? Str(data?["attributes"]?["email"]);
             log.LogInformation("AllowSignup: parsed email={Email} tenant={Tenant}", email, calloutTenant);
         }
         catch (Exception ex)
@@ -83,7 +91,10 @@ public sealed class AuthExtensionFunctions(
 
         if (string.IsNullOrWhiteSpace(email))
         {
-            log.LogWarning("AllowSignup: email not found in CIAM payload — blocking");
+            // Log the raw payload (truncated) so an unexpected shape can be
+            // pinpointed without another deploy. Tenant/extension already verified.
+            log.LogWarning("AllowSignup: email not found in CIAM payload — blocking. payload={Payload}",
+                body.Length > 4000 ? body[..4000] : body);
             return await Block(req, "Sign-up unavailable. Please try again later.");
         }
 
@@ -113,6 +124,26 @@ public sealed class AuthExtensionFunctions(
         return await Block(req,
             "You haven't been invited to SLYPN yet. Ask a SLYPN admin to send you an invite, then sign up with the same email address.",
             title: "You need an invite");
+    }
+
+    /// <summary>Reads a JSON node as a string, returning null for missing/non-string nodes.</summary>
+    private static string? Str(JsonNode? node) =>
+        node is JsonValue v && v.TryGetValue<string>(out var s) ? s : null;
+
+    /// <summary>Returns the first identity's email-bearing issuerAssignedId, if any.</summary>
+    private static string? FirstIdentityEmail(JsonNode? identities)
+    {
+        if (identities is not JsonArray arr) return null;
+        foreach (var id in arr)
+        {
+            var signInType = Str(id?["signInType"]);
+            var value = Str(id?["issuerAssignedId"]);
+            if (value is null) continue;
+            if (string.Equals(signInType, "emailAddress", StringComparison.OrdinalIgnoreCase) ||
+                value.Contains('@'))
+                return value;
+        }
+        return null;
     }
 
     /// <summary>Constant-time string comparison to avoid leaking the secret via timing.</summary>


### PR DESCRIPTION
## Problem
After the shared-secret gate went live (#112) and the CIAM extension Target URL was updated with `?k=<secret>`, invited users were still blocked. Grafana showed the callout now passes the secret + tenant checks but fails the next step:

```
AllowSignup: parsed email=(null) tenant=3a825f01-…
AllowSignup: email not found in CIAM payload — blocking
```

The email-extraction paths (`data.userDetails.mail` / `data.attributes.email`) are wrong for the `onAttributeCollectionStart` event — it carries the registering email under `data.authenticationContext.user`, so it parsed as `null` and every invited user was blocked.

## Fix
- Read the email from the correct locations: `authenticationContext.user.mail`, then the email identity's `issuerAssignedId` (`signInType == emailAddress` or an `@`-bearing `issuerAssignedId`), with the previous paths kept as fallbacks.
- Safety net: if the email still can't be found, log the raw payload (truncated to 4 KB) so an unexpected shape can be pinpointed without another deploy.

Build clean, 28/28 tests pass.

## After merge (deploys to prod automatically)
Retry sign-up for an invited address (`qwerty@cookingcode.com`) → expect `AllowSignup: allowing invited email` in Grafana; an uninvited address → "You need an invite".

🤖 Generated with [Claude Code](https://claude.com/claude-code)