### PR TITLE
fix(web): mobile nav parity, alphabetical members, date-range picker tweaks

### DIFF
--- a/src/web/src/components/common/MonthRangePicker.vue
+++ b/src/web/src/components/common/MonthRangePicker.vue
@@ -150,17 +150,25 @@ const hint = computed(() =>
       <!-- Two year panels -->
       <div class="flex divide-x divide-slypn-100 p-4">
 
-        <!-- Left year -->
-        <div class="w-44 pr-4">
+        <!-- Left year (the only panel shown on mobile) -->
+        <div class="w-44 md:pr-4">
           <div class="mb-3 flex items-center justify-between">
             <button
               type="button"
               class="rounded p-1 text-slypn-500 hover:bg-slypn-50"
+              aria-label="Previous year"
               @click="pickerYear--"
             >&larr;</button>
             <span class="text-sm font-semibold text-slypn-700">{{ pickerYear }}</span>
-            <!-- spacer keeps header symmetric -->
-            <span class="w-6" />
+            <!-- Next-year arrow on mobile; desktop uses the second panel's arrow. -->
+            <button
+              type="button"
+              class="rounded p-1 text-slypn-500 hover:bg-slypn-50 md:hidden"
+              aria-label="Next year"
+              @click="pickerYear++"
+            >&rarr;</button>
+            <!-- spacer keeps the desktop header symmetric -->
+            <span class="hidden w-6 md:block" />
           </div>
           <div class="grid grid-cols-3">
             <div
@@ -180,8 +188,8 @@ const hint = computed(() =>
           </div>
         </div>
 
-        <!-- Right year -->
-        <div class="w-44 pl-4">
+        <!-- Right year (desktop only — mobile shows a single year) -->
+        <div class="hidden w-44 pl-4 md:block">
           <div class="mb-3 flex items-center justify-between">
             <span class="w-6" />
             <span class="text-sm font-semibold text-slypn-700">{{ pickerYear + 1 }}</span>
@@ -217,7 +225,8 @@ const hint = computed(() =>
         <div class="flex gap-2">
           <button
             type="button"
-            class="rounded-md bg-slypn-50 px-2.5 py-1 text-xs font-medium text-slypn-600 hover:bg-slypn-100"
+            :disabled="phase !== 'end'"
+            class="rounded-md bg-slypn-50 px-2.5 py-1 text-xs font-medium text-slypn-600 hover:bg-slypn-100 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-slypn-50"
             @click="pickNoEnd"
           >No end date</button>
           <button

--- a/src/web/src/components/editor/SaveIndicator.spec.ts
+++ b/src/web/src/components/editor/SaveIndicator.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import SaveIndicator from './SaveIndicator.vue'
+import type { AutoSaveStatus } from '@/composables/useAutoSave'
 
-function mountIndicator(props: Record<string, unknown>) {
+function mountIndicator(props: { status: AutoSaveStatus; lastSavedAt?: Date | null; error?: string | null }) {
   return mount(SaveIndicator, { props: { lastSavedAt: null, ...props } })
 }
 

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -174,47 +174,65 @@ async function onSignOut() {
         >
           {{ item.label }}
         </RouterLink>
-        <RouterLink
-          v-if="auth.isContributor || auth.isAdmin"
-          to="/admin/events"
-          class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
-          active-class="bg-slypn-50"
-          @click="mobileOpen = false"
-        >Event management</RouterLink>
-        <RouterLink
-          v-if="auth.isAdmin"
-          to="/admin/approvals"
-          class="flex items-center justify-between rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
-          active-class="bg-slypn-50"
-          @click="mobileOpen = false"
-        >
-          Approvals
-          <span
-            v-if="approvalsStore.pendingCount > 0"
-            class="ml-2 rounded-full bg-amber-500 px-1.5 py-0.5 text-xs font-bold text-white"
-          >{{ approvalsStore.pendingCount }}</span>
-        </RouterLink>
-        <RouterLink
-          v-if="auth.isAdmin"
-          to="/admin/members"
-          class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
-          active-class="bg-slypn-50"
-          @click="mobileOpen = false"
-        >Members</RouterLink>
-        <RouterLink
-          v-if="auth.isContributor || auth.isAdmin"
-          to="/admin/content"
-          class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
-          active-class="bg-slypn-50"
-          @click="mobileOpen = false"
-        >Content management</RouterLink>
-        <RouterLink
-          v-if="auth.isAdmin"
-          to="/admin/resources"
-          class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
-          active-class="bg-slypn-50"
-          @click="mobileOpen = false"
-        >Resources</RouterLink>
+        <!-- Authenticated: dashboard + role-gated tools, mirroring the desktop user menu -->
+        <template v-if="auth.isAuthenticated">
+          <div class="my-1 border-t border-slypn-100" role="separator" aria-hidden="true"></div>
+          <RouterLink
+            to="/dashboard"
+            class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+            active-class="bg-slypn-50"
+            @click="mobileOpen = false"
+          >Dashboard</RouterLink>
+          <div class="my-1 border-t border-slypn-100" role="separator" aria-hidden="true"></div>
+          <RouterLink
+            v-if="auth.isAdmin"
+            to="/admin/approvals"
+            class="flex items-center justify-between rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+            active-class="bg-slypn-50"
+            @click="mobileOpen = false"
+          >
+            Approvals
+            <span
+              v-if="approvalsStore.pendingCount > 0"
+              class="ml-2 rounded-full bg-amber-500 px-1.5 py-0.5 text-xs font-bold text-white"
+            >{{ approvalsStore.pendingCount }}</span>
+          </RouterLink>
+          <RouterLink
+            v-if="auth.isContributor || auth.isAdmin"
+            to="/admin/content"
+            class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+            active-class="bg-slypn-50"
+            @click="mobileOpen = false"
+          >Content management</RouterLink>
+          <RouterLink
+            v-if="auth.isContributor || auth.isAdmin"
+            to="/editor"
+            class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+            active-class="bg-slypn-50"
+            @click="mobileOpen = false"
+          >Editor</RouterLink>
+          <RouterLink
+            v-if="auth.isContributor || auth.isAdmin"
+            to="/admin/events"
+            class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+            active-class="bg-slypn-50"
+            @click="mobileOpen = false"
+          >Event management</RouterLink>
+          <RouterLink
+            v-if="auth.isAdmin"
+            to="/admin/members"
+            class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+            active-class="bg-slypn-50"
+            @click="mobileOpen = false"
+          >Members</RouterLink>
+          <RouterLink
+            v-if="auth.isAdmin"
+            to="/admin/resources"
+            class="rounded-md px-3 py-2 text-base font-medium text-slypn-800 hover:bg-slypn-50"
+            active-class="bg-slypn-50"
+            @click="mobileOpen = false"
+          >Resources</RouterLink>
+        </template>
         <button
           v-if="!auth.isAuthenticated"
           class="mt-1 rounded-md bg-slypn-600 px-3 py-2 text-center text-base font-semibold text-white hover:bg-slypn-700"

--- a/src/web/src/composables/useBeforeUnload.test.ts
+++ b/src/web/src/composables/useBeforeUnload.test.ts
@@ -51,7 +51,7 @@ describe('useBeforeUnload', () => {
 
   it('the handler sets returnValue only while warning', () => {
     const { shouldWarn } = mountWith(true)
-    const handler = addSpy.mock.calls.find(c => c[0] === 'beforeunload')![1] as (e: BeforeUnloadEvent) => void
+    const handler = addSpy.mock.calls.find((c: unknown[]) => c[0] === 'beforeunload')![1] as (e: BeforeUnloadEvent) => void
     const event = { preventDefault: vi.fn(), returnValue: undefined } as unknown as BeforeUnloadEvent
     handler(event)
     expect(event.preventDefault).toHaveBeenCalled()

--- a/src/web/src/views/MemberManagementView.vue
+++ b/src/web/src/views/MemberManagementView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import { apiFetch, apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
@@ -33,6 +33,11 @@ const allRoles: Role[] = ['Admin', 'Contributor', 'Member']
 const { data: members, loading, error, refresh } = useAsyncData(
   () => apiJson<Member[]>('/members'),
 )
+
+// Display members alphabetically by name (case-insensitive).
+const sortedMembers = computed(() =>
+  [...(members.value ?? [])].sort((a, b) =>
+    a.displayName.localeCompare(b.displayName, 'en', { sensitivity: 'base' })))
 
 // ── Role update ────────────────────────────────────────────────────────────
 
@@ -239,7 +244,7 @@ const fmtDate = (iso: string) =>
 
       <div v-if="members?.length" class="divide-y divide-slypn-100">
         <div
-          v-for="m in members"
+          v-for="m in sortedMembers"
           :key="m.id"
           class="flex flex-col gap-3 px-6 py-4 sm:flex-row sm:items-center sm:gap-6"
         >

--- a/src/web/src/views/views.events.spec.ts
+++ b/src/web/src/views/views.events.spec.ts
@@ -57,10 +57,15 @@ describe('MonthRangePicker', () => {
     expect(end).toBeInstanceOf(Date)
   })
 
-  it('emits a null end via "No end date"', async () => {
+  it('emits a null end via "No end date" (disabled until picking the end)', async () => {
     const w = mountP(new Date(2026, 0, 1), new Date(2026, 0, 1))
-    await w.find('button').trigger('click')
-    await w.findAll('button').find(b => b.text() === 'No end date')!.trigger('click')
+    await w.find('button').trigger('click') // open — phase: start
+    // "No end date" is present but disabled until a start month is chosen.
+    expect(w.findAll('button').find(b => b.text() === 'No end date')!.attributes('disabled')).toBeDefined()
+    await w.findAll('button').find(b => b.text() === 'Mar')!.trigger('click') // pick start — phase: end
+    const noEnd = w.findAll('button').find(b => b.text() === 'No end date')!
+    expect(noEnd.attributes('disabled')).toBeUndefined()
+    await noEnd.trigger('click')
     expect(w.emitted('change')![0][1]).toBeNull()
   })
 })

--- a/src/web/src/views/views.events.spec.ts
+++ b/src/web/src/views/views.events.spec.ts
@@ -15,6 +15,7 @@ import EventFormDialog from '@/components/common/EventFormDialog.vue'
 import EventCalendar from '@/components/common/EventCalendar.vue'
 import EventManagementView from './EventManagementView.vue'
 import { useAuthStore } from '@/stores/auth'
+import type { CommunityEvent } from '@/types/content'
 
 const stubs = { RouterLink: RouterLinkStub, teleport: true }
 let pinia: Pinia
@@ -71,7 +72,7 @@ describe('MonthRangePicker', () => {
 })
 
 describe('EventFormDialog', () => {
-  const evt = { id: 'e1', title: 'Quiz', type: 'Q&A', startsAt: '2026-06-01T18:00:00Z', endsAt: '2026-06-01T20:00:00Z', location: 'Pub', description: 'Fun', _etag: 'w1' }
+  const evt: CommunityEvent = { id: 'e1', title: 'Quiz', type: 'Q&A', startsAt: '2026-06-01T18:00:00Z', endsAt: '2026-06-01T20:00:00Z', location: 'Pub', description: 'Fun', _etag: 'w1' }
 
   it('adds an event via POST', async () => {
     apiFetch.mockResolvedValue(ok({ id: 'new' }))


### PR DESCRIPTION
## Summary
Four small web UI fixes.

- **Mobile nav parity** (`AppNav`): the mobile menu now mirrors the desktop user menu — adds the missing **Dashboard** and **Editor** links, matches the item order (Dashboard → Approvals → Content management → Editor → Event management → Members → Resources), and adds the horizontal separators before/after Dashboard. The authenticated section is gated on `auth.isAuthenticated`.
- **Alphabetical members** (`MemberManagementView`): the members list is now sorted alphabetically by display name (case-insensitive) via a computed; API ordering is unchanged.
- **Date-range picker — "No end date"** (`MonthRangePicker`): the button is now **disabled** (greyed) until you're choosing the end month, instead of being clickable during start selection.
- **Date-range picker — mobile** (`MonthRangePicker`): shows a **single year** on mobile (two panels on desktop), with a mobile-only next-year arrow added to the visible panel.

## Testing
- `npm run lint` ✅
- `npm run test:unit` ✅ (198 passed) — updated the `MonthRangePicker` spec for the disabled "No end date" behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)