### PR TITLE
test: raise web + API unit-test coverage

### DIFF
--- a/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Slypn.Api.Functions;
+using Slypn.Api.Models;
+using Slypn.Api.Services;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class AdminFunctionsTests
+{
+    private static readonly CancellationToken Ct = CancellationToken.None;
+
+    // ── Members ──────────────────────────────────────────────────────────────
+    private static MembersFunctions MembersFn(FakeContentRepository repo) =>
+        new(repo, new FakeInviteService(), new FakeEntraUserService(), NullLogger<MembersFunctions>.Instance);
+
+    private static Member Member(string id = "m1", string? oid = "oidA") =>
+        new(id, "a@b.com", "Alice", new[] { "Member" }, "active", DateTime.UtcNow, Oid: oid) { Etag = "e1" };
+
+    [Fact]
+    public async Task Members_list_disabled_then_ok()
+    {
+        var repo = new FakeContentRepository { Writes = false };
+        var fn = MembersFn(repo);
+        var disabled = (TestHttpResponseData)await fn.List(TestHttp.Get(new TestFunctionContext(), "http://localhost/api/members"), Ct);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, disabled.StatusCode);
+
+        repo.Writes = true;
+        repo.Members.Add(Member());
+        var ok = (TestHttpResponseData)await fn.List(TestHttp.Get(new TestFunctionContext(), "http://localhost/api/members"), Ct);
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+    }
+
+    [Fact]
+    public async Task Members_invite_rejects_bad_role_and_accepts_valid()
+    {
+        var repo = new FakeContentRepository();
+        var fn = MembersFn(repo);
+        var ctx = new TestFunctionContext().WithUser("admin-oid", "Admin", "Admin");
+
+        var bad = (TestHttpResponseData)await fn.Invite(
+            TestHttp.Json(ctx, "POST", "http://localhost/api/members/invite", new { email = "x@y.com", displayName = "X", roles = new[] { "Wizard" } }), ctx, Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
+
+        var ok = (TestHttpResponseData)await fn.Invite(
+            TestHttp.Json(ctx, "POST", "http://localhost/api/members/invite", new { email = "x@y.com", displayName = "X", roles = new[] { "Member" } }), ctx, Ct);
+        Assert.Contains((int)ok.StatusCode, new[] { 200, 201 });
+        Assert.Contains("redeem", ok.ReadBodyAsString());
+    }
+
+    [Fact]
+    public async Task Members_update_roles_404_then_ok()
+    {
+        var repo = new FakeContentRepository();
+        var fn = MembersFn(repo);
+        var notFound = (TestHttpResponseData)await fn.UpdateRoles(
+            TestHttp.Json(new TestFunctionContext(), "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Admin" } }), "m1", Ct);
+        Assert.Equal(HttpStatusCode.NotFound, notFound.StatusCode);
+
+        repo.MemberById = Member();
+        var ok = (TestHttpResponseData)await fn.UpdateRoles(
+            TestHttp.Json(new TestFunctionContext(), "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Contributor" } }), "m1", Ct);
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+    }
+
+    [Fact]
+    public async Task Members_delete_blocks_self_and_allows_other()
+    {
+        var repo = new FakeContentRepository { MemberById = Member(oid: "self-oid") };
+        var fn = MembersFn(repo);
+        var self = new TestFunctionContext().WithUser("self-oid", "Me", "Admin");
+        var blocked = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(self, "DELETE", "http://localhost/api/members/m1", ""), "m1", self, Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, blocked.StatusCode);
+
+        var other = new TestFunctionContext().WithUser("admin-oid", "Admin", "Admin");
+        var ok = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(other, "DELETE", "http://localhost/api/members/m1", ""), "m1", other, Ct);
+        Assert.Equal(HttpStatusCode.NoContent, ok.StatusCode);
+    }
+
+    // ── Drafts ──────────────────────────────────────────────────────────────
+    private static DraftsFunctions DraftsFn(FakeContentRepository repo) =>
+        new(repo, new HtmlSanitizer(), NullLogger<DraftsFunctions>.Instance);
+
+    private static Draft Draft(string id = "d1") =>
+        new(id, "oid-1", "Author", "article", "T", "s", "Sum", "<p>b</p>", "Community", new[] { "x" }, 3, DateTime.UtcNow, DateTime.UtcNow) { Etag = "e1" };
+
+    [Fact]
+    public async Task Drafts_list_requires_oid()
+    {
+        var repo = new FakeContentRepository();
+        var fn = DraftsFn(repo);
+        var noUser = new TestFunctionContext();
+        var bad = (TestHttpResponseData)await fn.List(TestHttp.Get(noUser, "http://localhost/api/drafts"), noUser, Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
+
+        var ctx = new TestFunctionContext().WithUser("oid-1", "A", "Contributor");
+        var ok = (TestHttpResponseData)await fn.List(TestHttp.Get(ctx, "http://localhost/api/drafts"), ctx, Ct);
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+    }
+
+    [Fact]
+    public async Task Drafts_get_404_then_200()
+    {
+        var repo = new FakeContentRepository();
+        var fn = DraftsFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-1", "A", "Contributor");
+        var missing = (TestHttpResponseData)await fn.Get(TestHttp.Get(ctx, "http://localhost/api/drafts/d1"), ctx, "d1", Ct);
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+
+        repo.DraftById = Draft();
+        var ok = (TestHttpResponseData)await fn.Get(TestHttp.Get(ctx, "http://localhost/api/drafts/d1"), ctx, "d1", Ct);
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+    }
+
+    [Fact]
+    public async Task Drafts_upsert_delete_submit()
+    {
+        var repo = new FakeContentRepository();
+        var fn = DraftsFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
+
+        var draftBody = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", tags = new[] { "x" }, readingMinutes = 3 };
+        var upsert = (TestHttpResponseData)await fn.Upsert(TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/d1", draftBody), ctx, "d1", Ct);
+        Assert.Equal(HttpStatusCode.OK, upsert.StatusCode);
+
+        var del = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(ctx, "DELETE", "http://localhost/api/drafts/d1", ""), ctx, "d1", Ct);
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+
+        var submit = (TestHttpResponseData)await fn.Submit(TestHttp.Raw(ctx, "POST", "http://localhost/api/drafts/d1/submit", ""), ctx, "d1", Ct);
+        Assert.Contains((int)submit.StatusCode, new[] { 200, 201 });
+    }
+
+    // ── Media ──────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Media_503_when_unconfigured()
+    {
+        var fn = new MediaFunctions(new FakeBlobService { Configured = false });
+        var resp = (TestHttpResponseData)await fn.Upload(TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/media", ""));
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Media_415_when_not_multipart()
+    {
+        var fn = new MediaFunctions(new FakeBlobService());
+        var req = new TestHttpRequestData(new TestFunctionContext(), "POST", "http://localhost/api/media", "x",
+            new Dictionary<string, string> { ["Content-Type"] = "application/json" });
+        var resp = (TestHttpResponseData)await fn.Upload(req);
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, resp.StatusCode);
+    }
+}

--- a/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Slypn.Api.Functions;
+using Slypn.Api.Models;
+using Slypn.Api.Services;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class ArticlesFunctionsTests
+{
+    private static readonly CancellationToken Ct = CancellationToken.None;
+
+    private static (ArticlesFunctions fn, FakeContentRepository repo) Make()
+    {
+        var repo = new FakeContentRepository();
+        var fn = new ArticlesFunctions(repo, new HtmlSanitizer(), NullLogger<ArticlesFunctions>.Instance);
+        return (fn, repo);
+    }
+
+    private static Article Sample(string id = "a1") =>
+        new(id, "slug", "Title", "Summary", "Body", "Author", DateTime.UtcNow, 5, "Community", new[] { "t" }) { Etag = "e1" };
+
+    [Fact]
+    public async Task GetArticles_returns_200_with_list()
+    {
+        var (fn, repo) = Make();
+        repo.Articles.Add(Sample());
+        var ctx = new TestFunctionContext();
+        var resp = (TestHttpResponseData)await fn.GetArticles(TestHttp.Get(ctx, "http://localhost/api/articles"), Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = resp.ReadBodyAs<List<Article>>();
+        Assert.Single(body!);
+    }
+
+    [Fact]
+    public async Task GetArticleBySlug_returns_404_when_missing()
+    {
+        var (fn, _) = Make();
+        var ctx = new TestFunctionContext();
+        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(TestHttp.Get(ctx, "http://localhost/api/articles/x"), "x", Ct);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetArticleBySlug_returns_200_when_found()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleBySlug = Sample();
+        var ctx = new TestFunctionContext();
+        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(TestHttp.Get(ctx, "http://localhost/api/articles/slug"), "slug", Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_returns_503_when_writes_disabled()
+    {
+        var (fn, repo) = Make();
+        repo.Writes = false;
+        var ctx = new TestFunctionContext();
+        var req = TestHttp.Json(ctx, "POST", "http://localhost/api/articles", new { });
+        var resp = (TestHttpResponseData)await fn.Create(req, Ct);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_returns_400_on_invalid_body()
+    {
+        var (fn, _) = Make();
+        var ctx = new TestFunctionContext();
+        var req = TestHttp.Json(ctx, "POST", "http://localhost/api/articles", new { title = "x" });
+        var resp = (TestHttpResponseData)await fn.Create(req, Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_returns_201_on_valid_body()
+    {
+        var (fn, _) = Make();
+        var ctx = new TestFunctionContext();
+        var input = new
+        {
+            slug = "valid-slug", title = "A valid title", summary = "A long enough summary.",
+            body = "Body content long enough.", author = "Jane", readingMinutes = 5,
+            category = "Community", status = "draft",
+        };
+        var req = TestHttp.Json(ctx, "POST", "http://localhost/api/articles", input);
+        var resp = (TestHttpResponseData)await fn.Create(req, Ct);
+        Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
+        Assert.Equal("new-id", resp.ReadBodyAs<Article>()!.Id);
+    }
+
+    [Fact]
+    public async Task Delete_requires_status_query()
+    {
+        var (fn, _) = Make();
+        var ctx = new TestFunctionContext();
+        var resp = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(ctx, "DELETE", "http://localhost/api/articles/a1", ""), "a1", Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+
+        var ok = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(ctx, "DELETE", "http://localhost/api/articles/a1?status=published", ""), "a1", Ct);
+        Assert.Equal(HttpStatusCode.NoContent, ok.StatusCode);
+    }
+
+    [Fact]
+    public async Task Publish_returns_200()
+    {
+        var (fn, _) = Make();
+        var ctx = new TestFunctionContext();
+        var resp = (TestHttpResponseData)await fn.Publish(TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/publish", ""), "a1", Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Edit_requires_oid_and_returns_201_with_user()
+    {
+        var (fn, _) = Make();
+        var noUser = new TestFunctionContext();
+        var bad = (TestHttpResponseData)await fn.Edit(TestHttp.Raw(noUser, "POST", "http://localhost/api/articles/a1/edit", ""), noUser, "a1", Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
+
+        var withUser = new TestFunctionContext().WithUser("oid-1", "Editor", "Contributor");
+        var ok = (TestHttpResponseData)await fn.Edit(TestHttp.Raw(withUser, "POST", "http://localhost/api/articles/a1/edit", ""), withUser, "a1", Ct);
+        Assert.Contains((int)ok.StatusCode, new[] { 200, 201 });
+    }
+}

--- a/src/api/Slypn.Api.Tests/AuthExtensionFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AuthExtensionFunctionsTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Slypn.Api.Functions;
+using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class AuthExtensionFunctionsTests
+{
+    private static readonly CancellationToken Ct = CancellationToken.None;
+
+    private static AuthExtensionFunctions Make(FakeContentRepository repo, SignupGateOptions? gate = null) =>
+        new(repo, Options.Create(gate ?? new SignupGateOptions()), NullLogger<AuthExtensionFunctions>.Instance);
+
+    private static string Body(string? email, string? tenant = null)
+    {
+        var tenantJson = tenant is null ? "null" : "\"" + tenant + "\"";
+        var mailJson = email is null ? "null" : "\"" + email + "\"";
+        return "{\"data\":{\"tenantId\":" + tenantJson +
+               ",\"authenticationContext\":{\"user\":{\"mail\":" + mailJson + "}}}}";
+    }
+
+    private static string Read(TestHttpResponseData r) => r.ReadBodyAsString();
+
+    [Fact]
+    public async Task Allows_signup_when_storage_unconfigured()
+    {
+        var fn = Make(new FakeContentRepository { Writes = false });
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("a@b.com"));
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+        Assert.Contains("continueWithDefaultBehavior", Read(resp));
+    }
+
+    [Fact]
+    public async Task Allows_invited_email()
+    {
+        var repo = new FakeContentRepository { MemberByEmail = new Member("m1", "a@b.com", "A", new[] { "Member" }, "invited", DateTime.UtcNow) };
+        var fn = Make(repo);
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("a@b.com"));
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+        Assert.Contains("continueWithDefaultBehavior", Read(resp));
+    }
+
+    [Fact]
+    public async Task Blocks_uninvited_email()
+    {
+        var fn = Make(new FakeContentRepository()); // writes enabled, no member
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("nobody@x.com"));
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+        Assert.Contains("showBlockPage", Read(resp));
+    }
+
+    [Fact]
+    public async Task Blocks_when_email_missing()
+    {
+        var fn = Make(new FakeContentRepository { Writes = false });
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body(null));
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+        Assert.Contains("showBlockPage", Read(resp));
+    }
+
+    [Fact]
+    public async Task Blocks_when_shared_secret_mismatches()
+    {
+        var fn = Make(new FakeContentRepository { Writes = false }, new SignupGateOptions { Secret = "expected" });
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup?k=wrong", Body("a@b.com"));
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+        Assert.Contains("showBlockPage", Read(resp));
+    }
+
+    [Fact]
+    public async Task Passes_secret_check_with_correct_key()
+    {
+        var fn = Make(new FakeContentRepository { Writes = false }, new SignupGateOptions { Secret = "expected" });
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup?k=expected", Body("a@b.com"));
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+        Assert.Contains("continueWithDefaultBehavior", Read(resp));
+    }
+
+    [Fact]
+    public async Task Blocks_on_tenant_mismatch()
+    {
+        var fn = Make(new FakeContentRepository { Writes = false }, new SignupGateOptions { TenantId = "expected-tenant" });
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("a@b.com", tenant: "other-tenant"));
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+        Assert.Contains("showBlockPage", Read(resp));
+    }
+}

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -1,0 +1,178 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Slypn.Api.Functions;
+using Slypn.Api.Models;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class ContentFunctionsTests
+{
+    private static readonly CancellationToken Ct = CancellationToken.None;
+
+    private static CommunityEvent Event(string id = "e1", string? createdBy = "owner") => new(
+        id, "Coffee", "Coffee meet-up",
+        new DateTimeOffset(2026, 6, 1, 10, 0, 0, TimeSpan.Zero),
+        new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero),
+        "Brixton", "Come along", null, createdBy, "Owner") { Etag = "e1" };
+
+    private static object ValidEvent() => new
+    {
+        title = "Coffee morning", type = "Coffee meet-up",
+        startsAt = "2026-06-01T10:00:00Z", endsAt = "2026-06-01T12:00:00Z",
+        location = "Brixton", description = "Come along",
+    };
+
+    // ── Blog ──────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Blog_list_returns_200()
+    {
+        var repo = new FakeContentRepository();
+        repo.Blogs.Add(new Article("b1", "s", "T", "Sum", "B", "A", DateTime.UtcNow, 3, "News", new[] { "x" }) { Type = "blog" });
+        var fn = new BlogFunctions(repo);
+        var resp = (TestHttpResponseData)await fn.GetBlogPosts(TestHttp.Get(new TestFunctionContext(), "http://localhost/api/blog"), Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    // ── Events ──────────────────────────────────────────────────────────────────
+    private static EventsFunctions EventsFn(FakeContentRepository repo) =>
+        new(repo, NullLogger<EventsFunctions>.Instance);
+
+    [Fact]
+    public async Task Events_get_returns_404_then_200()
+    {
+        var repo = new FakeContentRepository();
+        var fn = EventsFn(repo);
+        var missing = (TestHttpResponseData)await fn.GetEvent(TestHttp.Get(new TestFunctionContext(), "http://localhost/api/events/x"), "x", Ct);
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+
+        repo.EventById = Event();
+        var found = (TestHttpResponseData)await fn.GetEvent(TestHttp.Get(new TestFunctionContext(), "http://localhost/api/events/e1"), "e1", Ct);
+        Assert.Equal(HttpStatusCode.OK, found.StatusCode);
+    }
+
+    [Fact]
+    public async Task Events_list_returns_200()
+    {
+        var repo = new FakeContentRepository { Events = { Event() } };
+        var fn = EventsFn(repo);
+        var resp = (TestHttpResponseData)await fn.GetEvents(TestHttp.Get(new TestFunctionContext(), "http://localhost/api/events?upcoming=true"), Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Events_create_disabled_then_valid()
+    {
+        var repo = new FakeContentRepository { Writes = false };
+        var fn = EventsFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid", "U", "Contributor");
+        var disabled = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/events", ValidEvent()), ctx, Ct);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, disabled.StatusCode);
+
+        repo.Writes = true;
+        var ok = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/events", ValidEvent()), ctx, Ct);
+        Assert.Contains((int)ok.StatusCode, new[] { 200, 201 });
+    }
+
+    [Fact]
+    public async Task Events_replace_enforces_ownership()
+    {
+        var repo = new FakeContentRepository { EventById = Event(createdBy: "owner") };
+        var fn = EventsFn(repo);
+        // Non-admin, non-owner → forbidden
+        var stranger = new TestFunctionContext().WithUser("stranger", "S", "Contributor");
+        var forbidden = (TestHttpResponseData)await fn.Replace(TestHttp.Json(stranger, "PUT", "http://localhost/api/events/e1", ValidEvent()), "e1", stranger, Ct);
+        Assert.Equal(HttpStatusCode.Forbidden, forbidden.StatusCode);
+
+        // Admin → allowed
+        var admin = new TestFunctionContext().WithUser("admin", "A", "Admin");
+        var ok = (TestHttpResponseData)await fn.Replace(TestHttp.Json(admin, "PUT", "http://localhost/api/events/e1", ValidEvent()), "e1", admin, Ct);
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+    }
+
+    [Fact]
+    public async Task Events_delete_owner_succeeds_and_missing_404()
+    {
+        var repo = new FakeContentRepository();
+        var fn = EventsFn(repo);
+        var owner = new TestFunctionContext().WithUser("owner", "O", "Contributor");
+        var missing = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(owner, "DELETE", "http://localhost/api/events/e1", ""), "e1", owner, Ct);
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+
+        repo.EventById = Event(createdBy: "owner");
+        var ok = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(owner, "DELETE", "http://localhost/api/events/e1", ""), "e1", owner, Ct);
+        Assert.Equal(HttpStatusCode.NoContent, ok.StatusCode);
+    }
+
+    // ── Resources ────────────────────────────────────────────────────────────────
+    private static ResourcesFunctions ResourcesFn(FakeContentRepository repo) =>
+        new(repo, NullLogger<ResourcesFunctions>.Instance);
+
+    [Fact]
+    public async Task Resources_list_and_create_and_delete()
+    {
+        var repo = new FakeContentRepository { Resources = { new Resource("r1", "T", "D", "https://x.org", "NHS") } };
+        var fn = ResourcesFn(repo);
+        var ctx = new TestFunctionContext();
+
+        var list = (TestHttpResponseData)await fn.GetResources(TestHttp.Get(ctx, "http://localhost/api/resources"), Ct);
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+
+        var valid = new { title = "Helpline", description = "Support line", url = "https://x.org/a", category = "NHS" };
+        var created = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/resources", valid), Ct);
+        Assert.Contains((int)created.StatusCode, new[] { 200, 201 });
+
+        var noCat = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(ctx, "DELETE", "http://localhost/api/resources/r1", ""), "r1", Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, noCat.StatusCode);
+
+        var deleted = (TestHttpResponseData)await fn.Delete(TestHttp.Raw(ctx, "DELETE", "http://localhost/api/resources/r1?category=NHS", ""), "r1", Ct);
+        Assert.Equal(HttpStatusCode.NoContent, deleted.StatusCode);
+    }
+
+    // ── Newsletters ──────────────────────────────────────────────────────────────
+    private static NewslettersFunctions NewslettersFn(FakeContentRepository repo) =>
+        new(repo, NullLogger<NewslettersFunctions>.Instance);
+
+    [Fact]
+    public async Task Newsletters_list_create_subscribe()
+    {
+        var repo = new FakeContentRepository { Newsletters = { new Newsletter("n1", "May", new DateOnly(2026, 5, 1), "summary text", new[] { "t" }) } };
+        var fn = NewslettersFn(repo);
+        var ctx = new TestFunctionContext();
+
+        var list = (TestHttpResponseData)await fn.GetNewsletters(TestHttp.Get(ctx, "http://localhost/api/newsletters"), Ct);
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+
+        var valid = new { title = "June 2026", issueDate = "2026-06-01", summary = "A long enough summary.", topics = new[] { "x" } };
+        var created = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/newsletters", valid), Ct);
+        Assert.Contains((int)created.StatusCode, new[] { 200, 201 });
+
+        var sub = (TestHttpResponseData)await fn.Subscribe(TestHttp.Json(ctx, "POST", "http://localhost/api/newsletter/subscribe", new { email = "me@example.com" }), Ct);
+        Assert.Contains((int)sub.StatusCode, new[] { 200, 201 });
+    }
+
+    // ── Me ──────────────────────────────────────────────────────────────────────
+    private static MeSelfFunctions MeFn(FakeContentRepository repo) =>
+        new(repo, NullLogger<MeSelfFunctions>.Instance);
+
+    [Fact]
+    public async Task Me_returns_roles_for_linked_member()
+    {
+        var repo = new FakeContentRepository { MemberByOid = new Member("m1", "a@b.com", "A", new[] { "Admin" }, "active", DateTime.UtcNow, Oid: "oid-1") };
+        var fn = MeFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-1", "A", "Admin");
+        var resp = (TestHttpResponseData)await fn.Get(TestHttp.Get(ctx, "http://localhost/api/me"), ctx, Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("Admin", resp.ReadBodyAsString());
+    }
+
+    [Fact]
+    public async Task Me_returns_empty_when_writes_disabled()
+    {
+        var repo = new FakeContentRepository { Writes = false };
+        var fn = MeFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-1", "A", "Admin");
+        var resp = (TestHttpResponseData)await fn.Get(TestHttp.Get(ctx, "http://localhost/api/me"), ctx, Ct);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+}

--- a/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
@@ -1,0 +1,108 @@
+using Azure.Data.Tables;
+using Slypn.Api.Models.Inputs;
+using Slypn.Api.Services;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+// Storage is unconfigured, so ContentRepository serves reads from MockDataService
+// and rejects all writes / member / draft access via EnsureWrites.
+file sealed class UnconfiguredTableStore : ITableStore
+{
+    public bool IsConfigured => false;
+    public TableClient Articles    => throw new NotSupportedException();
+    public TableClient Drafts      => throw new NotSupportedException();
+    public TableClient Events      => throw new NotSupportedException();
+    public TableClient Resources   => throw new NotSupportedException();
+    public TableClient Newsletters => throw new NotSupportedException();
+    public TableClient Members     => throw new NotSupportedException();
+}
+
+file sealed class NoopBodyStore : IContentBodyStore
+{
+    public bool IsConfigured => false;
+    public Task PutAsync(string prefix, string id, string html, CancellationToken ct) => Task.CompletedTask;
+    public Task<string> GetAsync(string prefix, string id, CancellationToken ct) => Task.FromResult("");
+    public Task DeleteAsync(string prefix, string id, CancellationToken ct) => Task.CompletedTask;
+}
+
+public class ContentRepositoryReadTests
+{
+    private static readonly CancellationToken Ct = CancellationToken.None;
+    private static ContentRepository Repo() =>
+        new(new UnconfiguredTableStore(), new NoopBodyStore(), new MockDataService());
+
+    [Fact]
+    public void SupportsWrites_is_false_when_unconfigured()
+    {
+        Assert.False(Repo().SupportsWrites);
+    }
+
+    [Fact]
+    public async Task Lists_articles_from_mock_data()
+    {
+        var articles = await Repo().ListArticlesAsync(null, Ct);
+        Assert.NotEmpty(articles);
+        Assert.All(articles, a => Assert.Equal("article", a.Type));
+    }
+
+    [Fact]
+    public async Task Filters_articles_by_status()
+    {
+        var published = await Repo().ListArticlesAsync("published", Ct);
+        Assert.All(published, a => Assert.Equal("published", a.Status));
+    }
+
+    [Fact]
+    public async Task Lists_blog_posts_from_mock_data()
+    {
+        var blogs = await Repo().ListBlogPostsAsync(null, Ct);
+        Assert.All(blogs, b => Assert.Equal("blog", b.Type));
+    }
+
+    [Fact]
+    public async Task Gets_article_by_slug_or_id()
+    {
+        var bySlug = await Repo().GetArticleBySlugAsync("working-with-parkinsons", Ct);
+        Assert.NotNull(bySlug);
+        var byId = await Repo().GetArticleBySlugAsync("a1", Ct);
+        Assert.NotNull(byId);
+        var missing = await Repo().GetArticleBySlugAsync("does-not-exist", Ct);
+        Assert.Null(missing);
+    }
+
+    [Fact]
+    public async Task Lists_events_resources_newsletters_from_mock()
+    {
+        var repo = Repo();
+        Assert.NotEmpty(await repo.ListEventsAsync(false, Ct));
+        Assert.NotEmpty(await repo.ListResourcesAsync(Ct));
+        var newsletters = await repo.ListNewslettersAsync(Ct);
+        Assert.NotEmpty(newsletters);
+        // newsletters come back newest-first
+        Assert.True(newsletters[0].IssueDate >= newsletters[^1].IssueDate);
+    }
+
+    [Fact]
+    public async Task GetEventById_returns_null_when_unconfigured()
+    {
+        Assert.Null(await Repo().GetEventByIdAsync("e1", Ct));
+    }
+
+    [Fact]
+    public async Task Writes_throw_when_unconfigured()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Repo().CreateArticleAsync(new ArticleInput(), Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Repo().CreateResourceAsync(new ResourceInput(), Ct));
+    }
+
+    [Fact]
+    public async Task Member_and_draft_reads_throw_when_unconfigured()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().ListMembersAsync(Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().GetMemberByEmailAsync("a@b.com", Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().ListDraftsByAuthorAsync("oid", Ct));
+    }
+}

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -1,0 +1,121 @@
+using Slypn.Api.Models;
+using Slypn.Api.Models.Inputs;
+using Slypn.Api.Services;
+
+namespace Slypn.Api.Tests;
+
+/// <summary>
+/// Hand-rolled in-memory IContentRepository for Function unit tests. Reads return
+/// the seeded lists; writes echo a constructed entity. Toggle <see cref="Writes"/>
+/// to exercise the "writes disabled" branches.
+/// </summary>
+internal sealed class FakeContentRepository : IContentRepository
+{
+    public bool Writes = true;
+    public bool SupportsWrites => Writes;
+
+    public List<Article> Articles = new();
+    public List<Article> Blogs = new();
+    public Article? ArticleBySlug;
+    public List<CommunityEvent> Events = new();
+    public CommunityEvent? EventById;
+    public List<Resource> Resources = new();
+    public List<Newsletter> Newsletters = new();
+    public List<Member> Members = new();
+    public Member? MemberByEmail;
+    public Member? MemberByOid;
+    public Member? MemberById;
+    public List<Draft> Drafts = new();
+    public Draft? DraftById;
+
+    /// <summary>Set to throw from the next write to exercise error mapping.</summary>
+    public Exception? ThrowOnWrite;
+
+    private T Guard<T>(T value)
+    {
+        if (ThrowOnWrite is not null) throw ThrowOnWrite;
+        return value;
+    }
+
+    public Task<IReadOnlyList<Article>> ListArticlesAsync(string? status, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<Article>>(Articles);
+    public Task<IReadOnlyList<Article>> ListBlogPostsAsync(string? status, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<Article>>(Blogs);
+    public Task<Article?> GetArticleBySlugAsync(string slug, CancellationToken ct)
+        => Task.FromResult(ArticleBySlug);
+    public Task<IReadOnlyList<CommunityEvent>> ListEventsAsync(bool upcomingOnly, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<CommunityEvent>>(Events);
+    public Task<CommunityEvent?> GetEventByIdAsync(string id, CancellationToken ct)
+        => Task.FromResult(EventById);
+    public Task<IReadOnlyList<Resource>> ListResourcesAsync(CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<Resource>>(Resources);
+    public Task<IReadOnlyList<Newsletter>> ListNewslettersAsync(CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<Newsletter>>(Newsletters);
+
+    public Task<Article> CreateArticleAsync(ArticleInput input, CancellationToken ct)
+        => Task.FromResult(Guard(MakeArticle("new-id", input)));
+    public Task<Article> ReplaceArticleAsync(string id, ArticleInput input, string? ifMatch, CancellationToken ct)
+        => Task.FromResult(Guard(MakeArticle(id, input)));
+    public Task DeleteArticleAsync(string id, string status, string? ifMatch, CancellationToken ct)
+        => Guard(Task.CompletedTask);
+
+    public Task<CommunityEvent> CreateEventAsync(EventInput input, string? oid, string? name, CancellationToken ct)
+        => Task.FromResult(Guard(MakeEvent("new-id", input, oid, name)));
+    public Task<CommunityEvent> ReplaceEventAsync(string id, string oldYm, EventInput input, string? oid, string? name, string? ifMatch, CancellationToken ct)
+        => Task.FromResult(Guard(MakeEvent(id, input, oid, name)));
+    public Task DeleteEventAsync(string id, string yearMonth, string? ifMatch, CancellationToken ct)
+        => Guard(Task.CompletedTask);
+
+    public Task<Resource> CreateResourceAsync(ResourceInput input, CancellationToken ct)
+        => Task.FromResult(Guard(new Resource("new-id", input.Title, input.Description, input.Url, input.Category)));
+    public Task<Resource> ReplaceResourceAsync(string id, ResourceInput input, string? ifMatch, CancellationToken ct)
+        => Task.FromResult(Guard(new Resource(id, input.Title, input.Description, input.Url, input.Category)));
+    public Task DeleteResourceAsync(string id, string category, string? ifMatch, CancellationToken ct)
+        => Guard(Task.CompletedTask);
+
+    public Task<Newsletter> CreateNewsletterAsync(NewsletterInput input, CancellationToken ct)
+        => Task.FromResult(Guard(new Newsletter("new-id", input.Title, input.IssueDate, input.Summary, input.Topics)));
+    public Task<Newsletter> ReplaceNewsletterAsync(string id, NewsletterInput input, string? ifMatch, CancellationToken ct)
+        => Task.FromResult(Guard(new Newsletter(id, input.Title, input.IssueDate, input.Summary, input.Topics)));
+    public Task DeleteNewsletterAsync(string id, string year, string? ifMatch, CancellationToken ct)
+        => Guard(Task.CompletedTask);
+
+    public Task<Member?> GetMemberByEmailAsync(string email, CancellationToken ct) => Task.FromResult(MemberByEmail);
+    public Task<Member?> GetMemberByIdAsync(string id, CancellationToken ct) => Task.FromResult(MemberById);
+    public Task<Member?> GetMemberByOidAsync(string oid, CancellationToken ct) => Task.FromResult(MemberByOid);
+    public Task<IReadOnlyList<Member>> ListMembersAsync(CancellationToken ct) => Task.FromResult<IReadOnlyList<Member>>(Members);
+    public Task<Member> UpsertMemberAsync(Member member, string? ifMatch, CancellationToken ct) => Task.FromResult(Guard(member));
+    public Task DeleteMemberAsync(string id, string? ifMatch, CancellationToken ct) => Guard(Task.CompletedTask);
+
+    public Task<Draft?> GetDraftAsync(string id, string authorId, CancellationToken ct) => Task.FromResult(DraftById);
+    public Task<IReadOnlyList<Draft>> ListDraftsByAuthorAsync(string authorId, CancellationToken ct) => Task.FromResult<IReadOnlyList<Draft>>(Drafts);
+    public Task<Draft> UpsertDraftAsync(Draft draft, string? ifMatch, CancellationToken ct) => Task.FromResult(Guard(draft));
+    public Task DeleteDraftAsync(string id, string authorId, string? ifMatch, CancellationToken ct) => Guard(Task.CompletedTask);
+
+    public Task<Article> SubmitDraftAsync(string draftId, string authorId, CancellationToken ct)
+        => Task.FromResult(Guard(MakeArticle(draftId, null)));
+    public Task<Draft> CreateRevisionDraftAsync(string articleId, string oid, string name, CancellationToken ct)
+        => Task.FromResult(Guard(MakeDraft(articleId, oid, name)));
+    public Task<Article> RequestArticleDeletionAsync(string id, string oid, CancellationToken ct)
+        => Task.FromResult(Guard(MakeArticle(id, null)));
+    public Task<Article> CancelArticleDeletionAsync(string id, CancellationToken ct)
+        => Task.FromResult(Guard(MakeArticle(id, null)));
+    public Task<Article?> GetArticleAsync(string id, string status, CancellationToken ct) => Task.FromResult<Article?>(MakeArticle(id, null));
+    public Task<Article> PublishArticleAsync(string id, CancellationToken ct) => Task.FromResult(Guard(MakeArticle(id, null)));
+    public Task<Draft> ReviseArticleAsync(string id, string feedback, CancellationToken ct)
+        => Task.FromResult(Guard(MakeDraft(id, "oid", "name") with { RevisionFeedback = feedback }));
+
+    private static Article MakeArticle(string id, ArticleInput? input) => new(
+        id, input?.Slug ?? "slug", input?.Title ?? "Title", input?.Summary ?? "Summary",
+        input?.Body ?? "Body", input?.Author ?? "Author", DateTime.UtcNow,
+        input?.ReadingMinutes ?? 5, input?.Category ?? "Community",
+        input?.Tags ?? new List<string>(), input?.Status ?? "published") { Etag = "etag-1" };
+
+    private static CommunityEvent MakeEvent(string id, EventInput input, string? oid, string? name) => new(
+        id, input.Title, input.Type, input.StartsAt, input.EndsAt, input.Location,
+        input.Description, input.SignupUrl, oid, name) { Etag = "etag-1" };
+
+    private static Draft MakeDraft(string id, string oid, string name) => new(
+        id, oid, name, "article", "Title", "slug", "Summary", "Body", "Community",
+        new List<string>(), 5, DateTime.UtcNow, DateTime.UtcNow) { Etag = "etag-1" };
+}

--- a/src/api/Slypn.Api.Tests/Fakes.cs
+++ b/src/api/Slypn.Api.Tests/Fakes.cs
@@ -1,0 +1,30 @@
+using Slypn.Api.Services;
+
+namespace Slypn.Api.Tests;
+
+internal sealed class FakeInviteService : IInviteService
+{
+    public bool IsConfigured => true;
+    public InviteResult Result = new(true, "https://redeem/abc", null);
+    public Task<InviteResult> SendInviteAsync(string email, string displayName, CancellationToken ct)
+        => Task.FromResult(Result);
+}
+
+internal sealed class FakeEntraUserService : IEntraUserService
+{
+    public bool IsConfigured => true;
+    public List<string> Deleted = new();
+    public Task DeleteUserAsync(string oid, CancellationToken ct) { Deleted.Add(oid); return Task.CompletedTask; }
+}
+
+internal sealed class FakeBlobService : IBlobService
+{
+    public bool Configured = true;
+    public bool IsConfigured => Configured;
+    public IReadOnlySet<string> AllowedContentTypes { get; } =
+        new HashSet<string> { "image/png", "image/jpeg", "image/webp" };
+    public Task<string> UploadMediaAsync(Stream content, string contentType, CancellationToken ct)
+        => Task.FromResult("media/uploaded.png");
+    public Uri GetMediaReadUrl(string blobName, TimeSpan? validFor = null)
+        => new($"https://blob.example/{blobName}?sas=token");
+}

--- a/src/api/Slypn.Api.Tests/FunctionContextExtensionsTests.cs
+++ b/src/api/Slypn.Api.Tests/FunctionContextExtensionsTests.cs
@@ -1,0 +1,34 @@
+using Slypn.Api.Infrastructure;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class FunctionContextExtensionsTests
+{
+    [Fact]
+    public void Returns_null_when_no_principal()
+    {
+        var ctx = new TestFunctionContext();
+        Assert.Null(ctx.GetPrincipal());
+        Assert.Null(ctx.GetUserOid());
+        Assert.Null(ctx.GetUserName());
+        Assert.False(ctx.IsAdmin());
+    }
+
+    [Fact]
+    public void Reads_oid_name_and_admin_role_from_principal()
+    {
+        var ctx = new TestFunctionContext().WithUser("oid-9", "Grace", "Admin");
+        Assert.Equal("oid-9", ctx.GetUserOid());
+        Assert.Equal("Grace", ctx.GetUserName());
+        Assert.True(ctx.IsAdmin());
+    }
+
+    [Fact]
+    public void IsAdmin_false_for_non_admin_role()
+    {
+        var ctx = new TestFunctionContext().WithUser("oid-1", "Member User", "Member");
+        Assert.False(ctx.IsAdmin());
+        Assert.Equal("Member User", ctx.GetUserName());
+    }
+}

--- a/src/api/Slypn.Api.Tests/InfrastructureTests.cs
+++ b/src/api/Slypn.Api.Tests/InfrastructureTests.cs
@@ -1,0 +1,76 @@
+using Slypn.Api.Infrastructure;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class InfrastructureTests
+{
+    [Fact]
+    public void EntraOptions_IsConfigured_requires_authority_and_audience()
+    {
+        Assert.False(new EntraOptions().IsConfigured);
+        Assert.False(new EntraOptions { Authority = "https://x" }.IsConfigured);
+        Assert.True(new EntraOptions { Authority = "https://x", Audience = "api://y" }.IsConfigured);
+    }
+
+    [Fact]
+    public void GraphOptions_flags()
+    {
+        var opts = new GraphOptions();
+        Assert.True(opts.IsConfigured); // default InviteRedirectUrl is set
+        Assert.False(opts.HasClientCredentials);
+        opts.ClientSecret = "secret";
+        Assert.True(opts.HasClientCredentials);
+    }
+
+    [Fact]
+    public void OtelOptions_IsConfigured_requires_endpoint()
+    {
+        Assert.False(new OtelOptions().IsConfigured);
+        Assert.True(new OtelOptions { Endpoint = "https://otlp" }.IsConfigured);
+        Assert.Equal("slypn-api", new OtelOptions().ServiceName);
+    }
+
+    [Fact]
+    public void SignupGateOptions_holds_expected_values()
+    {
+        var opts = new SignupGateOptions { Secret = "s", TenantId = "t", ExtensionId = "e" };
+        Assert.Equal("s", opts.Secret);
+        Assert.Equal("t", opts.TenantId);
+        Assert.Equal("e", opts.ExtensionId);
+    }
+
+    [Theory]
+    [InlineData("admin", "Admin")]
+    [InlineData("contributor", "Contributor")]
+    [InlineData("member", "Member")]
+    [InlineData("ADMIN", "Admin")]
+    public void DevPersonas_resolves_known_keys(string key, string expectedRole)
+    {
+        var persona = DevPersonas.Resolve(key);
+        Assert.Contains(expectedRole, persona.Roles);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("unknown")]
+    public void DevPersonas_falls_back_to_admin(string? key)
+    {
+        Assert.Equal("admin", DevPersonas.Resolve(key).Key);
+    }
+
+    [Fact]
+    public void DevPersonas_all_have_one_role_each()
+    {
+        Assert.Equal(3, DevPersonas.All.Count);
+        Assert.All(DevPersonas.All, p => Assert.Single(p.Roles));
+    }
+
+    [Fact]
+    public void RequireRoleAttribute_captures_roles()
+    {
+        var attr = new RequireRoleAttribute("Admin", "Contributor");
+        Assert.Equal(new[] { "Admin", "Contributor" }, attr.Roles);
+        Assert.Empty(new RequireRoleAttribute().Roles);
+    }
+}

--- a/src/api/Slypn.Api.Tests/InputValidationTests.cs
+++ b/src/api/Slypn.Api.Tests/InputValidationTests.cs
@@ -1,0 +1,114 @@
+using System.ComponentModel.DataAnnotations;
+using Slypn.Api.Models.Inputs;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class InputValidationTests
+{
+    private static (bool Ok, List<ValidationResult> Errors) Validate(object o)
+    {
+        var ctx = new ValidationContext(o);
+        var errors = new List<ValidationResult>();
+        var ok = Validator.TryValidateObject(o, ctx, errors, validateAllProperties: true);
+        return (ok, errors);
+    }
+
+    private static ArticleInput ValidArticle() => new()
+    {
+        Slug = "a-valid-slug", Title = "A good title", Summary = "A sufficiently long summary.",
+        Body = "Body content that is long enough.", Author = "Jane", ReadingMinutes = 5,
+        Category = "Community", Status = "draft",
+    };
+
+    [Fact]
+    public void ArticleInput_valid_passes()
+    {
+        Assert.True(Validate(ValidArticle()).Ok);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("nonsense")]
+    public void ArticleInput_rejects_bad_status(string status)
+    {
+        var input = ValidArticle();
+        input.Status = status;
+        Assert.False(Validate(input).Ok);
+    }
+
+    [Fact]
+    public void ArticleInput_rejects_short_title()
+    {
+        var input = ValidArticle();
+        input.Title = "no";
+        Assert.False(Validate(input).Ok);
+    }
+
+    [Fact]
+    public void EventInput_rejects_non_url_signup()
+    {
+        var input = new EventInput
+        {
+            Title = "Coffee", Type = "Coffee meet-up", StartsAt = DateTimeOffset.UtcNow,
+            EndsAt = DateTimeOffset.UtcNow.AddHours(1), Location = "Brixton", Description = "Come",
+            SignupUrl = "not-a-url",
+        };
+        Assert.False(Validate(input).Ok);
+    }
+
+    [Fact]
+    public void EventInput_valid_passes_with_no_signup()
+    {
+        var input = new EventInput
+        {
+            Title = "Coffee", Type = "Coffee meet-up", StartsAt = DateTimeOffset.UtcNow,
+            EndsAt = DateTimeOffset.UtcNow.AddHours(1), Location = "Brixton", Description = "Come",
+        };
+        Assert.True(Validate(input).Ok);
+    }
+
+    [Fact]
+    public void MemberInviteInput_requires_exactly_one_role()
+    {
+        var valid = new MemberInviteInput { Email = "a@b.com", DisplayName = "A", Roles = { "Admin" } };
+        Assert.True(Validate(valid).Ok);
+
+        var none = new MemberInviteInput { Email = "a@b.com", DisplayName = "A" };
+        Assert.False(Validate(none).Ok);
+
+        var two = new MemberInviteInput { Email = "a@b.com", DisplayName = "A", Roles = { "Admin", "Member" } };
+        Assert.False(Validate(two).Ok);
+    }
+
+    [Fact]
+    public void MemberInviteInput_rejects_bad_email()
+    {
+        var input = new MemberInviteInput { Email = "nope", DisplayName = "A", Roles = { "Admin" } };
+        Assert.False(Validate(input).Ok);
+    }
+
+    [Fact]
+    public void MemberRolesInput_requires_one_role()
+    {
+        Assert.True(Validate(new MemberRolesInput { Roles = { "Contributor" } }).Ok);
+        Assert.False(Validate(new MemberRolesInput()).Ok);
+    }
+
+    [Fact]
+    public void NewsletterInput_validates_length()
+    {
+        var valid = new NewsletterInput { Title = "May 2026", IssueDate = new DateOnly(2026, 5, 1), Summary = "A long enough summary." };
+        Assert.True(Validate(valid).Ok);
+
+        var bad = new NewsletterInput { Title = "x", IssueDate = new DateOnly(2026, 5, 1), Summary = "short" };
+        Assert.False(Validate(bad).Ok);
+    }
+
+    [Fact]
+    public void SubscribeInput_requires_valid_email()
+    {
+        Assert.True(Validate(new SubscribeInput { Email = "a@b.com" }).Ok);
+        Assert.False(Validate(new SubscribeInput { Email = "bad" }).Ok);
+    }
+}

--- a/src/api/Slypn.Api.Tests/ModelsAndMockDataTests.cs
+++ b/src/api/Slypn.Api.Tests/ModelsAndMockDataTests.cs
@@ -1,0 +1,59 @@
+using Slypn.Api.Models;
+using Slypn.Api.Services;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class ModelsAndMockDataTests
+{
+    [Fact]
+    public void Article_defaults_type_and_status()
+    {
+        var a = new Article("id", "slug", "Title", "Summary", "Body", "Author",
+            new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc), 5, "Community", new[] { "x" });
+        Assert.Equal("article", a.Type);
+        Assert.Equal("published", a.Status);
+        Assert.Null(a.Etag);
+        Assert.Null(a.AuthorId);
+    }
+
+    [Fact]
+    public void CommunityEvent_YearMonth_uses_utc_year_month()
+    {
+        var e = new CommunityEvent("id", "Quiz", "Q&A",
+            new DateTimeOffset(2026, 6, 1, 10, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero),
+            "Online", "desc", null);
+        Assert.Equal("2026-06", e.YearMonth);
+    }
+
+    [Fact]
+    public void Newsletter_Year_is_four_digit_issue_year()
+    {
+        var n = new Newsletter("id", "May 2026", new DateOnly(2026, 5, 1), "summary text", new[] { "t" });
+        Assert.Equal("2026", n.Year);
+    }
+
+    [Fact]
+    public void Draft_and_Member_records_round_trip_etag()
+    {
+        var d = new Draft("id", "auth", "Author", "article", "T", "s", "sum", "body", "cat",
+            new[] { "x" }, 1, DateTime.UtcNow, DateTime.UtcNow) { Etag = "e1" };
+        Assert.Equal("e1", d.Etag);
+
+        var m = new Member("id", "a@b.com", "Alice", new[] { "Member" }, "active", DateTime.UtcNow);
+        Assert.Equal("active", m.Status);
+        Assert.Null(m.Oid);
+    }
+
+    [Fact]
+    public void MockDataService_exposes_all_seed_collections()
+    {
+        var mock = new MockDataService();
+        Assert.Equal(5, mock.Articles.Count);
+        Assert.Equal(3, mock.BlogPosts.Count);
+        Assert.NotEmpty(mock.Events);
+        Assert.Equal(9, mock.Resources.Count);
+        Assert.Equal(4, mock.Newsletters.Count);
+    }
+}

--- a/src/api/Slypn.Api.Tests/ServicesTests.cs
+++ b/src/api/Slypn.Api.Tests/ServicesTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Slypn.Api.Infrastructure;
+using Slypn.Api.Services;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+file sealed class StubHttpFactory : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name) => new();
+}
+
+public class ServicesTests
+{
+    private static readonly CancellationToken Ct = CancellationToken.None;
+    private static IOptions<StorageOptions> EmptyStorage => Options.Create(new StorageOptions());
+
+    [Fact]
+    public async Task LoggingInviteService_reports_unconfigured()
+    {
+        var svc = new LoggingInviteService(NullLogger<LoggingInviteService>.Instance);
+        Assert.False(svc.IsConfigured);
+        var result = await svc.SendInviteAsync("a@b.com", "Alice", Ct);
+        Assert.False(result.Sent);
+        Assert.Null(result.RedeemUrl);
+        Assert.Equal("sign-up-url-not-configured", result.Reason);
+    }
+
+    [Fact]
+    public async Task BlobService_unconfigured_blocks_writes()
+    {
+        var svc = new BlobService(EmptyStorage, NullLogger<BlobService>.Instance);
+        Assert.False(svc.IsConfigured);
+        Assert.Equal(3, svc.AllowedContentTypes.Count);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => svc.UploadMediaAsync(new MemoryStream(), "image/png", Ct));
+        Assert.Throws<InvalidOperationException>(() => svc.GetMediaReadUrl("x.png"));
+    }
+
+    [Fact]
+    public async Task ContentBodyStore_unconfigured_throws_on_access()
+    {
+        var svc = new ContentBodyStore(EmptyStorage, NullLogger<ContentBodyStore>.Instance);
+        Assert.False(svc.IsConfigured);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.PutAsync("articles", "a1", "<p>x</p>", Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetAsync("articles", "a1", Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteAsync("articles", "a1", Ct));
+    }
+
+    [Fact]
+    public void TableStore_unconfigured_throws_on_handle_access()
+    {
+        var svc = new TableStore(EmptyStorage, NullLogger<TableStore>.Instance);
+        Assert.False(svc.IsConfigured);
+        Assert.Throws<InvalidOperationException>(() => svc.Articles);
+        Assert.Throws<InvalidOperationException>(() => svc.Members);
+    }
+
+    [Fact]
+    public async Task EntraUserService_unconfigured_is_noop()
+    {
+        var svc = new EntraUserService(
+            Options.Create(new GraphOptions()), // no client secret
+            Options.Create(new EntraOptions()),
+            new StubHttpFactory(),
+            NullLogger<EntraUserService>.Instance);
+        Assert.False(svc.IsConfigured);
+        await svc.DeleteUserAsync("oid-1", Ct); // returns without throwing or calling Graph
+    }
+}

--- a/src/api/Slypn.Api.Tests/TestHttp.cs
+++ b/src/api/Slypn.Api.Tests/TestHttp.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using Azure.Core.Serialization;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Slypn.Api.Infrastructure;
+
+namespace Slypn.Api.Tests;
+
+/// <summary>
+/// Minimal in-memory implementations of the isolated-worker HTTP types so Function
+/// methods can be invoked directly in unit tests. Only the members the SLYPN
+/// functions actually touch are wired up; the rest throw.
+/// </summary>
+internal sealed class TestFunctionContext : FunctionContext
+{
+    private readonly IServiceProvider _services = BuildServices();
+
+    private static IServiceProvider BuildServices()
+    {
+        var sc = new ServiceCollection();
+        sc.Configure<WorkerOptions>(o =>
+            o.Serializer = new JsonObjectSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+        return sc.BuildServiceProvider();
+    }
+
+    public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
+    public override IServiceProvider InstanceServices { get => _services; set { } }
+    public override string InvocationId => "test-invocation";
+    public override string FunctionId => "test-function";
+    public override TraceContext TraceContext => throw new NotSupportedException();
+    public override BindingContext BindingContext => throw new NotSupportedException();
+    public override RetryContext RetryContext => throw new NotSupportedException();
+    public override FunctionDefinition FunctionDefinition => throw new NotSupportedException();
+    public override IInvocationFeatures Features => throw new NotSupportedException();
+
+    /// <summary>Attach a signed-in principal with the given oid/name/roles.</summary>
+    public TestFunctionContext WithUser(string oid, string name = "Test User", params string[] roles)
+    {
+        var identity = new ClaimsIdentity("test", "name", "roles");
+        identity.AddClaim(new Claim("oid", oid));
+        identity.AddClaim(new Claim("name", name));
+        foreach (var r in roles) identity.AddClaim(new Claim("roles", r));
+        Items[JwtMiddleware.PrincipalContextKey] = new ClaimsPrincipal(identity);
+        return this;
+    }
+}
+
+internal sealed class TestHttpCookies : HttpCookies
+{
+    public override void Append(string name, string value) { }
+    public override void Append(IHttpCookie cookie) { }
+    public override IHttpCookie CreateNew() => throw new NotSupportedException();
+}
+
+internal sealed class TestHttpResponseData : HttpResponseData
+{
+    public TestHttpResponseData(FunctionContext ctx) : base(ctx) { }
+    public override HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
+    public override HttpHeadersCollection Headers { get; set; } = new();
+    public override Stream Body { get; set; } = new MemoryStream();
+    public override HttpCookies Cookies { get; } = new TestHttpCookies();
+
+    public string ReadBodyAsString()
+    {
+        Body.Position = 0;
+        using var reader = new StreamReader(Body, Encoding.UTF8, leaveOpen: true);
+        return reader.ReadToEnd();
+    }
+
+    public T? ReadBodyAs<T>()
+    {
+        var json = ReadBodyAsString();
+        return string.IsNullOrWhiteSpace(json) ? default : JsonSerializer.Deserialize<T>(json, Web);
+    }
+
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+}
+
+internal sealed class TestHttpRequestData : HttpRequestData
+{
+    private readonly Stream _body;
+    public TestHttpRequestData(FunctionContext ctx, string method, string url, string? body = null,
+        IDictionary<string, string>? headers = null) : base(ctx)
+    {
+        Method = method;
+        Url = new Uri(url);
+        _body = new MemoryStream(body is null ? Array.Empty<byte>() : Encoding.UTF8.GetBytes(body));
+        Headers = new HttpHeadersCollection();
+        if (headers is not null)
+            foreach (var (k, v) in headers) Headers.Add(k, v);
+    }
+
+    public override Stream Body => _body;
+    public override HttpHeadersCollection Headers { get; }
+    public override IReadOnlyCollection<IHttpCookie> Cookies => Array.Empty<IHttpCookie>();
+    public override Uri Url { get; }
+    public override IEnumerable<ClaimsIdentity> Identities => Array.Empty<ClaimsIdentity>();
+    public override string Method { get; }
+    public override HttpResponseData CreateResponse() => new TestHttpResponseData(FunctionContext);
+}
+
+internal static class TestHttp
+{
+    public static TestHttpRequestData Get(FunctionContext ctx, string url) =>
+        new(ctx, "GET", url);
+
+    public static TestHttpRequestData Json(FunctionContext ctx, string method, string url, object body,
+        IDictionary<string, string>? headers = null) =>
+        new(ctx, method, url, JsonSerializer.Serialize(body, new JsonSerializerOptions(JsonSerializerDefaults.Web)), headers);
+
+    public static TestHttpRequestData Raw(FunctionContext ctx, string method, string url, string body) =>
+        new(ctx, method, url, body);
+}

--- a/src/web/src/App.spec.ts
+++ b/src/web/src/App.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+
+describe('App shell', () => {
+  it('renders nav, footer, and the router outlet', () => {
+    const w = mount(App, {
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          AppNav: { template: '<nav class="nav-stub" />' },
+          AppFooter: { template: '<footer class="footer-stub" />' },
+          CookieBanner: { template: '<div class="cookie-stub" />' },
+          DevPersonaSwitcher: { template: '<div class="persona-stub" />' },
+          RouterView: { template: '<main class="outlet-stub" />' },
+        },
+      },
+    })
+    expect(w.find('.nav-stub').exists()).toBe(true)
+    expect(w.find('.footer-stub').exists()).toBe(true)
+    expect(w.find('.outlet-stub').exists()).toBe(true)
+    expect(w.find('.cookie-stub').exists()).toBe(true)
+  })
+})

--- a/src/web/src/components/common/ArticleCard.spec.ts
+++ b/src/web/src/components/common/ArticleCard.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import ArticleCard from './ArticleCard.vue'
+import type { Article } from '@/types/content'
+
+const article: Article = {
+  id: 'a1',
+  slug: 'hello-world',
+  title: 'Hello World',
+  summary: 'A short summary',
+  body: '<p>body</p>',
+  author: 'Jane',
+  publishedAt: '2026-05-01T10:00:00Z',
+  readingMinutes: 4,
+  category: 'Community',
+  tags: ['x'],
+}
+
+function mountCard(a: Article = article) {
+  return mount(ArticleCard, {
+    props: { article: a },
+    global: { stubs: { RouterLink: RouterLinkStub } },
+  })
+}
+
+describe('ArticleCard', () => {
+  it('renders title, category, author, summary and reading time', () => {
+    const w = mountCard()
+    expect(w.text()).toContain('Hello World')
+    expect(w.text()).toContain('Community')
+    expect(w.text()).toContain('Jane')
+    expect(w.text()).toContain('4 min read')
+  })
+
+  it('links to the article slug', () => {
+    const w = mountCard()
+    expect(w.findComponent(RouterLinkStub).props('to')).toBe('/articles/hello-world')
+  })
+
+  it('falls back to the id when slug is empty', () => {
+    const w = mountCard({ ...article, slug: '' })
+    expect(w.findComponent(RouterLinkStub).props('to')).toBe('/articles/a1')
+  })
+
+  it('formats the published date in en-GB', () => {
+    const w = mountCard()
+    expect(w.text()).toMatch(/May 2026/)
+  })
+})

--- a/src/web/src/components/common/CookieBanner.spec.ts
+++ b/src/web/src/components/common/CookieBanner.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mount } from '@vue/test-utils'
+
+const choice = ref<'accepted' | 'declined' | null>(null)
+const accept = vi.fn(() => { choice.value = 'accepted' })
+const decline = vi.fn(() => { choice.value = 'declined' })
+
+vi.mock('@/composables/useCookieConsent', () => ({
+  useCookieConsent: () => ({ choice, accept, decline }),
+}))
+
+import CookieBanner from './CookieBanner.vue'
+
+function mountBanner() {
+  return mount(CookieBanner, { global: { stubs: { teleport: true } } })
+}
+
+describe('CookieBanner', () => {
+  beforeEach(() => {
+    choice.value = null
+    accept.mockClear()
+    decline.mockClear()
+  })
+
+  it('shows the dialog while no choice has been made', () => {
+    const w = mountBanner()
+    expect(w.find('[role="dialog"]').exists()).toBe(true)
+    expect(w.text()).toContain('We’d like to use cookies')
+  })
+
+  it('calls accept when Accept all is clicked', async () => {
+    const w = mountBanner()
+    await w.findAll('button').find(b => b.text() === 'Accept all')!.trigger('click')
+    expect(accept).toHaveBeenCalled()
+  })
+
+  it('calls decline when Decline is clicked', async () => {
+    const w = mountBanner()
+    await w.findAll('button').find(b => b.text() === 'Decline')!.trigger('click')
+    expect(decline).toHaveBeenCalled()
+  })
+
+  it('hides the dialog once a choice exists', () => {
+    choice.value = 'accepted'
+    const w = mountBanner()
+    expect(w.find('[role="dialog"]').exists()).toBe(false)
+  })
+})

--- a/src/web/src/components/common/EventCard.spec.ts
+++ b/src/web/src/components/common/EventCard.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import EventCard from './EventCard.vue'
+import type { CommunityEvent } from '@/types/content'
+
+const base: CommunityEvent = {
+  id: 'e1',
+  title: 'Coffee morning',
+  type: 'Coffee meet-up',
+  startsAt: '2026-05-10T10:00:00Z',
+  endsAt: '2026-05-10T12:00:00Z',
+  location: 'Brixton',
+  description: 'Come along',
+}
+
+function mountCard(ev: Partial<CommunityEvent> = {}, props: Record<string, unknown> = {}) {
+  return mount(EventCard, {
+    props: { event: { ...base, ...ev }, ...props },
+    global: { stubs: { RouterLink: RouterLinkStub } },
+  })
+}
+
+describe('EventCard', () => {
+  it('renders type, title, location and description', () => {
+    const w = mountCard()
+    expect(w.text()).toContain('Coffee meet-up')
+    expect(w.text()).toContain('Coffee morning')
+    expect(w.text()).toContain('Brixton')
+    expect(w.text()).toContain('Come along')
+  })
+
+  it('links to the event detail route', () => {
+    const w = mountCard()
+    expect(w.findComponent(RouterLinkStub).props('to')).toEqual({ name: 'event-detail', params: { id: 'e1' } })
+  })
+
+  it('renders a single-day time range when start and end share a day', () => {
+    const w = mountCard()
+    // single-day branch shows one date with two times (start–end); assert two
+    // HH:MM tokens without pinning the timezone-dependent values.
+    const times = w.text().match(/\d{2}:\d{2}/g) ?? []
+    expect(times.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders a multi-day range across different days', () => {
+    const w = mountCard({ endsAt: '2026-05-11T09:00:00Z' })
+    expect(w.text()).toMatch(/May/)
+  })
+
+  it('shows a Past badge and signup link when applicable', () => {
+    const w = mountCard({ signupUrl: 'https://example.com/signup' }, { past: true })
+    expect(w.text()).toContain('Past')
+    const link = w.find('a[href="https://example.com/signup"]')
+    expect(link.exists()).toBe(true)
+  })
+
+  it('shows the year for events outside the current year', () => {
+    const w = mountCard({ startsAt: '2020-01-15T10:00:00Z', endsAt: '2020-01-15T11:00:00Z' })
+    expect(w.text()).toContain('2020')
+  })
+})

--- a/src/web/src/components/common/HeroBanner.spec.ts
+++ b/src/web/src/components/common/HeroBanner.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import HeroBanner from './HeroBanner.vue'
+
+describe('HeroBanner', () => {
+  it('renders the title and shows eyebrow + subtitle when given', () => {
+    const w = mount(HeroBanner, {
+      props: { eyebrow: 'About', title: 'Our story', subtitle: 'A community' },
+    })
+    expect(w.text()).toContain('About')
+    expect(w.find('h1').text()).toBe('Our story')
+    expect(w.text()).toContain('A community')
+  })
+
+  it('omits eyebrow and subtitle when not provided', () => {
+    const w = mount(HeroBanner, { props: { title: 'Just a title' } })
+    expect(w.findAll('p')).toHaveLength(0)
+    expect(w.find('h1').text()).toBe('Just a title')
+  })
+
+  it('renders brand, actions and default slots', () => {
+    const w = mount(HeroBanner, {
+      props: { title: 'T' },
+      slots: {
+        brand: '<div class="brand-slot">B</div>',
+        actions: '<button>Go</button>',
+        default: '<p class="extra">extra</p>',
+      },
+    })
+    expect(w.find('.brand-slot').exists()).toBe(true)
+    expect(w.find('button').text()).toBe('Go')
+    expect(w.find('.extra').exists()).toBe(true)
+  })
+})

--- a/src/web/src/components/common/NewsletterCard.spec.ts
+++ b/src/web/src/components/common/NewsletterCard.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NewsletterCard from './NewsletterCard.vue'
+import type { Newsletter } from '@/types/content'
+
+const newsletter: Newsletter = {
+  id: 'n1',
+  title: 'May 2026 issue',
+  issueDate: '2026-05-01',
+  summary: 'What happened in May',
+  topics: ['Meet-ups', 'Fundraising'],
+}
+
+describe('NewsletterCard', () => {
+  it('renders the title, summary and formatted issue date', () => {
+    const w = mount(NewsletterCard, { props: { newsletter } })
+    expect(w.text()).toContain('May 2026 issue')
+    expect(w.text()).toContain('What happened in May')
+    expect(w.text()).toMatch(/May 2026/)
+  })
+
+  it('lists each topic', () => {
+    const w = mount(NewsletterCard, { props: { newsletter } })
+    const items = w.findAll('li')
+    expect(items).toHaveLength(2)
+    expect(w.text()).toContain('Meet-ups')
+    expect(w.text()).toContain('Fundraising')
+  })
+})

--- a/src/web/src/components/common/PillFilter.spec.ts
+++ b/src/web/src/components/common/PillFilter.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PillFilter from './PillFilter.vue'
+
+describe('PillFilter', () => {
+  it('renders nothing when there are no options', () => {
+    const w = mount(PillFilter, { props: { options: [], modelValue: 'All' } })
+    expect(w.find('button').exists()).toBe(false)
+  })
+
+  it('renders All plus an option per entry', () => {
+    const w = mount(PillFilter, { props: { options: ['A', 'B'], modelValue: 'All' } })
+    const buttons = w.findAll('button')
+    expect(buttons).toHaveLength(3)
+    expect(buttons[0].text()).toBe('All')
+  })
+
+  it('emits the option value on click', async () => {
+    const w = mount(PillFilter, { props: { options: ['A', 'B'], modelValue: 'All' } })
+    await w.findAll('button')[1].trigger('click')
+    expect(w.emitted('update:modelValue')![0]).toEqual(['A'])
+  })
+
+  it('emits All when the All button is clicked', async () => {
+    const w = mount(PillFilter, { props: { options: ['A'], modelValue: 'A' } })
+    await w.findAll('button')[0].trigger('click')
+    expect(w.emitted('update:modelValue')![0]).toEqual(['All'])
+  })
+
+  it('marks the active option', () => {
+    const w = mount(PillFilter, { props: { options: ['A', 'B'], modelValue: 'B' } })
+    const active = w.findAll('button')[2]
+    expect(active.classes().join(' ')).toContain('bg-slypn-600')
+  })
+})

--- a/src/web/src/components/common/PublishedContent.spec.ts
+++ b/src/web/src/components/common/PublishedContent.spec.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/api', () => ({ apiFetch, apiJson: vi.fn() }))
 
 import PublishedContent from './PublishedContent.vue'
 import { useAuthStore } from '@/stores/auth'
+import { DEV_PERSONA_STORAGE_KEY } from '@/lib/devPersonas'
 
 const stubs = { teleport: true, DraftEditor: { template: '<div class="draft-editor-stub" />' } }
 let pinia: Pinia
@@ -111,6 +112,29 @@ describe('PublishedContent', () => {
     const w = mountC()
     await flushPromises()
     expect(w.text()).toContain('Nothing published yet')
+  })
+
+  it('lets a contributor request deletion of their own item', async () => {
+    const memberOid = '33333333-3333-3333-3333-333333333333'
+    localStorage.setItem(DEV_PERSONA_STORAGE_KEY, 'member')
+    pinia = createPinia()
+    setActivePinia(pinia)
+    await useAuthStore().initialize() // member persona
+    mockLoad([item({ authorId: memberOid })])
+    apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (url.endsWith('/request-deletion') && method === 'POST') return Promise.resolve(ok(item({ authorId: memberOid, deletionRequestedBy: memberOid })))
+      if (method === 'GET' && url === '/articles?status=published') return Promise.resolve(ok([item({ authorId: memberOid })]))
+      if (method === 'GET') return Promise.resolve(ok([]))
+      return Promise.resolve(ok({}))
+    })
+    const w = mountC()
+    await flushPromises()
+    const reqBtn = w.findAll('button').find(b => b.text() === 'Request deletion')!
+    expect(reqBtn).toBeTruthy()
+    await reqBtn.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/articles/i1/request-deletion', { method: 'POST' })
   })
 
   it('shows a load error', async () => {

--- a/src/web/src/components/common/PublishedContent.spec.ts
+++ b/src/web/src/components/common/PublishedContent.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiFetch, apiJson: vi.fn() }))
+
+import PublishedContent from './PublishedContent.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const stubs = { teleport: true, DraftEditor: { template: '<div class="draft-editor-stub" />' } }
+let pinia: Pinia
+const mountC = () => mount(PublishedContent, { global: { plugins: [pinia], stubs } })
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+}
+
+const item = (over = {}) => ({
+  id: 'i1', slug: 's', title: 'Live article', summary: 'sum', author: 'Jo',
+  authorId: 'oid1', publishedAt: '2026-05-01T00:00:00Z', category: 'Community',
+  type: 'article', status: 'published', ...over,
+})
+
+function mockLoad(published: unknown[], inReview: unknown[] = []) {
+  apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+    const method = init?.method ?? 'GET'
+    if (method === 'GET' && url === '/articles?status=published') return Promise.resolve(ok(published))
+    if (method === 'GET' && url === '/blog?status=published') return Promise.resolve(ok([]))
+    if (method === 'GET' && url === '/articles?status=in-review') return Promise.resolve(ok(inReview))
+    if (method === 'GET' && url === '/blog?status=in-review') return Promise.resolve(ok([]))
+    return Promise.resolve(ok({}))
+  })
+}
+
+beforeEach(async () => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiFetch.mockReset()
+  vi.stubGlobal('confirm', vi.fn(() => true))
+  await useAuthStore().initialize() // dev-skip admin
+})
+
+describe('PublishedContent', () => {
+  it('lists published items for an admin', async () => {
+    mockLoad([item(), item({ id: 'i2', title: 'Second post', type: 'blog' })])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('Live article')
+    expect(w.text()).toContain('Second post')
+  })
+
+  it('filters by type', async () => {
+    mockLoad([item(), item({ id: 'i2', title: 'A blog', type: 'blog' })])
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Blogs')!.trigger('click')
+    expect(w.text()).toContain('A blog')
+    expect(w.text()).not.toContain('Live article')
+  })
+
+  it('searches title/summary', async () => {
+    mockLoad([item(), item({ id: 'i2', title: 'Unique heading' })])
+    const w = mountC()
+    await flushPromises()
+    await w.find('input[type="search"]').setValue('Unique')
+    expect(w.text()).toContain('Unique heading')
+    expect(w.text()).not.toContain('Live article')
+  })
+
+  it('opens the edit dialog after creating a revision draft', async () => {
+    mockLoad([item()])
+    apiFetch.mockImplementationOnce(() => Promise.resolve(ok([item()]))) // first load call still works via default below
+    // re-apply load + edit behaviour
+    apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (url.endsWith('/edit') && method === 'POST') return Promise.resolve(ok({ id: 'draft-1' }))
+      if (method === 'GET' && url === '/articles?status=published') return Promise.resolve(ok([item()]))
+      if (method === 'GET') return Promise.resolve(ok([]))
+      return Promise.resolve(ok({}))
+    })
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Edit')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/articles/i1/edit', { method: 'POST' })
+    expect(w.find('.draft-editor-stub').exists()).toBe(true)
+  })
+
+  it('deletes an item as admin after confirmation', async () => {
+    mockLoad([item()])
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/articles/i1?status=published', { method: 'DELETE' })
+    expect(w.text()).not.toContain('Live article')
+  })
+
+  it('marks items with a pending revision and disables edit', async () => {
+    mockLoad([item()], [{ replacesArticleId: 'i1' }])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('Revision pending')
+    const editBtn = w.findAll('button').find(b => b.text() === 'Edit')!
+    expect(editBtn.attributes('disabled')).toBeDefined()
+  })
+
+  it('shows the empty state', async () => {
+    mockLoad([])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('Nothing published yet')
+  })
+
+  it('shows a load error', async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Err', json: () => Promise.resolve([]), text: () => Promise.resolve('') } as unknown as Response)
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('500')
+  })
+})

--- a/src/web/src/components/common/ResourceCard.spec.ts
+++ b/src/web/src/components/common/ResourceCard.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ResourceCard from './ResourceCard.vue'
+import type { Resource } from '@/types/content'
+
+const resource: Resource = {
+  id: 'r1',
+  title: 'Parkinson’s UK helpline',
+  description: 'Free confidential support',
+  url: 'https://www.parkinsons.org.uk/helpline',
+  category: "Parkinson's UK",
+}
+
+describe('ResourceCard', () => {
+  it('renders the title, category and description', () => {
+    const w = mount(ResourceCard, { props: { resource } })
+    expect(w.text()).toContain('Parkinson’s UK helpline')
+    expect(w.text()).toContain("Parkinson's UK")
+    expect(w.text()).toContain('Free confidential support')
+  })
+
+  it('links out to the url and strips the protocol in the label', () => {
+    const w = mount(ResourceCard, { props: { resource } })
+    const a = w.find('a')
+    expect(a.attributes('href')).toBe('https://www.parkinsons.org.uk/helpline')
+    expect(a.attributes('target')).toBe('_blank')
+    expect(w.text()).toContain('www.parkinsons.org.uk/helpline')
+    expect(w.text()).not.toContain('https://www.parkinsons.org.uk/helpline')
+  })
+})

--- a/src/web/src/components/editor/DraftEditor.spec.ts
+++ b/src/web/src/components/editor/DraftEditor.spec.ts
@@ -89,6 +89,20 @@ describe('DraftEditor', () => {
     expect(w.findAll('button').find(b => b.text() === 'Blog post')!.classes().join(' ')).toContain('bg-slypn-600')
   })
 
+  it('shows a conflict banner on a 412 and resolves by discarding local', async () => {
+    mockApi((url, method) => {
+      if (url.startsWith('/drafts/') && method === 'PUT') return resp({}, { ok: false, status: 412 })
+      return undefined
+    })
+    const w = mountEditor()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Submit for review'))!.trigger('click')
+    await flushPromises()
+    expect(w.text()).toContain('This draft was updated elsewhere')
+    await w.findAll('button').find(b => b.text()?.includes('Discard mine'))!.trigger('click')
+    expect(w.text()).not.toContain('This draft was updated elsewhere')
+  })
+
   it('surfaces a submit error', async () => {
     mockApi((url, method) => {
       if (url.endsWith('/submit') && method === 'POST') return resp('nope', { ok: false, status: 500 })

--- a/src/web/src/components/editor/DraftEditor.spec.ts
+++ b/src/web/src/components/editor/DraftEditor.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiFetch }))
+
+import DraftEditor from './DraftEditor.vue'
+
+function resp(body: unknown, init: { ok?: boolean; status?: number; etag?: string } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: 'OK',
+    headers: { get: () => init.etag ?? 'etag-1' },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(''),
+  } as unknown as Response
+}
+
+const draftPayload = {
+  type: 'article', title: 'My draft', slug: '', summary: 'A summary',
+  body: '<p>Real content here</p>', category: 'Community', tags: [], readingMinutes: 1,
+}
+
+function mockApi(over: (url: string, method: string) => Response | undefined = () => undefined) {
+  apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+    const method = init?.method ?? 'GET'
+    if (typeof url !== 'string') return Promise.resolve(resp({}))
+    const custom = over(url, method)
+    if (custom) return Promise.resolve(custom)
+    if (url.startsWith('/drafts/') && method === 'GET') return Promise.resolve(resp(draftPayload))
+    if (url === '/articles?status=published') return Promise.resolve(resp([{ category: 'Community' }]))
+    if (url === '/blog?status=published') return Promise.resolve(resp([{ category: 'News' }]))
+    if (url.startsWith('/drafts/') && method === 'PUT') return Promise.resolve(resp({}))
+    if (url.endsWith('/submit') && method === 'POST') return Promise.resolve(resp({}))
+    return Promise.resolve(resp({}))
+  })
+}
+
+const mountEditor = (props: Record<string, unknown> = {}) =>
+  mount(DraftEditor, { props: { draftId: 'd1', ...props }, global: { stubs: { teleport: true } } })
+
+beforeEach(() => apiFetch.mockReset())
+
+describe('DraftEditor', () => {
+  it('loads the draft and fills the form', async () => {
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+    expect((w.find('input[type="text"]').element as HTMLInputElement).value).toBe('My draft')
+    expect(w.find('textarea').element).toBeTruthy()
+    expect(apiFetch).toHaveBeenCalledWith('/drafts/d1')
+  })
+
+  it('shows the read-only banner without fetching a draft', async () => {
+    mockApi()
+    const w = mountEditor({ readonly: true, initialContent: draftPayload })
+    await flushPromises()
+    expect(w.text()).toContain('In review · read only')
+    expect(apiFetch).not.toHaveBeenCalledWith('/drafts/d1')
+  })
+
+  it('emits close when Close is clicked', async () => {
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Close')!.trigger('click')
+    expect(w.emitted('close')).toBeTruthy()
+  })
+
+  it('submits for review (save then submit) when valid', async () => {
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+    const submit = w.findAll('button').find(b => b.text()?.includes('Submit for review'))!
+    expect(submit.attributes('disabled')).toBeUndefined()
+    await submit.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/drafts/d1', expect.objectContaining({ method: 'PUT' }))
+    expect(apiFetch).toHaveBeenCalledWith('/drafts/d1/submit', { method: 'POST' })
+    expect(w.emitted('submitted')).toBeTruthy()
+  })
+
+  it('switches the draft type', async () => {
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Blog post')!.trigger('click')
+    expect(w.findAll('button').find(b => b.text() === 'Blog post')!.classes().join(' ')).toContain('bg-slypn-600')
+  })
+
+  it('surfaces a submit error', async () => {
+    mockApi((url, method) => {
+      if (url.endsWith('/submit') && method === 'POST') return resp('nope', { ok: false, status: 500 })
+      return undefined
+    })
+    const w = mountEditor()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Submit for review'))!.trigger('click')
+    await flushPromises()
+    expect(w.text()).toContain('Submit failed')
+  })
+})

--- a/src/web/src/components/editor/RichTextEditor.spec.ts
+++ b/src/web/src/components/editor/RichTextEditor.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiFetch }))
+
+import RichTextEditor from './RichTextEditor.vue'
+
+const mountEditor = (props: Record<string, unknown> = {}) =>
+  mount(RichTextEditor, { props: { modelValue: '<p>hello</p>', ...props }, global: { stubs: { teleport: true } } })
+
+beforeEach(() => apiFetch.mockReset())
+
+describe('RichTextEditor', () => {
+  it('renders the formatting toolbar', () => {
+    const w = mountEditor()
+    const labels = w.findAll('button').map(b => b.text())
+    expect(labels).toContain('B')
+    expect(labels).toContain('H1')
+    expect(labels).toContain('🔗')
+  })
+
+  it('hides the toolbar in readonly mode', () => {
+    const w = mountEditor({ readonly: true })
+    expect(w.findAll('button').length).toBe(0)
+  })
+
+  it('runs formatting commands without error', async () => {
+    const w = mountEditor()
+    await w.findAll('button').find(b => b.text() === 'B')!.trigger('click')
+    await w.findAll('button').find(b => b.text() === 'H2')!.trigger('click')
+    await w.findAll('button').find(b => b.text() === '•')!.trigger('click')
+    expect(w.exists()).toBe(true)
+  })
+
+  it('opens and cancels the link dialog', async () => {
+    const w = mountEditor()
+    await w.findAll('button').find(b => b.text() === '🔗')!.trigger('click')
+    expect(w.text()).toContain('Insert link')
+    await w.findAll('button').find(b => b.text() === 'Cancel')!.trigger('click')
+    expect(w.text()).not.toContain('Insert link')
+  })
+
+  it('uploads an image through the media endpoint', async () => {
+    apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ name: 'p.png', url: 'https://cdn/p.png' }), text: () => Promise.resolve('') } as unknown as Response)
+    const w = mountEditor()
+    const file = new File(['x'], 'p.png', { type: 'image/png' })
+    const input = w.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+    await input.trigger('change')
+    await Promise.resolve()
+    expect(apiFetch).toHaveBeenCalledWith('/media', expect.objectContaining({ method: 'POST' }))
+  })
+})

--- a/src/web/src/components/editor/SaveIndicator.spec.ts
+++ b/src/web/src/components/editor/SaveIndicator.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SaveIndicator from './SaveIndicator.vue'
+
+function mountIndicator(props: Record<string, unknown>) {
+  return mount(SaveIndicator, { props: { lastSavedAt: null, ...props } })
+}
+
+describe('SaveIndicator', () => {
+  it('shows "Not saved yet" when idle with no save', () => {
+    const w = mountIndicator({ status: 'idle' })
+    expect(w.text()).toContain('Not saved yet')
+  })
+
+  it('shows editing while pending', () => {
+    const w = mountIndicator({ status: 'pending' })
+    expect(w.html()).toContain('Editing')
+  })
+
+  it('shows saving while saving', () => {
+    const w = mountIndicator({ status: 'saving' })
+    expect(w.html()).toContain('Saving')
+  })
+
+  it('shows the error message on error', () => {
+    const w = mountIndicator({ status: 'error', error: 'boom' })
+    expect(w.text()).toContain('Save failed: boom')
+  })
+
+  it('shows a saved timestamp when saved', () => {
+    const w = mountIndicator({ status: 'saved', lastSavedAt: new Date('2026-05-01T09:30:00Z') })
+    expect(w.text()).toMatch(/Saved at \d{2}:\d{2}:\d{2}/)
+  })
+
+  it('shows saved when a lastSavedAt exists even if status is idle', () => {
+    const w = mountIndicator({ status: 'idle', lastSavedAt: new Date('2026-05-01T09:30:00Z') })
+    expect(w.text()).toContain('Saved at')
+  })
+
+  it('applies a status-specific dot colour', () => {
+    const w = mountIndicator({ status: 'saved', lastSavedAt: new Date() })
+    expect(w.find('span').classes().join(' ')).toContain('bg-emerald-500')
+  })
+})

--- a/src/web/src/components/layout/AppFooter.spec.ts
+++ b/src/web/src/components/layout/AppFooter.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import AppFooter from './AppFooter.vue'
+
+function mountFooter() {
+  return mount(AppFooter, { global: { stubs: { RouterLink: RouterLinkStub } } })
+}
+
+describe('AppFooter', () => {
+  it('renders the white logo and explore links', () => {
+    const w = mountFooter()
+    expect(w.find('img[alt="SLYPN"]').exists()).toBe(true)
+    const links = w.findAllComponents(RouterLinkStub).map(l => l.props('to'))
+    expect(links).toContain('/about')
+    expect(links).toContain('/newsletter')
+  })
+
+  it('shows the current year and the Parkinson’s UK affiliation link', () => {
+    const w = mountFooter()
+    expect(w.text()).toContain(String(new Date().getFullYear()))
+    const ext = w.find('a[href="https://www.parkinsons.org.uk/"]')
+    expect(ext.exists()).toBe(true)
+  })
+})

--- a/src/web/src/components/layout/AppNav.spec.ts
+++ b/src/web/src/components/layout/AppNav.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const push = vi.fn()
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>)
+  return { ...actual, useRouter: () => ({ push }) }
+})
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) }),
+}))
+
+import AppNav from './AppNav.vue'
+import { useAuthStore } from '@/stores/auth'
+
+let pinia: Pinia
+
+function mountNav() {
+  return mount(AppNav, {
+    global: { plugins: [pinia], stubs: { RouterLink: RouterLinkStub } },
+  })
+}
+
+describe('AppNav', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    pinia = createPinia()
+    setActivePinia(pinia)
+    push.mockClear()
+  })
+
+  it('renders the brand logo and primary nav links', () => {
+    const w = mountNav()
+    expect(w.find('img[alt="SLYPN"]').exists()).toBe(true)
+    const tos = w.findAllComponents(RouterLinkStub).map(l => l.props('to'))
+    expect(tos).toContain('/')
+    expect(tos).toContain('/events')
+    expect(tos).toContain('/newsletter')
+  })
+
+  it('shows a Sign in button when unauthenticated', () => {
+    const w = mountNav()
+    expect(w.text()).toContain('Sign in')
+  })
+
+  it('signs in via the auth store when Sign in is clicked', async () => {
+    const w = mountNav()
+    const auth = useAuthStore()
+    await w.find('button').trigger('click') // first button is Sign in (desktop) — but find the right one
+    const signIn = w.findAll('button').find(b => b.text() === 'Sign in')
+    if (signIn) await signIn.trigger('click')
+    expect(auth.isAuthenticated).toBe(true)
+  })
+
+  it('toggles the mobile menu', async () => {
+    const w = mountNav()
+    const toggle = w.find('button[aria-controls="mobile-nav"]')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    await toggle.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+  })
+
+  it('shows the user menu with admin links when signed in as admin', async () => {
+    const auth = useAuthStore()
+    await auth.initialize() // dev-skip admin
+    const w = mountNav()
+    const trigger = w.find('[data-testid="user-menu-trigger"]')
+    expect(trigger.exists()).toBe(true)
+    expect(trigger.text()).toContain('Test Admin')
+
+    await trigger.trigger('click')
+    expect(w.text()).toContain('Dashboard')
+    expect(w.text()).toContain('Approvals')
+    expect(w.text()).toContain('Sign out')
+  })
+})

--- a/src/web/src/composables/useAsyncData.test.ts
+++ b/src/web/src/composables/useAsyncData.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useAsyncData } from './useAsyncData'
+
+describe('useAsyncData', () => {
+  it('refresh() populates data and toggles loading', async () => {
+    const fetcher = vi.fn().mockResolvedValue([1, 2, 3])
+    const { data, loading, error, refresh } = useAsyncData(fetcher, { lazy: true })
+
+    expect(data.value).toBeNull()
+    expect(loading.value).toBe(false)
+
+    const p = refresh()
+    expect(loading.value).toBe(true)
+    await p
+
+    expect(data.value).toEqual([1, 2, 3])
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('captures an Error message into error', async () => {
+    const { error, data, refresh } = useAsyncData(() => Promise.reject(new Error('nope')), { lazy: true })
+    await refresh()
+    expect(error.value).toBe('nope')
+    expect(data.value).toBeNull()
+  })
+
+  it('stringifies non-Error rejections', async () => {
+    const { error, refresh } = useAsyncData(() => Promise.reject('weird'), { lazy: true })
+    await refresh()
+    expect(error.value).toBe('weird')
+  })
+
+  it('runs automatically on mount when not lazy', async () => {
+    const fetcher = vi.fn().mockResolvedValue('ok')
+    const Comp = defineComponent({
+      setup() {
+        return useAsyncData(fetcher)
+      },
+      template: '<div>{{ data }}</div>',
+    })
+    mount(Comp)
+    await nextTick()
+    await nextTick()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/web/src/composables/useAutoSave.test.ts
+++ b/src/web/src/composables/useAutoSave.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { defineComponent, ref, nextTick, type Ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useAutoSave, type AutoSaveStatus } from './useAutoSave'
+
+interface Harness {
+  status: Ref<AutoSaveStatus>
+  errorMessage: Ref<string | null>
+  lastSavedAt: Ref<Date | null>
+}
+
+function mountAutoSave<T>(state: Ref<T>, saveFn: (v: T) => Promise<void>, options = {}) {
+  let api!: Harness
+  const Comp = defineComponent({
+    setup() {
+      api = useAutoSave(state, saveFn, options) as Harness
+      return {}
+    },
+    template: '<div />',
+  })
+  const wrapper = mount(Comp)
+  return { api, wrapper }
+}
+
+describe('useAutoSave', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('skips the initial change by default', async () => {
+    const state = ref('a')
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+    const { api } = mountAutoSave(state, saveFn)
+
+    state.value = 'b' // first change is skipped
+    await nextTick()
+    await vi.runAllTimersAsync()
+    expect(saveFn).not.toHaveBeenCalled()
+    expect(api.status.value).toBe('idle')
+  })
+
+  it('debounces and saves after quiet period, moving through statuses', async () => {
+    const state = ref('a')
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+    const { api } = mountAutoSave(state, saveFn, { skipInitial: false, debounce: 1000 })
+
+    state.value = 'b'
+    await nextTick()
+    expect(api.status.value).toBe('pending')
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(saveFn).toHaveBeenCalledWith('b')
+    expect(api.status.value).toBe('saved')
+    expect(api.lastSavedAt.value).toBeInstanceOf(Date)
+  })
+
+  it('coalesces rapid edits into a single save', async () => {
+    const state = ref(0)
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+    mountAutoSave(state, saveFn, { skipInitial: false, debounce: 500 })
+
+    state.value = 1
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(200)
+    state.value = 2
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(200)
+    state.value = 3
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(saveFn).toHaveBeenCalledTimes(1)
+    expect(saveFn).toHaveBeenCalledWith(3)
+  })
+
+  it('captures save failures into error status', async () => {
+    const state = ref('a')
+    const saveFn = vi.fn().mockRejectedValue(new Error('save failed'))
+    const { api } = mountAutoSave(state, saveFn, { skipInitial: false, debounce: 100 })
+
+    state.value = 'b'
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(api.status.value).toBe('error')
+    expect(api.errorMessage.value).toBe('save failed')
+  })
+})

--- a/src/web/src/composables/useBeforeUnload.test.ts
+++ b/src/web/src/composables/useBeforeUnload.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { defineComponent, ref, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useBeforeUnload } from './useBeforeUnload'
+
+describe('useBeforeUnload', () => {
+  let addSpy: ReturnType<typeof vi.spyOn>
+  let removeSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    addSpy = vi.spyOn(window, 'addEventListener')
+    removeSpy = vi.spyOn(window, 'removeEventListener')
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  function mountWith(initial: boolean) {
+    const shouldWarn = ref(initial)
+    const Comp = defineComponent({
+      setup() {
+        useBeforeUnload(shouldWarn)
+        return {}
+      },
+      template: '<div />',
+    })
+    return { shouldWarn, wrapper: mount(Comp) }
+  }
+
+  it('registers a beforeunload listener while shouldWarn is true', () => {
+    mountWith(true)
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
+
+  it('adds the listener when shouldWarn flips on and removes it when off', async () => {
+    const { shouldWarn } = mountWith(false)
+    addSpy.mockClear()
+    shouldWarn.value = true
+    await nextTick()
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+
+    shouldWarn.value = false
+    await nextTick()
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
+
+  it('removes the listener on unmount', () => {
+    const { wrapper } = mountWith(true)
+    removeSpy.mockClear()
+    wrapper.unmount()
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
+
+  it('the handler sets returnValue only while warning', () => {
+    const { shouldWarn } = mountWith(true)
+    const handler = addSpy.mock.calls.find(c => c[0] === 'beforeunload')![1] as (e: BeforeUnloadEvent) => void
+    const event = { preventDefault: vi.fn(), returnValue: undefined } as unknown as BeforeUnloadEvent
+    handler(event)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(event.returnValue).toBe('')
+
+    shouldWarn.value = false
+    const event2 = { preventDefault: vi.fn(), returnValue: undefined } as unknown as BeforeUnloadEvent
+    handler(event2)
+    expect(event2.preventDefault).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/src/composables/useCookieConsent.test.ts
+++ b/src/web/src/composables/useCookieConsent.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCookieConsent } from './useCookieConsent'
+
+const STORAGE_KEY = 'slypn:cookie-consent'
+
+describe('useCookieConsent', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('accept() persists "accepted" and updates the choice ref', () => {
+    const { choice, accept } = useCookieConsent()
+    accept()
+    expect(choice.value).toBe('accepted')
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('accepted')
+  })
+
+  it('decline() persists "declined"', () => {
+    const { choice, decline } = useCookieConsent()
+    decline()
+    expect(choice.value).toBe('declined')
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('declined')
+  })
+
+  it('shares one reactive choice across callers (singleton)', () => {
+    const a = useCookieConsent()
+    const b = useCookieConsent()
+    a.accept()
+    expect(b.choice.value).toBe('accepted')
+  })
+})

--- a/src/web/src/lib/api.test.ts
+++ b/src/web/src/lib/api.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { apiFetch, apiJson } from './api'
+import { useAuthStore } from '@/stores/auth'
+
+// vitest.config.ts sets VITE_DEV_SKIP_AUTH=true, so apiFetch always attaches
+// the X-Slypn-Dev-User persona header and never a real bearer token.
+
+function mockResponse(body: unknown, init: { ok?: boolean; status?: number; statusText?: string } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  localStorage.clear()
+  setActivePinia(createPinia())
+  fetchMock = vi.fn().mockResolvedValue(mockResponse({ ok: true }))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('apiFetch', () => {
+  it('prefixes /api and sends the dev persona header', async () => {
+    await apiFetch('/articles')
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/articles')
+    const headers = init.headers as Headers
+    expect(headers.get('X-Slypn-Dev-User')).toBe('admin')
+    // Dev-skip issues no token, so no Authorization header.
+    expect(headers.get('Authorization')).toBeNull()
+  })
+
+  it('defaults Content-Type to JSON when a body is present', async () => {
+    await apiFetch('/articles', { method: 'POST', body: JSON.stringify({ a: 1 }) })
+    const headers = fetchMock.mock.calls[0][1].headers as Headers
+    expect(headers.get('Content-Type')).toBe('application/json')
+  })
+
+  it('does not set Content-Type for FormData bodies', async () => {
+    const fd = new FormData()
+    fd.append('f', 'x')
+    await apiFetch('/upload', { method: 'POST', body: fd })
+    const headers = fetchMock.mock.calls[0][1].headers as Headers
+    expect(headers.get('Content-Type')).toBeNull()
+  })
+
+  it('asks the auth store for a token when authenticated', async () => {
+    const auth = useAuthStore()
+    await auth.initialize() // dev-skip signs in; acquireToken resolves null
+    const spy = vi.spyOn(auth, 'acquireToken')
+    await apiFetch('/me')
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('apiJson', () => {
+  it('returns the parsed JSON body on success', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ id: '1', title: 'Hi' }))
+    const data = await apiJson<{ id: string; title: string }>('/articles/1')
+    expect(data).toEqual({ id: '1', title: 'Hi' })
+  })
+
+  it('throws with status and body text on failure', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse('boom', { ok: false, status: 500, statusText: 'Server Error' }))
+    await expect(apiJson('/articles')).rejects.toThrow(/500 Server Error — boom/)
+  })
+})

--- a/src/web/src/lib/draft.test.ts
+++ b/src/web/src/lib/draft.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { EMPTY_DRAFT, makeDraftId } from './draft'
+
+describe('draft helpers', () => {
+  it('EMPTY_DRAFT is an article skeleton with sane defaults', () => {
+    expect(EMPTY_DRAFT.type).toBe('article')
+    expect(EMPTY_DRAFT.title).toBe('')
+    expect(EMPTY_DRAFT.tags).toEqual([])
+    expect(EMPTY_DRAFT.readingMinutes).toBe(1)
+  })
+
+  it('makeDraftId returns a 32-char hex id with no dashes', () => {
+    const id = makeDraftId()
+    expect(id).toMatch(/^[0-9a-f]{32}$/)
+    expect(id).not.toContain('-')
+  })
+
+  it('makeDraftId returns unique ids', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => makeDraftId()))
+    expect(ids.size).toBe(50)
+  })
+})

--- a/src/web/src/lib/eventTypes.test.ts
+++ b/src/web/src/lib/eventTypes.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { EVENT_TYPES } from './eventTypes'
+
+describe('EVENT_TYPES', () => {
+  it('has the seven canonical types', () => {
+    expect(EVENT_TYPES).toHaveLength(7)
+    expect(EVENT_TYPES).toContain('Coffee meet-up')
+    expect(EVENT_TYPES).toContain('Q&A')
+  })
+
+  it('is sorted alphabetically', () => {
+    const sorted = [...EVENT_TYPES].sort((a, b) => a.localeCompare(b))
+    expect([...EVENT_TYPES]).toEqual(sorted)
+  })
+
+  it('has no duplicates', () => {
+    expect(new Set(EVENT_TYPES).size).toBe(EVENT_TYPES.length)
+  })
+})

--- a/src/web/src/lib/faro.test.ts
+++ b/src/web/src/lib/faro.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { isFaroConfigured, setupFaro, getFaro } from './faro'
+
+// No VITE_FARO_URL in the test env, so Faro is unconfigured and inert.
+describe('faro (unconfigured)', () => {
+  it('reports not configured', () => {
+    expect(isFaroConfigured).toBe(false)
+  })
+
+  it('setupFaro is a no-op and never initialises an instance', () => {
+    expect(() => setupFaro()).not.toThrow()
+    expect(getFaro()).toBeNull()
+  })
+})

--- a/src/web/src/lib/msal.test.ts
+++ b/src/web/src/lib/msal.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  isAuthConfigured,
+  isDevSkipAuth,
+  msalInstance,
+  ensureMsalInitialized,
+  buildSilentRequest,
+  clearMsalInteractionState,
+  apiScope,
+} from './msal'
+import type { AccountInfo } from '@azure/msal-browser'
+
+// Test env runs in dev-skip mode (VITE_DEV_SKIP_AUTH=true). MSAL config presence
+// depends on .env, so these assertions stay config-agnostic.
+describe('msal config', () => {
+  it('runs in dev-skip mode and exposes a boolean config flag', () => {
+    expect(isDevSkipAuth).toBe(true)
+    expect(typeof isAuthConfigured).toBe('boolean')
+    // msalInstance is null iff MSAL isn't configured.
+    expect(isAuthConfigured ? msalInstance !== null : msalInstance === null).toBe(true)
+  })
+
+  it('ensureMsalInitialized resolves to null when no instance exists', async () => {
+    if (msalInstance === null) {
+      await expect(ensureMsalInitialized()).resolves.toBeNull()
+    } else {
+      expect(typeof ensureMsalInitialized).toBe('function')
+    }
+  })
+
+  it('buildSilentRequest pairs the account with the api scope', () => {
+    const account = { username: 'a@b.com' } as AccountInfo
+    expect(buildSilentRequest(account)).toEqual({ account, scopes: [apiScope] })
+  })
+
+  describe('clearMsalInteractionState', () => {
+    beforeEach(() => sessionStorage.clear())
+
+    it('removes stale interaction-status keys and leaves others', () => {
+      sessionStorage.setItem('msal.account.interaction.status', 'in_progress')
+      sessionStorage.setItem('msal.token', 'keep-me')
+      clearMsalInteractionState()
+      expect(sessionStorage.getItem('msal.account.interaction.status')).toBeNull()
+      expect(sessionStorage.getItem('msal.token')).toBe('keep-me')
+    })
+  })
+})

--- a/src/web/src/router/router.spec.ts
+++ b/src/web/src/router/router.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import router from './index'
+
+type ScrollFn = (to: { hash: string }, from: unknown, saved: unknown) => unknown
+
+beforeEach(() => setActivePinia(createPinia()))
+
+describe('router scrollBehavior', () => {
+  const scroll = router.options.scrollBehavior as unknown as ScrollFn
+
+  it('returns the saved position when navigating back/forward', () => {
+    const saved = { left: 0, top: 250 }
+    expect(scroll({ hash: '' }, {}, saved)).toBe(saved)
+  })
+
+  it('scrolls to a hash target with a header offset', () => {
+    expect(scroll({ hash: '#post-1' }, {}, null)).toEqual({ el: '#post-1', top: 96, behavior: 'smooth' })
+  })
+
+  it('scrolls to top by default', () => {
+    expect(scroll({ hash: '' }, {}, null)).toEqual({ top: 0 })
+  })
+})
+
+describe('router auth guard (dev-skip admin)', () => {
+  it('allows a public route', async () => {
+    await router.push('/')
+    expect(router.currentRoute.value.name).toBe('home')
+  })
+
+  it('allows an auth-gated route when signed in', async () => {
+    await router.push('/dashboard')
+    expect(router.currentRoute.value.name).toBe('dashboard')
+  })
+
+  it('allows a role-gated route for the admin persona', async () => {
+    await router.push('/admin/members')
+    expect(router.currentRoute.value.name).toBe('admin-members')
+  })
+})

--- a/src/web/src/stores/approvals.test.ts
+++ b/src/web/src/stores/approvals.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+const apiFetch = vi.fn()
+vi.mock('@/lib/api', () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }))
+
+import { useApprovalsStore } from './approvals'
+
+function res(body: unknown, ok = true) {
+  return { ok, json: () => Promise.resolve(body) } as unknown as Response
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  apiFetch.mockReset()
+})
+
+describe('approvals store', () => {
+  it('counts in-review articles + blog plus pending deletions', async () => {
+    apiFetch
+      .mockResolvedValueOnce(res([{ id: 'a1' }, { id: 'a2' }]))           // articles in-review
+      .mockResolvedValueOnce(res([{ id: 'b1' }]))                          // blog in-review
+      .mockResolvedValueOnce(res([{ deletionRequestedBy: 'u1' }, {}]))     // published articles
+      .mockResolvedValueOnce(res([{ deletionRequestedBy: 'u2' }]))         // published blog
+    const store = useApprovalsStore()
+    await store.refresh()
+    // 2 + 1 in-review, plus 2 deletion requests
+    expect(store.pendingCount).toBe(5)
+  })
+
+  it('bails out without updating when an in-review request fails', async () => {
+    apiFetch
+      .mockResolvedValueOnce(res([], false))
+      .mockResolvedValueOnce(res([]))
+      .mockResolvedValueOnce(res([]))
+      .mockResolvedValueOnce(res([]))
+    const store = useApprovalsStore()
+    await store.refresh()
+    expect(store.pendingCount).toBe(0)
+  })
+
+  it('swallows thrown errors and keeps the last count', async () => {
+    apiFetch.mockRejectedValue(new Error('network'))
+    const store = useApprovalsStore()
+    await store.refresh()
+    expect(store.pendingCount).toBe(0)
+  })
+
+  it('ignores deletion counts when published fetches fail', async () => {
+    apiFetch
+      .mockResolvedValueOnce(res([{ id: 'a1' }]))
+      .mockResolvedValueOnce(res([{ id: 'b1' }]))
+      .mockResolvedValueOnce(res([], false))
+      .mockResolvedValueOnce(res([], false))
+    const store = useApprovalsStore()
+    await store.refresh()
+    expect(store.pendingCount).toBe(2)
+  })
+})

--- a/src/web/src/stores/auth.msal.spec.ts
+++ b/src/web/src/stores/auth.msal.spec.ts
@@ -29,6 +29,7 @@ vi.mock('@/lib/msal', () => ({
   msalInstance: msal.instance,
 }))
 
+import { BrowserAuthError, InteractionRequiredAuthError } from '@azure/msal-browser'
 import { useAuthStore } from './auth'
 
 const account = {
@@ -89,6 +90,35 @@ describe('auth store · MSAL mode', () => {
   it('setPersona is a no-op outside dev-skip', () => {
     const auth = useAuthStore()
     expect(() => auth.setPersona('member')).not.toThrow()
+  })
+
+  it('clears stale interaction state and retries login once', async () => {
+    msal.instance.loginRedirect
+      .mockRejectedValueOnce(new BrowserAuthError('interaction_in_progress'))
+      .mockResolvedValueOnce(undefined)
+    const auth = useAuthStore()
+    await auth.login()
+    expect(msal.clearMsalInteractionState).toHaveBeenCalled()
+    expect(msal.instance.loginRedirect).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to interactive token acquisition when interaction is required', async () => {
+    msal.instance.getAllAccounts.mockReturnValue([account])
+    const auth = useAuthStore()
+    await auth.initialize()
+    msal.instance.acquireTokenSilent.mockRejectedValueOnce(new InteractionRequiredAuthError('interaction_required'))
+    await expect(auth.acquireToken()).resolves.toBeNull()
+    expect(msal.instance.acquireTokenRedirect).toHaveBeenCalled()
+  })
+
+  it('uses decoded token roles when /me is not ok', async () => {
+    msal.instance.getAllAccounts.mockReturnValue([account])
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }))
+    const auth = useAuthStore()
+    await auth.initialize()
+    // /me failed and the access token has no decodable roles, so it falls back
+    // to the id-token claim roles.
+    expect(auth.roles).toEqual(['Member'])
   })
 
   it('falls back to id-token claim roles when token acquisition fails', async () => {

--- a/src/web/src/stores/auth.msal.spec.ts
+++ b/src/web/src/stores/auth.msal.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// Exercise the real-MSAL (non dev-skip) branches of the auth store by mocking
+// the msal lib module so isDevSkipAuth is false and a fake PublicClientApplication
+// is wired in.
+const msal = vi.hoisted(() => ({
+  instance: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    handleRedirectPromise: vi.fn().mockResolvedValue(null),
+    getAllAccounts: vi.fn(() => [] as unknown[]),
+    setActiveAccount: vi.fn(),
+    loginRedirect: vi.fn().mockResolvedValue(undefined),
+    logoutRedirect: vi.fn().mockResolvedValue(undefined),
+    acquireTokenSilent: vi.fn().mockResolvedValue({ accessToken: 'access-token' }),
+    acquireTokenRedirect: vi.fn().mockResolvedValue(undefined),
+  },
+  ensureMsalInitialized: vi.fn().mockResolvedValue(null),
+  clearMsalInteractionState: vi.fn(),
+}))
+
+vi.mock('@/lib/msal', () => ({
+  apiScope: 'api://scope',
+  isAuthConfigured: true,
+  isDevSkipAuth: false,
+  buildSilentRequest: (account: unknown) => ({ account, scopes: ['api://scope'] }),
+  clearMsalInteractionState: msal.clearMsalInteractionState,
+  ensureMsalInitialized: msal.ensureMsalInitialized,
+  msalInstance: msal.instance,
+}))
+
+import { useAuthStore } from './auth'
+
+const account = {
+  username: 'user@example.com',
+  name: 'Real User',
+  idTokenClaims: { oid: 'oid-1', roles: ['Member'] },
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  msal.instance.getAllAccounts.mockReturnValue([])
+  msal.instance.acquireTokenSilent.mockResolvedValue({ accessToken: 'access-token' })
+  msal.ensureMsalInitialized.mockResolvedValue(null)
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ roles: ['Admin'] }) }))
+})
+
+describe('auth store · MSAL mode', () => {
+  it('picks up a cached account and harvests roles from /me', async () => {
+    msal.instance.getAllAccounts.mockReturnValue([account])
+    const auth = useAuthStore()
+    await auth.initialize()
+    expect(auth.isAuthenticated).toBe(true)
+    expect(msal.instance.setActiveAccount).toHaveBeenCalledWith(account)
+    expect(auth.roles).toEqual(['Admin']) // from /api/me
+    expect(auth.isAdmin).toBe(true)
+  })
+
+  it('uses the account from a redirect result', async () => {
+    msal.ensureMsalInitialized.mockResolvedValue({ account })
+    const auth = useAuthStore()
+    await auth.initialize()
+    expect(auth.isAuthenticated).toBe(true)
+    expect(msal.instance.setActiveAccount).toHaveBeenCalledWith(account)
+  })
+
+  it('login triggers a redirect', async () => {
+    const auth = useAuthStore()
+    await auth.login('/dashboard')
+    expect(msal.instance.loginRedirect).toHaveBeenCalled()
+  })
+
+  it('logout triggers a redirect when signed in', async () => {
+    msal.instance.getAllAccounts.mockReturnValue([account])
+    const auth = useAuthStore()
+    await auth.initialize()
+    await auth.logout()
+    expect(msal.instance.logoutRedirect).toHaveBeenCalled()
+  })
+
+  it('acquireToken returns the silent token', async () => {
+    msal.instance.getAllAccounts.mockReturnValue([account])
+    const auth = useAuthStore()
+    await auth.initialize()
+    await expect(auth.acquireToken()).resolves.toBe('access-token')
+  })
+
+  it('setPersona is a no-op outside dev-skip', () => {
+    const auth = useAuthStore()
+    expect(() => auth.setPersona('member')).not.toThrow()
+  })
+
+  it('falls back to id-token claim roles when token acquisition fails', async () => {
+    msal.instance.getAllAccounts.mockReturnValue([account])
+    msal.instance.acquireTokenSilent.mockRejectedValue(new Error('login required'))
+    const auth = useAuthStore()
+    await auth.initialize()
+    // apiRoles stays empty, so the computed falls back to idTokenClaims.roles.
+    expect(auth.roles).toEqual(['Member'])
+  })
+})

--- a/src/web/src/stores/auth.test.ts
+++ b/src/web/src/stores/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { useAuthStore } from './auth'
 import { DEV_PERSONA_STORAGE_KEY } from '@/lib/devPersonas'
@@ -32,5 +32,73 @@ describe('auth store · dev-skip personas', () => {
     expect(auth.isAdmin).toBe(false)
     expect(auth.isMember).toBe(true)
     expect(auth.displayName).toBe('Test Member')
+  })
+})
+
+describe('auth store · getters and actions (dev-skip)', () => {
+  let origLocation: Location
+
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    origLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { href: 'http://localhost/', origin: 'http://localhost', reload: vi.fn() },
+    })
+  })
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: origLocation })
+  })
+
+  it('isConfigured is true in dev-skip mode', () => {
+    expect(useAuthStore().isConfigured).toBe(true)
+  })
+
+  it('displayName falls back to "Member" before sign-in', () => {
+    const auth = useAuthStore()
+    expect(auth.isAuthenticated).toBe(false)
+    expect(auth.displayName).toBe('Member')
+  })
+
+  it('oid resolves to the active persona oid', () => {
+    const auth = useAuthStore()
+    expect(auth.oid).toBe('11111111-1111-1111-1111-111111111111')
+  })
+
+  it('acquireToken returns null in dev-skip mode', async () => {
+    const auth = useAuthStore()
+    await auth.initialize()
+    await expect(auth.acquireToken()).resolves.toBeNull()
+  })
+
+  it('login signs in as the dev account', async () => {
+    const auth = useAuthStore()
+    await auth.login()
+    expect(auth.isAuthenticated).toBe(true)
+    expect(auth.displayName).toBe('Test Admin')
+  })
+
+  it('logout clears the account', async () => {
+    const auth = useAuthStore()
+    await auth.initialize()
+    expect(auth.isAuthenticated).toBe(true)
+    await auth.logout()
+    expect(auth.isAuthenticated).toBe(false)
+    expect(auth.roles).toEqual([])
+  })
+
+  it('setPersona persists the key and reloads', () => {
+    const auth = useAuthStore()
+    auth.setPersona('contributor')
+    expect(localStorage.getItem(DEV_PERSONA_STORAGE_KEY)).toBe('contributor')
+    expect(window.location.reload).toHaveBeenCalled()
+  })
+
+  it('initialize is idempotent', async () => {
+    const auth = useAuthStore()
+    await auth.initialize()
+    await auth.initialize()
+    expect(auth.initialized).toBe(true)
   })
 })

--- a/src/web/src/test/setup.ts
+++ b/src/web/src/test/setup.ts
@@ -1,0 +1,15 @@
+// Global test setup: stub browser APIs happy-dom doesn't implement so views
+// that use them (infinite-scroll sentinels, etc.) can mount.
+import { vi } from 'vitest'
+
+class IntersectionObserverStub {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  takeRecords = vi.fn(() => [])
+  root = null
+  rootMargin = ''
+  thresholds = []
+}
+
+vi.stubGlobal('IntersectionObserver', IntersectionObserverStub)

--- a/src/web/src/views/EditorView.spec.ts
+++ b/src/web/src/views/EditorView.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+
+import EditorView from './EditorView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const DraftEditorStub = {
+  props: ['draftId', 'readonly', 'initialContent'],
+  template: '<div class="draft-editor-stub" />',
+  methods: { flush() { return Promise.resolve() }, isDirty() { return false } },
+}
+const stubs = { teleport: true, DraftEditor: DraftEditorStub }
+let pinia: Pinia
+const mountV = () => mount(EditorView, { global: { plugins: [pinia], stubs } })
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+}
+
+const draftSummary = (over = {}) => ({ id: 'd1', title: 'A draft', type: 'article', updatedAt: '2026-05-01T00:00:00Z', _etag: 'e1', ...over })
+
+function mockLists(drafts: unknown[]) {
+  apiJson.mockImplementation((path: string) => {
+    if (path === '/drafts') return Promise.resolve(drafts)
+    return Promise.resolve([]) // in-review article/blog
+  })
+}
+
+beforeEach(async () => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiJson.mockReset(); apiFetch.mockReset()
+  vi.stubGlobal('confirm', vi.fn(() => true))
+  await useAuthStore().initialize()
+})
+
+describe('EditorView', () => {
+  it('lists existing drafts', async () => {
+    mockLists([draftSummary(), draftSummary({ id: 'd2', title: 'Second draft' })])
+    const w = mountV()
+    await flushPromises()
+    expect(w.text()).toContain('A draft')
+    expect(w.text()).toContain('Second draft')
+  })
+
+  it('shows the empty state', async () => {
+    mockLists([])
+    const w = mountV()
+    await flushPromises()
+    expect(w.text()).toContain('No drafts or submissions yet')
+  })
+
+  it('creates a new draft and opens the editor', async () => {
+    mockLists([])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountV()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('New draft'))!.trigger('click')
+    await w.find('input[type="text"]').setValue('Fresh idea')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith(expect.stringMatching(/^\/drafts\//), expect.objectContaining({ method: 'PUT' }))
+    expect(w.find('.draft-editor-stub').exists()).toBe(true)
+  })
+
+  it('opens an existing draft when its row is clicked', async () => {
+    mockLists([draftSummary()])
+    const w = mountV()
+    await flushPromises()
+    await w.find('[role="button"]').trigger('click')
+    await flushPromises()
+    expect(w.find('.draft-editor-stub').exists()).toBe(true)
+  })
+
+  it('deletes a draft after confirmation', async () => {
+    mockLists([draftSummary()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountV()
+    await flushPromises()
+    await w.find('button[title="Delete draft"]').trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/drafts/d1', expect.objectContaining({ method: 'DELETE' }))
+    expect(w.text()).toContain('No drafts or submissions yet')
+  })
+
+  it('shows a list load error', async () => {
+    apiJson.mockImplementation((path: string) => {
+      if (path === '/drafts') return Promise.reject(new Error('list boom'))
+      return Promise.resolve([])
+    })
+    const w = mountV()
+    await flushPromises()
+    expect(w.text()).toContain('list boom')
+  })
+})

--- a/src/web/src/views/MemberManagementView.spec.ts
+++ b/src/web/src/views/MemberManagementView.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+
+import MemberManagementView from './MemberManagementView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const stubs = { RouterLink: RouterLinkStub }
+let pinia: Pinia
+const mountC = () => mount(MemberManagementView, { global: { plugins: [pinia], stubs } })
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+}
+
+const member = (over = {}) => ({
+  id: 'm1', email: 'a@b.com', displayName: 'Alice', roles: ['Member'],
+  status: 'active', invitedAt: '2026-04-01T00:00:00Z', oid: 'oidA', _etag: 'e1', ...over,
+})
+
+beforeEach(async () => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiJson.mockReset()
+  apiFetch.mockReset()
+  vi.stubGlobal('confirm', vi.fn(() => true))
+  await useAuthStore().initialize()
+})
+
+describe('MemberManagementView', () => {
+  it('lists members', async () => {
+    apiJson.mockResolvedValue([member()])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('Alice')
+    expect(w.text()).toContain('a@b.com')
+  })
+
+  it('changes a member role via PATCH', async () => {
+    apiJson.mockResolvedValue([member()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountC()
+    await flushPromises()
+    const adminBtn = w.findAll('button').find(b => b.text() === 'Admin')!
+    await adminBtn.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/members/m1', expect.objectContaining({ method: 'PATCH' }))
+  })
+
+  it('removes a member after confirmation', async () => {
+    apiJson.mockResolvedValue([member()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Remove')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/members/m1', expect.objectContaining({ method: 'DELETE' }))
+  })
+
+  it('disables removing yourself', async () => {
+    // admin persona oid
+    apiJson.mockResolvedValue([member({ id: 'me', oid: '11111111-1111-1111-1111-111111111111' })])
+    const w = mountC()
+    await flushPromises()
+    const removeBtn = w.findAll('button').find(b => b.text() === 'Remove')!
+    expect(removeBtn.attributes('disabled')).toBeDefined()
+  })
+
+  it('sends an invite and shows the redeem link', async () => {
+    apiJson.mockResolvedValue([])
+    apiFetch.mockResolvedValue(ok({ member: { email: 'new@x.com' }, inviteSent: true, redeemUrl: 'https://redeem/abc', inviteReason: null }))
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Invite a member'))!.trigger('click')
+    await w.find('input[type="email"]').setValue('new@x.com')
+    await w.find('input[type="text"]').setValue('New Person')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/members/invite', expect.objectContaining({ method: 'POST' }))
+    expect(w.text()).toContain('https://redeem/abc')
+  })
+
+  it('shows the empty state', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('No members yet')
+  })
+
+  it('shows a load error', async () => {
+    apiJson.mockRejectedValue(new Error('boom'))
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain("Couldn't load members")
+  })
+})

--- a/src/web/src/views/views.admin.spec.ts
+++ b/src/web/src/views/views.admin.spec.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>)
+  return { ...actual, useRoute: () => ({ params: {}, query: {} }), useRouter: () => ({ push: vi.fn() }) }
+})
+
+import ApprovalsQueue from '@/components/common/ApprovalsQueue.vue'
+import ResourceManagementView from './ResourceManagementView.vue'
+import ApprovalsView from './ApprovalsView.vue'
+import ManageContentView from './ManageContentView.vue'
+
+const stubs = { RouterLink: RouterLinkStub, teleport: true }
+let pinia: Pinia
+const mountC = (C: unknown) => mount(C as never, { global: { plugins: [pinia], stubs } })
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+}
+
+beforeEach(() => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiJson.mockReset()
+  apiFetch.mockReset()
+  vi.stubGlobal('confirm', vi.fn(() => true))
+})
+
+const pending = (over = {}) => ({
+  id: 'p1', slug: 's', title: 'Pending piece', summary: 'sum', body: '<p>body</p>',
+  author: 'Jess', publishedAt: '2026-05-01T10:00:00Z', category: 'Community', tags: [],
+  status: 'in-review', readingMinutes: 3, type: 'article', ...over,
+})
+
+describe('ApprovalsQueue', () => {
+  function mockLoad(articles: unknown[], published: unknown[] = []) {
+    apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET' && url === '/articles?status=in-review') return Promise.resolve(ok(articles))
+      if (method === 'GET' && url === '/blog?status=in-review') return Promise.resolve(ok([]))
+      if (method === 'GET' && url === '/articles?status=published') return Promise.resolve(ok(published))
+      if (method === 'GET' && url === '/blog?status=published') return Promise.resolve(ok([]))
+      return Promise.resolve(ok({}))
+    })
+  }
+
+  it('renders pending articles grouped by author', async () => {
+    mockLoad([pending()])
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    expect(w.text()).toContain('Jess')
+    expect(w.text()).toContain('Pending piece')
+  })
+
+  it('shows the empty state', async () => {
+    mockLoad([])
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    expect(w.text()).toContain('No submissions waiting')
+  })
+
+  it('approves (publishes) an article and removes it', async () => {
+    mockLoad([pending()])
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Approve')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/articles/p1/publish', { method: 'POST' })
+    expect(w.text()).not.toContain('Pending piece')
+  })
+
+  it('toggles the article body open', async () => {
+    mockLoad([pending()])
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Pending piece')!.trigger('click')
+    expect(w.html()).toContain('<p>body</p>')
+  })
+
+  it('requests a revision with feedback', async () => {
+    mockLoad([pending()])
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Revise')!.trigger('click')
+    const textarea = w.find('textarea')
+    await textarea.setValue('Please tighten the intro')
+    await w.findAll('button').find(b => b.text() === 'Send back for revision')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/articles/p1/revise', expect.objectContaining({ method: 'POST' }))
+    expect(w.text()).not.toContain('Pending piece')
+  })
+
+  it('lists deletion requests and approves a deletion', async () => {
+    mockLoad([], [pending({ id: 'd1', title: 'Old post', deletionRequestedBy: 'u9' })])
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    expect(w.text()).toContain('Deletion requests')
+    expect(w.text()).toContain('Old post')
+    await w.findAll('button').find(b => b.text() === 'Approve deletion')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/articles/d1?status=published', { method: 'DELETE' })
+  })
+
+  it('shows a load error', async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error', json: () => Promise.resolve([]), text: () => Promise.resolve('') } as unknown as Response)
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    expect(w.text()).toContain('500')
+  })
+})
+
+describe('ResourceManagementView', () => {
+  const resource = (over = {}) => ({ id: 'r1', title: 'Helpline', description: 'd', url: 'https://x.org/a', category: 'NHS', _etag: 'e1', ...over })
+
+  it('renders resources grouped by category', async () => {
+    apiJson.mockResolvedValue([resource()])
+    const w = mountC(ResourceManagementView)
+    await flushPromises()
+    expect(w.text()).toContain('Helpline')
+    expect(w.text()).toContain('NHS')
+  })
+
+  it('adds a resource via the dialog', async () => {
+    apiJson.mockResolvedValue([])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountC(ResourceManagementView)
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Add resource'))!.trigger('click')
+    await w.find('input[type="text"]').setValue('New link')
+    await w.find('textarea').setValue('desc')
+    await w.find('input[type="url"]').setValue('https://new.example')
+    const catInput = w.findAll('input').find(i => i.attributes('list') === 'resource-category-hints')!
+    await catInput.setValue('Local')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/resources', expect.objectContaining({ method: 'POST' }))
+  })
+
+  it('deletes a resource after confirmation', async () => {
+    apiJson.mockResolvedValue([resource()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountC(ResourceManagementView)
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith(expect.stringContaining('/resources/r1?category=NHS'), expect.objectContaining({ method: 'DELETE' }))
+  })
+
+  it('shows the empty state', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountC(ResourceManagementView)
+    await flushPromises()
+    expect(w.text()).toContain('No resources yet')
+  })
+})
+
+describe('admin wrapper views', () => {
+  it('ApprovalsView mounts its queue', async () => {
+    apiFetch.mockResolvedValue(ok([]))
+    const w = mountC(ApprovalsView)
+    await flushPromises()
+    expect(w.text()).toContain('Approvals')
+  })
+
+  it('ManageContentView mounts published content', async () => {
+    apiFetch.mockResolvedValue(ok([]))
+    apiJson.mockResolvedValue([])
+    const w = mountC(ManageContentView)
+    await flushPromises()
+    expect(w.text()).toContain('Content management')
+  })
+})

--- a/src/web/src/views/views.events.spec.ts
+++ b/src/web/src/views/views.events.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+const router = { push: vi.fn(), replace: vi.fn().mockResolvedValue(undefined), back: vi.fn() }
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>)
+  return { ...actual, useRoute: () => ({ params: {}, query: {} }), useRouter: () => router }
+})
+
+import MonthRangePicker from '@/components/common/MonthRangePicker.vue'
+import EventFormDialog from '@/components/common/EventFormDialog.vue'
+import EventCalendar from '@/components/common/EventCalendar.vue'
+import EventManagementView from './EventManagementView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const stubs = { RouterLink: RouterLinkStub, teleport: true }
+let pinia: Pinia
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+}
+
+beforeEach(() => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiJson.mockReset(); apiFetch.mockReset()
+  vi.stubGlobal('confirm', vi.fn(() => true))
+})
+
+describe('MonthRangePicker', () => {
+  const mountP = (start: Date, end: Date | null) =>
+    mount(MonthRangePicker, { props: { start, end } })
+
+  it('labels a closed range', () => {
+    const w = mountP(new Date(2026, 0, 1), new Date(2026, 5, 1))
+    expect(w.text()).toContain('Jan 2026')
+    expect(w.text()).toContain('Jun 2026')
+  })
+
+  it('labels an open-ended range with "onwards"', () => {
+    const w = mountP(new Date(2026, 0, 1), null)
+    expect(w.text()).toContain('onwards')
+  })
+
+  it('emits a start/end range after two picks', async () => {
+    const w = mountP(new Date(2026, 0, 1), new Date(2026, 0, 1))
+    await w.find('button').trigger('click') // open
+    const monthButtons = w.findAll('button').filter(b => b.text() === 'Mar' || b.text() === 'Jun')
+    await monthButtons[0].trigger('click') // start
+    await monthButtons[1].trigger('click') // end
+    expect(w.emitted('change')).toBeTruthy()
+    const [start, end] = w.emitted('change')![0] as [Date, Date]
+    expect(start).toBeInstanceOf(Date)
+    expect(end).toBeInstanceOf(Date)
+  })
+
+  it('emits a null end via "No end date"', async () => {
+    const w = mountP(new Date(2026, 0, 1), new Date(2026, 0, 1))
+    await w.find('button').trigger('click')
+    await w.findAll('button').find(b => b.text() === 'No end date')!.trigger('click')
+    expect(w.emitted('change')![0][1]).toBeNull()
+  })
+})
+
+describe('EventFormDialog', () => {
+  const evt = { id: 'e1', title: 'Quiz', type: 'Q&A', startsAt: '2026-06-01T18:00:00Z', endsAt: '2026-06-01T20:00:00Z', location: 'Pub', description: 'Fun', _etag: 'w1' }
+
+  it('adds an event via POST', async () => {
+    apiFetch.mockResolvedValue(ok({ id: 'new' }))
+    const w = mount(EventFormDialog, { props: { open: true, event: null }, global: { stubs } })
+    await w.find('input[type="text"]').setValue('Coffee')
+    await w.find('input[type="datetime-local"]').setValue('2026-06-01T10:00')
+    await w.findAll('input[type="datetime-local"]')[1].setValue('2026-06-01T12:00')
+    await w.findAll('input[type="text"]')[1].setValue('Brixton')
+    await w.find('textarea').setValue('Morning coffee')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/events', expect.objectContaining({ method: 'POST' }))
+    expect(w.emitted('saved')).toBeTruthy()
+  })
+
+  it('edits an event via PUT and prefills fields', async () => {
+    apiFetch.mockResolvedValue(ok({ id: 'e1' }))
+    const w = mount(EventFormDialog, { props: { open: true, event: evt }, global: { stubs } })
+    expect((w.find('input[type="text"]').element as HTMLInputElement).value).toBe('Quiz')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/events/e1', expect.objectContaining({ method: 'PUT' }))
+  })
+
+  it('emits close on Cancel', async () => {
+    const w = mount(EventFormDialog, { props: { open: true, event: null }, global: { stubs } })
+    await w.findAll('button').find(b => b.text() === 'Cancel')!.trigger('click')
+    expect(w.emitted('close')).toBeTruthy()
+  })
+
+  it('shows an error when the save fails', async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 400, statusText: 'Bad', text: () => Promise.resolve('invalid'), json: () => Promise.resolve({}) } as unknown as Response)
+    const w = mount(EventFormDialog, { props: { open: true, event: evt }, global: { stubs } })
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(w.text()).toContain('400')
+  })
+})
+
+describe('EventCalendar', () => {
+  it('renders the month label and weekday headers', () => {
+    const w = mount(EventCalendar, { props: { events: [] }, global: { stubs } })
+    expect(w.text()).toContain('Mon')
+    expect(w.text()).toContain('Sun')
+  })
+
+  it('navigates between months', async () => {
+    const w = mount(EventCalendar, { props: { events: [] }, global: { stubs } })
+    const label = w.find('h3').text()
+    await w.find('button[aria-label="Next month"]').trigger('click')
+    expect(w.find('h3').text()).not.toBe(label)
+    await w.find('button[aria-label="Previous month"]').trigger('click')
+    expect(w.find('h3').text()).toBe(label)
+  })
+
+  it('renders an event pill', () => {
+    const now = new Date()
+    const iso = (d: number, h: number) => new Date(now.getFullYear(), now.getMonth(), d, h).toISOString()
+    const w = mount(EventCalendar, {
+      props: { events: [{ id: 'e1', title: 'Coffee', type: 'Coffee meet-up', startsAt: iso(15, 10), endsAt: iso(15, 12), location: 'X', description: 'd' }] },
+      global: { stubs },
+    })
+    expect(w.text()).toContain('Coffee')
+  })
+})
+
+describe('EventManagementView', () => {
+  const evt = (over = {}) => ({ id: 'e1', title: 'Team coffee', type: 'Coffee meet-up', startsAt: new Date().toISOString(), endsAt: new Date(Date.now() + 3600000).toISOString(), location: 'Brixton', description: 'd', _etag: 'w1', ...over })
+  const childStubs = {
+    ...stubs,
+    MonthRangePicker: { template: '<div class="mrp" />' },
+    EventFormDialog: { props: ['open', 'event'], template: '<div v-if="open" class="event-dialog-open" />' },
+  }
+  const mountV = () => mount(EventManagementView, { global: { plugins: [pinia], stubs: childStubs } })
+
+  beforeEach(async () => { await useAuthStore().initialize() })
+
+  it('lists events (ignoring the date range)', async () => {
+    apiJson.mockResolvedValue([evt()])
+    const w = mountV()
+    await flushPromises()
+    await w.find('input[type="checkbox"]').setValue(true)
+    expect(w.text()).toContain('Team coffee')
+  })
+
+  it('opens the add dialog', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountV()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Add event'))!.trigger('click')
+    expect(w.find('.event-dialog-open').exists()).toBe(true)
+  })
+
+  it('deletes an event after confirmation', async () => {
+    apiJson.mockResolvedValue([evt()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountV()
+    await flushPromises()
+    await w.find('input[type="checkbox"]').setValue(true)
+    await w.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/events/e1', expect.objectContaining({ method: 'DELETE' }))
+  })
+
+  it('shows a load error', async () => {
+    apiJson.mockRejectedValue(new Error('boom'))
+    const w = mountV()
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load events')
+  })
+})

--- a/src/web/src/views/views.misc.spec.ts
+++ b/src/web/src/views/views.misc.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+
+const route = { params: {} as Record<string, string>, query: {} as Record<string, string>, hash: '', fullPath: '/missing' }
+const router = { push: vi.fn(), replace: vi.fn(), back: vi.fn() }
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>)
+  return { ...actual, useRoute: () => route, useRouter: () => router }
+})
+
+import EventsView from './EventsView.vue'
+import EventsPreviousView from './EventsPreviousView.vue'
+import EventDetailView from './EventDetailView.vue'
+import ArticleDetailView from './ArticleDetailView.vue'
+import DashboardView from './DashboardView.vue'
+import LoginView from './LoginView.vue'
+import NotFoundView from './NotFoundView.vue'
+import AuthCallbackView from './AuthCallbackView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const stubs = { RouterLink: RouterLinkStub, EventCalendar: { template: '<div class="event-calendar-stub" />' } }
+let pinia: Pinia
+const mountView = (C: unknown) => mount(C as never, { global: { plugins: [pinia], stubs } })
+
+const ev = (over = {}) => ({
+  id: 'e1', title: 'Coffee morning', type: 'Coffee meet-up',
+  startsAt: '2999-06-01T10:00:00Z', endsAt: '2999-06-01T12:00:00Z',
+  location: 'Brixton', description: 'Come along', ...over,
+})
+
+function jsonResponse(body: unknown, init: { status?: number; ok?: boolean } = {}) {
+  return { status: init.status ?? 200, ok: init.ok ?? true, statusText: 'OK', json: () => Promise.resolve(body) } as unknown as Response
+}
+
+beforeEach(() => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiJson.mockReset()
+  apiFetch.mockReset()
+  Object.assign(route, { params: {}, query: {}, hash: '', fullPath: '/missing' })
+  router.push.mockClear(); router.replace.mockClear(); router.back.mockClear()
+})
+
+describe('EventsView', () => {
+  it('renders upcoming events and toggles to the calendar', async () => {
+    apiJson.mockResolvedValue([ev()])
+    const w = mountView(EventsView)
+    await flushPromises()
+    expect(w.text()).toContain('Coffee morning')
+
+    const calBtn = w.findAll('button').find(b => b.text() === 'Calendar')!
+    await calBtn.trigger('click')
+    expect(w.find('.event-calendar-stub').exists()).toBe(true)
+  })
+
+  it('shows the error state', async () => {
+    apiJson.mockRejectedValue(new Error('down'))
+    const w = mountView(EventsView)
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load events')
+  })
+})
+
+describe('EventsPreviousView', () => {
+  it('lists past events', async () => {
+    apiJson.mockResolvedValue([ev({ id: 'old', title: 'Old social', startsAt: '2020-01-01T10:00:00Z', endsAt: '2020-01-01T11:00:00Z' })])
+    const w = mountView(EventsPreviousView)
+    await flushPromises()
+    expect(w.text()).toContain('Old social')
+  })
+
+  it('shows the empty state when there are no past events', async () => {
+    apiJson.mockResolvedValue([ev()])
+    const w = mountView(EventsPreviousView)
+    await flushPromises()
+    expect(w.text()).toContain('No previous events found')
+  })
+})
+
+describe('EventDetailView', () => {
+  it('renders the event and goes back on click', async () => {
+    route.params = { id: 'e1' }
+    apiJson.mockResolvedValue(ev())
+    const w = mountView(EventDetailView)
+    await flushPromises()
+    expect(w.text()).toContain('Coffee morning')
+    expect(w.text()).toContain('Brixton')
+    await w.find('button').trigger('click')
+    expect(router.back).toHaveBeenCalled()
+  })
+
+  it('shows an error message on failure', async () => {
+    route.params = { id: 'e1' }
+    apiJson.mockRejectedValue(new Error('gone'))
+    const w = mountView(EventDetailView)
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load event')
+  })
+})
+
+describe('ArticleDetailView', () => {
+  const art = { id: 'a1', slug: 's', title: 'Deep dive', summary: 'sum', body: '<p>hi</p>', author: 'Jo', publishedAt: '2026-05-01T00:00:00Z', readingMinutes: 5, category: 'Community', tags: ['t'] }
+
+  it('renders the fetched article', async () => {
+    route.params = { slug: 's' }
+    apiFetch.mockResolvedValue(jsonResponse(art))
+    const w = mountView(ArticleDetailView)
+    await flushPromises()
+    expect(w.text()).toContain('Deep dive')
+    expect(w.html()).toContain('hi')
+  })
+
+  it('shows not-found when the article is 404', async () => {
+    route.params = { slug: 'missing' }
+    apiFetch.mockResolvedValue(jsonResponse(null, { status: 404, ok: false }))
+    const w = mountView(ArticleDetailView)
+    await flushPromises()
+    expect(w.text()).toContain('Article not found')
+  })
+
+  it('shows an error on non-404 failure', async () => {
+    route.params = { slug: 's' }
+    apiFetch.mockResolvedValue(jsonResponse(null, { status: 500, ok: false }))
+    const w = mountView(ArticleDetailView)
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load this article')
+  })
+})
+
+describe('DashboardView', () => {
+  it('greets the signed-in admin and shows admin tiles', async () => {
+    apiFetch.mockResolvedValue(jsonResponse([]))
+    const auth = useAuthStore()
+    await auth.initialize()
+    const w = mountView(DashboardView)
+    await flushPromises()
+    expect(w.text()).toContain('Welcome back, Test Admin')
+    expect(w.text()).toContain('Admin')
+    expect(w.text()).toContain('Approvals')
+    expect(w.text()).toContain('Members')
+  })
+})
+
+describe('LoginView', () => {
+  it('offers sign-in and triggers login when configured', async () => {
+    const w = mountView(LoginView)
+    const auth = useAuthStore()
+    expect(w.text()).toContain('Continue with Entra External ID')
+    await w.find('button').trigger('click')
+    await flushPromises()
+    expect(auth.isAuthenticated).toBe(true)
+  })
+
+  it('shows the already-signed-in state', async () => {
+    const auth = useAuthStore()
+    await auth.initialize()
+    const w = mountView(LoginView)
+    expect(w.text()).toContain('already signed in')
+  })
+})
+
+describe('NotFoundView', () => {
+  it('shows the requested path', () => {
+    route.fullPath = '/nope'
+    const w = mountView(NotFoundView)
+    expect(w.text()).toContain('/nope')
+  })
+})
+
+describe('AuthCallbackView', () => {
+  it('initialises auth and redirects home', async () => {
+    const w = mountView(AuthCallbackView)
+    await flushPromises()
+    expect(w.text()).toContain('Signing you in')
+    expect(router.replace).toHaveBeenCalledWith({ name: 'home' })
+  })
+})

--- a/src/web/src/views/views.public.spec.ts
+++ b/src/web/src/views/views.public.spec.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+
+const route = { params: {} as Record<string, string>, query: {} as Record<string, string>, hash: '', fullPath: '/' }
+const router = { push: vi.fn(), replace: vi.fn(), back: vi.fn() }
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>)
+  return { ...actual, useRoute: () => route, useRouter: () => router }
+})
+
+import ArticlesView from './ArticlesView.vue'
+import ResourcesView from './ResourcesView.vue'
+import BlogView from './BlogView.vue'
+import NewsletterView from './NewsletterView.vue'
+import HomeView from './HomeView.vue'
+import AboutView from './AboutView.vue'
+
+const stubs = { RouterLink: RouterLinkStub }
+const mountView = (C: unknown) => mount(C as never, { global: { plugins: [createPinia()], stubs } })
+
+const article = (over = {}) => ({
+  id: 'a1', slug: 'a-1', title: 'Article One', summary: 's', body: 'b',
+  author: 'Jane', publishedAt: '2026-05-01T00:00:00Z', readingMinutes: 3,
+  category: 'Community', tags: [], ...over,
+})
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  apiJson.mockReset()
+  apiFetch.mockReset()
+  route.params = {}; route.query = {}; route.hash = ''
+})
+
+describe('ArticlesView', () => {
+  it('renders a card per published article', async () => {
+    apiJson.mockResolvedValue([article(), article({ id: 'a2', title: 'Article Two', category: 'Lifestyle' })])
+    const w = mountView(ArticlesView)
+    await flushPromises()
+    expect(w.text()).toContain('Article One')
+    expect(w.text()).toContain('Article Two')
+  })
+
+  it('filters by category when a pill is clicked', async () => {
+    apiJson.mockResolvedValue([article(), article({ id: 'a2', title: 'Article Two', category: 'Lifestyle' })])
+    const w = mountView(ArticlesView)
+    await flushPromises()
+    const lifestyle = w.findAll('button').find(b => b.text() === 'Lifestyle')!
+    await lifestyle.trigger('click')
+    expect(w.text()).toContain('Article Two')
+    expect(w.text()).not.toContain('Article One')
+  })
+
+  it('shows the empty state when there are none', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountView(ArticlesView)
+    await flushPromises()
+    expect(w.text()).toContain('No articles in this category yet.')
+  })
+
+  it('shows an error with a retry button', async () => {
+    apiJson.mockRejectedValue(new Error('boom'))
+    const w = mountView(ArticlesView)
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load articles')
+    expect(w.find('button').text()).toContain('Retry')
+  })
+})
+
+describe('ResourcesView', () => {
+  const resource = (over = {}) => ({ id: 'r1', title: 'Helpline', description: 'd', url: 'https://x.org/a', category: 'NHS', ...over })
+
+  it('renders resources and filters by category', async () => {
+    apiJson.mockResolvedValue([resource(), resource({ id: 'r2', title: 'Local clinic', category: 'Local' })])
+    const w = mountView(ResourcesView)
+    await flushPromises()
+    expect(w.text()).toContain('Helpline')
+    const local = w.findAll('button').find(b => b.text() === 'Local')!
+    await local.trigger('click')
+    expect(w.text()).toContain('Local clinic')
+    expect(w.text()).not.toContain('Helpline')
+  })
+
+  it('shows the error state', async () => {
+    apiJson.mockRejectedValue(new Error('nope'))
+    const w = mountView(ResourcesView)
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load resources')
+  })
+})
+
+describe('BlogView', () => {
+  const post = (over = {}) => ({ id: 'p1', title: 'Post One', summary: 's', body: '<p>b</p>', author: 'Sam', publishedAt: '2026-05-01T00:00:00Z', category: 'News', ...over })
+
+  it('renders posts with anchors', async () => {
+    apiJson.mockResolvedValue([post()])
+    const w = mountView(BlogView)
+    await flushPromises()
+    expect(w.text()).toContain('Post One')
+    expect(w.find('#post-p1').exists()).toBe(true)
+  })
+
+  it('shows the empty state', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountView(BlogView)
+    await flushPromises()
+    expect(w.text()).toContain('No posts yet')
+  })
+})
+
+describe('NewsletterView', () => {
+  it('lists past issues and subscribes on submit', async () => {
+    apiJson.mockResolvedValue([{ id: 'n1', title: 'May 2026', issueDate: '2026-05-01', summary: 's', topics: ['x'] }])
+    apiFetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
+    const w = mountView(NewsletterView)
+    await flushPromises()
+    expect(w.text()).toContain('Past issues')
+    expect(w.text()).toContain('May 2026')
+
+    await w.find('input[type="email"]').setValue('me@example.com')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/newsletter/subscribe', expect.objectContaining({ method: 'POST' }))
+    expect(w.text()).toContain('you’re on the list')
+  })
+
+  it('surfaces a subscribe error', async () => {
+    apiJson.mockResolvedValue([])
+    apiFetch.mockResolvedValue({ ok: false, status: 400, statusText: 'Bad', text: () => Promise.resolve('nope') })
+    const w = mountView(NewsletterView)
+    await flushPromises()
+    await w.find('input[type="email"]').setValue('me@example.com')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t subscribe')
+  })
+})
+
+describe('HomeView', () => {
+  it('renders featured articles, blog, and events', async () => {
+    apiJson.mockImplementation((path: string) => {
+      if (path.startsWith('/articles')) return Promise.resolve([article()])
+      if (path.startsWith('/blog')) return Promise.resolve([{ id: 'p1', title: 'Blog One', summary: 's', author: 'Sam', publishedAt: '2026-05-01T00:00:00Z' }])
+      if (path.startsWith('/events')) return Promise.resolve([{ id: 'e1', title: 'Coffee', type: 'Coffee meet-up', startsAt: '2026-06-01T10:00:00Z', endsAt: '2026-06-01T12:00:00Z', location: 'Brixton', description: 'd' }])
+      return Promise.resolve([])
+    })
+    const w = mountView(HomeView)
+    await flushPromises()
+    expect(w.text()).toContain('From our members')
+    expect(w.text()).toContain('Article One')
+    expect(w.text()).toContain('Blog One')
+    expect(w.text()).toContain('Coffee')
+  })
+})
+
+describe('AboutView', () => {
+  it('renders the static about content', () => {
+    const w = mountView(AboutView)
+    expect(w.text()).toContain('Who we are')
+    expect(w.text()).toContain('Founders')
+  })
+})

--- a/src/web/vitest.config.ts
+++ b/src/web/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     include: ['src/**/*.{test,spec}.ts'],
+    setupFiles: ['./src/test/setup.ts'],
     // Run unit tests as if the dev-skip persona switcher is active.
     env: { VITE_DEV_SKIP_AUTH: 'true' },
     coverage: {
@@ -21,6 +22,7 @@ export default defineConfig({
       include: ['src/**/*.{ts,vue}'],
       exclude: [
         'src/**/*.{test,spec}.ts',
+        'src/test/**',
         'src/main.ts',
         'src/env.d.ts',
         'src/**/*.d.ts',


### PR DESCRIPTION
## Summary
Adds a substantial unit-test suite for both the Vue web app and the .NET Functions API.

- **Web: 3.4% → ~80% statements / ~84% lines** (198 tests, 35 files)
- **API: 1.2% → ~34% lines** (108 tests; up from 28)

### Web (Vitest + @vue/test-utils)
- `lib`, `composables`, `stores` (incl. real-MSAL auth paths via a mocked msal lib)
- Router guard + `scrollBehavior`
- All leaf/layout components and the TipTap editor stack (`RichTextEditor`, `DraftEditor`, `EditorView`)
- All views — loading / loaded / empty / error / auth states, the 412-conflict flow, and contributor request-deletion
- Added `src/test/setup.ts` (stubs `IntersectionObserver`)

### API (xUnit)
- Record models + computed keys, input validation, infrastructure options, `DevPersonas`, `FunctionContext` extensions
- `ContentRepository` read fallbacks + write guards (against `MockDataService`)
- **All nine Function classes** via a hand-built `HttpRequestData`/`HttpResponseData`/`FunctionContext` test harness + fake `IContentRepository`: CRUD, role/ownership gates, validation, writes-disabled, and the CIAM signup gate
- Storage/invite/Entra services' unconfigured paths

### Why the API is ~34% (not 80%)
By design this PR is **pure unit tests, no storage emulator**. That leaves the largest code unreachable without infra:
- `ContentRepository` write paths (~500 lines) — need Azurite
- `BlobService` / `ContentBodyStore` / `TableStore` / `EntraJwtValidator` *configured* paths — need real Blob/Table/JWKS
- `JwtMiddleware` (204 lines) — tied to worker-runtime internals; not unit-testable with a light harness
- `Program.cs`, `TableBootstrapper` — startup wiring

Reaching 80% on the API would require Azurite-backed integration tests (the natural unlock) and/or a full worker-runtime harness for the middleware.

## Testing
- Web: `npm run lint` ✅ · `npm run test:unit` ✅ (198) · `npm run build` ✅
- API: `dotnet test` ✅ (108)

> Note: the rolldown/vitest native binding gets quarantined locally and may need `npm install` to repair before a Vitest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)