### PR TITLE
feat(swagger): OAuth2 PKCE login, env-aware title, same-origin spec URL

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -33,20 +33,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Build + deploy
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
         with:
           submodules: true
           lfs: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: src/web/package-lock.json
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4.3.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -58,6 +58,14 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Write API appsettings
+        env:
+          OTEL_ENV: ${{ github.event_name == 'push' && 'prod' || 'dev' }}
+        run: |
+          printf '{\n  "Otel": {\n    "Env": "%s"\n  }\n}\n' "$OTEL_ENV" \
+            > src/api/Slypn.Api/appsettings.json
+        shell: bash
+
       - name: Build + deploy to SWA
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -85,26 +93,6 @@ jobs:
           FARO_SOURCEMAP_STACK_ID:   ${{ secrets.FARO_SOURCEMAP_STACK_ID }}
           FARO_SOURCEMAP_API_KEY:    ${{ secrets.FARO_SOURCEMAP_API_KEY }}
 
-      - name: Set API OTel settings on PR preview
-        if: github.event_name == 'pull_request'
-        run: |
-          ENV_NAME="pr-${{ github.event.pull_request.number }}"
-          # SWA preview environments appear in ARM a few seconds after the deploy
-          # action completes. Retry for up to 2 minutes before failing.
-          for i in $(seq 1 8); do
-            az staticwebapp appsettings set \
-              --name swa-slypn-prod \
-              --resource-group rg-slypn-prod \
-              --environment-name "$ENV_NAME" \
-              --setting-names \
-                "Otel__Endpoint=${{ secrets.OTEL_ENDPOINT }}" \
-                "Otel__Headers=${{ secrets.OTEL_HEADERS }}" \
-                "Otel__ServiceName=slypn-api" \
-                "Otel__Env=dev" && break
-            echo "Environment not ready yet (attempt $i/8) — waiting 15s..."
-            sleep 15
-          done
-        shell: bash
 
   close_pr_environment:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -88,15 +88,22 @@ jobs:
       - name: Set API OTel settings on PR preview
         if: github.event_name == 'pull_request'
         run: |
-          az staticwebapp appsettings set \
-            --name swa-slypn-prod \
-            --resource-group rg-slypn-prod \
-            --environment-name "pr-${{ github.event.pull_request.number }}" \
-            --setting-names \
-              "Otel__Endpoint=${{ secrets.OTEL_ENDPOINT }}" \
-              "Otel__Headers=${{ secrets.OTEL_HEADERS }}" \
-              "Otel__ServiceName=slypn-api" \
-              "Otel__Env=dev"
+          ENV_NAME="pr-${{ github.event.pull_request.number }}"
+          # SWA preview environments appear in ARM a few seconds after the deploy
+          # action completes. Retry for up to 2 minutes before failing.
+          for i in $(seq 1 8); do
+            az staticwebapp appsettings set \
+              --name swa-slypn-prod \
+              --resource-group rg-slypn-prod \
+              --environment-name "$ENV_NAME" \
+              --setting-names \
+                "Otel__Endpoint=${{ secrets.OTEL_ENDPOINT }}" \
+                "Otel__Headers=${{ secrets.OTEL_HEADERS }}" \
+                "Otel__ServiceName=slypn-api" \
+                "Otel__Env=dev" && break
+            echo "Environment not ready yet (attempt $i/8) — waiting 15s..."
+            sleep 15
+          done
         shell: bash
 
   close_pr_environment:

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -62,10 +62,11 @@ jobs:
 
       - name: Write API appsettings
         env:
-          OTEL_ENV: ${{ github.event_name == 'push' && 'prod' || 'dev' }}
+          OTEL_ENV:      ${{ github.event_name == 'push' && 'prod' || 'dev' }}
+          SPA_CLIENT_ID: ${{ secrets.VITE_MSAL_CLIENT_ID }}
         run: |
-          printf '{\n  "Otel": {\n    "Env": "%s"\n  }\n}\n' "$OTEL_ENV" \
-            > src/api/Slypn.Api/appsettings.json
+          printf '{\n  "Otel": { "Env": "%s" },\n  "Swagger": { "SpaClientId": "%s" }\n}\n' \
+            "$OTEL_ENV" "$SPA_CLIENT_ID" > src/api/Slypn.Api/appsettings.json
         shell: bash
 
       - name: Build + deploy to SWA
@@ -117,13 +118,14 @@ jobs:
             "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
             -H "Authorization: Bearer $TOKEN" \
             | jq -c '.spa.redirectUris')
-          UPDATED=$(echo "$CURRENT" | jq -c --arg u "$CALLBACK" '. + [$u] | unique')
+          OAUTH_REDIRECT="${SWA_URL%/}/oauth2-redirect.html"
+          UPDATED=$(echo "$CURRENT" | jq -c --arg a "$CALLBACK" --arg b "$OAUTH_REDIRECT" '. + [$a,$b] | unique')
           curl -sf -X PATCH \
             "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
             -H "Authorization: Bearer $TOKEN" \
             -H "Content-Type: application/json" \
             -d "{\"spa\":{\"redirectUris\":${UPDATED}}}"
-          echo "Registered: $CALLBACK"
+          echo "Registered: $CALLBACK  $OAUTH_REDIRECT"
         shell: bash
 
   close_pr_environment:
@@ -151,6 +153,7 @@ jobs:
             --query "[?contains(hostname, '-${{ github.event.pull_request.number }}.')]|[0].hostname" \
             -o tsv)
           CALLBACK="https://${PR_HOST}/auth/callback"
+          OAUTH_REDIRECT="https://${PR_HOST}/oauth2-redirect.html"
           TOKEN=$(curl -sf \
             "https://login.microsoftonline.com/${CIAM_TENANT_ID}/oauth2/v2.0/token" \
             --data-urlencode "grant_type=client_credentials" \
@@ -162,7 +165,7 @@ jobs:
             "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
             -H "Authorization: Bearer $TOKEN" \
             | jq -c '.spa.redirectUris')
-          UPDATED=$(echo "$CURRENT" | jq -c --arg u "$CALLBACK" '[.[] | select(. != $u)]')
+          UPDATED=$(echo "$CURRENT" | jq -c --arg a "$CALLBACK" --arg b "$OAUTH_REDIRECT" '[.[] | select(. != $a and . != $b)]')
           curl -sf -X PATCH \
             "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
             -H "Authorization: Bearer $TOKEN" \

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -33,20 +33,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Build + deploy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: true
           lfs: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: src/web/package-lock.json
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: '8.0.x'
 
@@ -60,14 +60,6 @@ jobs:
           app_location: src/web
           api_location: src/api/Slypn.Api
           output_location: dist
-          # The action handles `npm ci` + `npm run build` for the Vue app
-          # and `dotnet build` for the Functions, so no preceding steps are
-          # required.
-          deployment_environment: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || '' }}
-          # Until the first Bicep deploy provisions the SWA + the secret is
-          # set in repo secrets, the action build-only and skips the upload
-          # instead of erroring. Remove this flag once the token is in place.
-          skip_deploy_on_missing_secrets: true
         env:
           # Vite bakes these into the JS bundle at build time.
           # Set via: .\infra\setup.ps1 (GitHub secrets phase).
@@ -95,4 +87,3 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           action: close
-          skip_deploy_on_missing_secrets: true

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 concurrency:
   # Include the event name so that a push to main and a pull_request-closed
@@ -37,6 +38,13 @@ jobs:
         with:
           submodules: true
           lfs: false
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -76,6 +84,20 @@ jobs:
           FARO_SOURCEMAP_APP_ID:     ${{ secrets.FARO_SOURCEMAP_APP_ID }}
           FARO_SOURCEMAP_STACK_ID:   ${{ secrets.FARO_SOURCEMAP_STACK_ID }}
           FARO_SOURCEMAP_API_KEY:    ${{ secrets.FARO_SOURCEMAP_API_KEY }}
+
+      - name: Set API OTel settings on PR preview
+        if: github.event_name == 'pull_request'
+        run: |
+          az staticwebapp appsettings set \
+            --name swa-slypn-prod \
+            --resource-group rg-slypn-prod \
+            --environment-name "pr-${{ github.event.pull_request.number }}" \
+            --setting-names \
+              "Otel__Endpoint=${{ secrets.OTEL_ENDPOINT }}" \
+              "Otel__Headers=${{ secrets.OTEL_HEADERS }}" \
+              "Otel__ServiceName=slypn-api" \
+              "Otel__Env=dev"
+        shell: bash
 
   close_pr_environment:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -3,10 +3,12 @@ name: Azure Static Web Apps deploy
 # Production deploys on push to main; PR previews on every open / update.
 # SWA closes the preview environment when the PR is closed.
 #
-# Required repo secret (set after first Bicep deploy):
-#   AZURE_STATIC_WEB_APPS_API_TOKEN — the deployment token from the SWA
-#     resource (Azure portal -> swa-slypn-* -> Manage deployment token,
-#     or `az staticwebapp secrets list -n swa-slypn-prod -g rg-slypn-prod`).
+# Required repo secrets (set via .\infra\setup.ps1):
+#   AZURE_STATIC_WEB_APPS_API_TOKEN — SWA deployment token
+#   CIAM_TENANT_ID     — Entra External ID tenant ID
+#   CIAM_CLIENT_ID     — slypn-ci app client ID (Application.ReadWrite.OwnedBy on Graph)
+#   CIAM_CLIENT_SECRET — slypn-ci client secret
+#   SPA_OBJECT_ID      — slypn-web app object ID
 
 on:
   push:
@@ -93,12 +95,83 @@ jobs:
           FARO_SOURCEMAP_STACK_ID:   ${{ secrets.FARO_SOURCEMAP_STACK_ID }}
           FARO_SOURCEMAP_API_KEY:    ${{ secrets.FARO_SOURCEMAP_API_KEY }}
 
+      - name: Register PR preview redirect URI
+        if: github.event_name == 'pull_request'
+        env:
+          CIAM_TENANT_ID:     ${{ secrets.CIAM_TENANT_ID }}
+          CIAM_CLIENT_ID:     ${{ secrets.CIAM_CLIENT_ID }}
+          CIAM_CLIENT_SECRET: ${{ secrets.CIAM_CLIENT_SECRET }}
+          SPA_OBJECT_ID:      ${{ secrets.SPA_OBJECT_ID }}
+        run: |
+          set -euo pipefail
+          SWA_HOST=$(az staticwebapp show \
+            --name swa-slypn-prod --resource-group rg-slypn-prod \
+            --query defaultHostname -o tsv)
+          CALLBACK="https://${SWA_HOST%%.*}-${{ github.event.pull_request.number }}.${SWA_HOST#*.}/auth/callback"
+          TOKEN=$(curl -sf \
+            "https://login.microsoftonline.com/${CIAM_TENANT_ID}/oauth2/v2.0/token" \
+            --data-urlencode "grant_type=client_credentials" \
+            --data-urlencode "client_id=${CIAM_CLIENT_ID}" \
+            --data-urlencode "client_secret=${CIAM_CLIENT_SECRET}" \
+            --data-urlencode "scope=https://graph.microsoft.com/.default" \
+            | jq -r .access_token)
+          CURRENT=$(curl -sf \
+            "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
+            -H "Authorization: Bearer $TOKEN" \
+            | jq -c '.spa.redirectUris')
+          UPDATED=$(echo "$CURRENT" | jq -c --arg u "$CALLBACK" '. + [$u] | unique')
+          curl -sf -X PATCH \
+            "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"spa\":{\"redirectUris\":${UPDATED}}}"
+          echo "Registered: $CALLBACK"
+        shell: bash
 
   close_pr_environment:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close PR environment
     steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Remove PR preview redirect URI
+        env:
+          CIAM_TENANT_ID:     ${{ secrets.CIAM_TENANT_ID }}
+          CIAM_CLIENT_ID:     ${{ secrets.CIAM_CLIENT_ID }}
+          CIAM_CLIENT_SECRET: ${{ secrets.CIAM_CLIENT_SECRET }}
+          SPA_OBJECT_ID:      ${{ secrets.SPA_OBJECT_ID }}
+        run: |
+          set -euo pipefail
+          SWA_HOST=$(az staticwebapp show \
+            --name swa-slypn-prod --resource-group rg-slypn-prod \
+            --query defaultHostname -o tsv)
+          CALLBACK="https://${SWA_HOST%%.*}-${{ github.event.pull_request.number }}.${SWA_HOST#*.}/auth/callback"
+          TOKEN=$(curl -sf \
+            "https://login.microsoftonline.com/${CIAM_TENANT_ID}/oauth2/v2.0/token" \
+            --data-urlencode "grant_type=client_credentials" \
+            --data-urlencode "client_id=${CIAM_CLIENT_ID}" \
+            --data-urlencode "client_secret=${CIAM_CLIENT_SECRET}" \
+            --data-urlencode "scope=https://graph.microsoft.com/.default" \
+            | jq -r .access_token)
+          CURRENT=$(curl -sf \
+            "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
+            -H "Authorization: Bearer $TOKEN" \
+            | jq -c '.spa.redirectUris')
+          UPDATED=$(echo "$CURRENT" | jq -c --arg u "$CALLBACK" '[.[] | select(. != $u)]')
+          curl -sf -X PATCH \
+            "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"spa\":{\"redirectUris\":${UPDATED}}}"
+          echo "Removed: $CALLBACK"
+        shell: bash
+
       - name: Close PR environment
         uses: Azure/static-web-apps-deploy@v1
         with:

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -102,12 +102,10 @@ jobs:
           CIAM_CLIENT_ID:     ${{ secrets.CIAM_CLIENT_ID }}
           CIAM_CLIENT_SECRET: ${{ secrets.CIAM_CLIENT_SECRET }}
           SPA_OBJECT_ID:      ${{ secrets.SPA_OBJECT_ID }}
+          SWA_URL:            ${{ steps.builddeploy.outputs.static_web_app_url }}
         run: |
           set -euo pipefail
-          SWA_HOST=$(az staticwebapp show \
-            --name swa-slypn-prod --resource-group rg-slypn-prod \
-            --query defaultHostname -o tsv)
-          CALLBACK="https://${SWA_HOST%%.*}-${{ github.event.pull_request.number }}.${SWA_HOST#*.}/auth/callback"
+          CALLBACK="${SWA_URL%/}/auth/callback"
           TOKEN=$(curl -sf \
             "https://login.microsoftonline.com/${CIAM_TENANT_ID}/oauth2/v2.0/token" \
             --data-urlencode "grant_type=client_credentials" \
@@ -148,10 +146,11 @@ jobs:
           SPA_OBJECT_ID:      ${{ secrets.SPA_OBJECT_ID }}
         run: |
           set -euo pipefail
-          SWA_HOST=$(az staticwebapp show \
+          PR_HOST=$(az staticwebapp environment list \
             --name swa-slypn-prod --resource-group rg-slypn-prod \
-            --query defaultHostname -o tsv)
-          CALLBACK="https://${SWA_HOST%%.*}-${{ github.event.pull_request.number }}.${SWA_HOST#*.}/auth/callback"
+            --query "[?contains(hostname, '-${{ github.event.pull_request.number }}.')]|[0].hostname" \
+            -o tsv)
+          CALLBACK="https://${PR_HOST}/auth/callback"
           TOKEN=$(curl -sf \
             "https://login.microsoftonline.com/${CIAM_TENANT_ID}/oauth2/v2.0/token" \
             --data-urlencode "grant_type=client_credentials" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       run:
         working-directory: src/web
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -40,15 +40,15 @@ jobs:
     name: API (.NET Functions)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4.3.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
       - name: NuGet cache
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('src/api/**/*.csproj') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       run:
         working-directory: src/web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -40,15 +40,15 @@ jobs:
     name: API (.NET Functions)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.0
         with:
           dotnet-version: '8.0.x'
 
       - name: NuGet cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.0
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('src/api/**/*.csproj') }}

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -919,13 +919,15 @@ if (-not $SkipGitHub) {
             $exists = az ad app federated-credential list --id $cicdObjId -o json 2>$null |
                       ConvertFrom-Json | Where-Object { $_.name -eq $fc.name }
             if (-not $exists) {
-                $params = @{
+                $tmpJson = New-TemporaryFile
+                @{
                     name      = $fc.name
                     issuer    = 'https://token.actions.githubusercontent.com'
                     subject   = $fc.subject
                     audiences = @('api://AzureADTokenExchange')
-                } | ConvertTo-Json
-                az ad app federated-credential create --id $cicdObjId --parameters $params | Out-Null
+                } | ConvertTo-Json | Set-Content $tmpJson -Encoding UTF8
+                az ad app federated-credential create --id $cicdObjId --parameters "@$($tmpJson.FullName)" | Out-Null
+                Remove-Item $tmpJson -ErrorAction SilentlyContinue
                 Ok "Federated credential: $($fc.name)"
             } else {
                 Info "Federated credential exists: $($fc.name)"

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -759,6 +759,106 @@ if (-not $SkipEntra) {
     }
 
 
+    # ── CI service principal — PR preview redirect URI management ─────────────
+    # slypn-ci lives in the CIAM tenant and holds Application.ReadWrite.OwnedBy
+    # on Microsoft Graph. It is added as an owner of slypn-web so it can patch
+    # the SPA redirect URI list when a PR preview is opened or closed.
+
+    Step 'Entra · CI service principal (slypn-ci)'
+
+    $ciAppName = 'slypn-ci'
+    $ciApps    = (Invoke-Graph GET "/applications?`$filter=displayName eq '$ciAppName'").value
+    $ciApp     = $ciApps | Select-Object -First 1
+    if ($ciApp) {
+        $ciClientId = $ciApp.appId
+        $ciObjectId = $ciApp.id
+        Info "Found: appId=$ciClientId"
+    } else {
+        $ciApp      = Invoke-Graph POST '/applications' @{
+            displayName    = $ciAppName
+            signInAudience = 'AzureADMyOrg'
+        }
+        $ciClientId = $ciApp.appId
+        $ciObjectId = $ciApp.id
+        Ok "Created: appId=$ciClientId"
+    }
+    $s['ciClientId'] = $ciClientId
+    $s['ciObjectId'] = $ciObjectId
+    Save-Secrets $s
+
+    # Ensure the service principal exists in the tenant.
+    $ciSp = (Invoke-Graph GET "/servicePrincipals?`$filter=appId eq '$ciClientId'").value |
+                Select-Object -First 1
+    if (-not $ciSp) {
+        $ciSp = Invoke-Graph POST '/servicePrincipals' @{ appId = $ciClientId }
+        Ok 'Created service principal'
+    } else {
+        Info "Service principal: $($ciSp.id)"
+    }
+    $ciSpId = $ciSp.id
+
+    # Grant Application.ReadWrite.OwnedBy (admin consent via appRoleAssignment).
+    $appReadWriteOwnedById = '18a4783c-866b-4cc7-a460-3d5e5662c884'
+    $ciAssignments = (Invoke-Graph GET "/servicePrincipals/$ciSpId/appRoleAssignments").value
+    $alreadyGranted = $ciAssignments | Where-Object {
+        $_.resourceId -eq $graphSpId -and $_.appRoleId -eq $appReadWriteOwnedById
+    }
+    if ($alreadyGranted) {
+        Info 'Application.ReadWrite.OwnedBy already granted'
+    } else {
+        Invoke-Graph POST "/servicePrincipals/$graphSpId/appRoleAssignedTo" @{
+            principalId = $ciSpId
+            resourceId  = $graphSpId
+            appRoleId   = $appReadWriteOwnedById
+        } | Out-Null
+        Ok 'Granted Application.ReadWrite.OwnedBy'
+    }
+
+    # Add CI SP as owner of slypn-web (required for OwnedBy permission to apply).
+    $owners      = (Invoke-Graph GET "/applications/$spaObjectId/owners").value
+    $alreadyOwner = $owners | Where-Object { $_.id -eq $ciSpId }
+    if ($alreadyOwner) {
+        Info 'CI SP already owner of slypn-web'
+    } else {
+        Invoke-Graph POST "/applications/$spaObjectId/owners/`$ref" @{
+            '@odata.id' = "https://graph.microsoft.com/v1.0/directoryObjects/$ciSpId"
+        } | Out-Null
+        Ok 'Added CI SP as owner of slypn-web'
+    }
+
+    # Create / rotate client secret.
+    $ciSecretName  = 'slypn-ci-gh-actions'
+    $ciCredentials = (Invoke-Graph GET "/applications/$ciObjectId").passwordCredentials
+    $managed       = @($ciCredentials | Where-Object { $_.displayName -eq $ciSecretName })
+    $needsSecret   = $RotateSecret.IsPresent
+    if (-not $s.Contains('ciClientSecret') -or [string]::IsNullOrWhiteSpace($s['ciClientSecret'])) {
+        $needsSecret = $true
+    } elseif ($managed.Count -gt 0) {
+        $expiry = [datetime]$managed[0].endDateTime
+        if ($expiry -gt (Get-Date).AddDays(30)) {
+            Info "Secret exists, expires $($expiry.ToString('yyyy-MM-dd'))"
+        } else {
+            Warn "Expires $($expiry.ToString('yyyy-MM-dd')) — rotating"
+            $needsSecret = $true
+        }
+    } else {
+        $needsSecret = $true
+    }
+    if ($needsSecret) {
+        foreach ($cred in $managed) {
+            try { Invoke-Graph POST "/applications/$ciObjectId/removePassword" @{ keyId = $cred.keyId } | Out-Null } catch {}
+        }
+        $result = Invoke-Graph POST "/applications/$ciObjectId/addPassword" @{
+            passwordCredential = @{
+                displayName = $ciSecretName
+                endDateTime = (Get-Date).AddYears(2).ToString('o')
+            }
+        }
+        $s['ciClientSecret'] = $result.secretText
+        Save-Secrets $s
+        Ok "Secret created, expires $($result.endDateTime.ToString('yyyy-MM-dd'))"
+    }
+
     # Make variables available for downstream phases.
     $tenantId     = $s['tenantId']
     $tenantDomain = $s['tenantDomain']
@@ -948,6 +1048,12 @@ if (-not $SkipGitHub) {
         if ($s.Contains('faroSourcemapApiKey'))   { Set-GhSecret 'FARO_SOURCEMAP_API_KEY'  $s['faroSourcemapApiKey'] }
         if ($grafanaOtlpUrl)                      { Set-GhSecret 'OTEL_ENDPOINT'            $grafanaOtlpUrl }
         if ($grafanaHeaders)                      { Set-GhSecret 'OTEL_HEADERS'             $grafanaHeaders }
+
+        # CIAM CI credentials — PR preview redirect URI management.
+        if ($s.Contains('tenantId'))        { Set-GhSecret 'CIAM_TENANT_ID'     $s['tenantId'] }
+        if ($s.Contains('spaObjectId'))     { Set-GhSecret 'SPA_OBJECT_ID'      $s['spaObjectId'] }
+        if ($s.Contains('ciClientId'))      { Set-GhSecret 'CIAM_CLIENT_ID'     $s['ciClientId'] }
+        if ($s.Contains('ciClientSecret'))  { Set-GhSecret 'CIAM_CLIENT_SECRET' $s['ciClientSecret'] }
     }
 }
 

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -921,15 +921,23 @@ if (-not $SkipSwa -and $swaName) {
 
     Ok "Applied $($settings.Count) setting(s) to $swaName"
 
-    # Otel__Env is baked into appsettings.json at CI time (prod for main, dev for
-    # PR previews). Deleting it from Azure app settings ensures the baked value is
-    # never overridden — all SWA environments (including PR previews) inherit Azure
-    # app settings, so a persistent Otel__Env=prod here would shadow the dev value.
-    az staticwebapp appsettings delete `
-        --name $swaName `
-        --resource-group $rg `
-        --setting-names Otel__Env 2>$null | Out-Null
-    Ok 'Removed Otel__Env from Azure app settings (baked per-build value takes precedence)'
+    # Otel__Env is baked into appsettings.json at CI time (prod for main, dev for PR
+    # previews). Delete it from ALL environments so the baked value is never overridden.
+    # The old CI workflow set it per-PR-environment; those stale overrides must be cleared.
+    $allEnvNames = @('default') + @(
+        az staticwebapp environment list --name $swaName --resource-group $rg `
+            --query '[].name' -o json | ConvertFrom-Json |
+            Where-Object { $_ -ne 'default' }
+    )
+    foreach ($envName in $allEnvNames) {
+        $envArg = if ($envName -eq 'default') { @() } else { @('--environment-name', $envName) }
+        az staticwebapp appsettings delete `
+            --name $swaName `
+            --resource-group $rg `
+            @envArg `
+            --setting-names Otel__Env 2>$null | Out-Null
+    }
+    Ok "Removed Otel__Env from all SWA environments ($($allEnvNames -join ', '))"
 } elseif (-not $SkipSwa) {
     Warn 'SWA name not known — skipping app settings (run with -SkipBicep after first deploy to apply)'
 }

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -584,10 +584,10 @@ if (-not $SkipEntra) {
     Save-Secrets $s
 
     # Redirect URIs — prod omitted if URL not yet known.
-    $redirectUris = @('http://localhost:5173/auth/callback')
+    $redirectUris = @('http://localhost:5173/auth/callback', 'http://localhost:5173/oauth2-redirect.html')
     $pUrl = if ($s.Contains('prodUrl')) { $s['prodUrl'] } else { '' }
     if (-not [string]::IsNullOrWhiteSpace($pUrl)) {
-        $redirectUris = @("$pUrl/auth/callback") + $redirectUris
+        $redirectUris = @("$pUrl/auth/callback", "$pUrl/oauth2-redirect.html") + $redirectUris
     }
 
     $spaApp           = Invoke-Graph GET "/applications/$spaObjectId"
@@ -1142,6 +1142,7 @@ if (-not $SkipLocal -and $authority -and $spaClientId -and $apiScopeStr) {
         $ls['Values']['Graph__InviteRedirectUrl'] = 'http://localhost:5173/'
         if ($grafanaOtlpUrl) { $ls['Values']['Otel__Endpoint'] = $grafanaOtlpUrl }
         if ($grafanaHeaders) { $ls['Values']['Otel__Headers']  = $grafanaHeaders }
+        $ls['Values']['Swagger__SpaClientId'] = $spaClientId
 
         $ls | ConvertTo-Json -Depth 5 | Set-Content $localSettingsPath -Encoding UTF8
         Ok "Updated $localSettingsPath (Entra/Graph fields; Storage unchanged)"

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -912,6 +912,7 @@ if (-not $SkipSwa -and $swaName) {
                                                    $settings['Otel__ServiceName']         = 'slypn-api'
     if ($grafanaOtlpUrl)                          { $settings['Otel__Endpoint']           = $grafanaOtlpUrl }
     if ($grafanaHeaders)                          { $settings['Otel__Headers']            = $grafanaHeaders }
+    if ($spaClientId)                             { $settings['Swagger__SpaClientId']     = $spaClientId }
 
     $settingArgs = $settings.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" }
     az staticwebapp appsettings set `

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -920,6 +920,16 @@ if (-not $SkipSwa -and $swaName) {
         --setting-names @settingArgs | Out-Null
 
     Ok "Applied $($settings.Count) setting(s) to $swaName"
+
+    # Otel__Env is baked into appsettings.json at CI time (prod for main, dev for
+    # PR previews). Deleting it from Azure app settings ensures the baked value is
+    # never overridden — all SWA environments (including PR previews) inherit Azure
+    # app settings, so a persistent Otel__Env=prod here would shadow the dev value.
+    az staticwebapp appsettings delete `
+        --name $swaName `
+        --resource-group $rg `
+        --setting-names Otel__Env 2>$null | Out-Null
+    Ok 'Removed Otel__Env from Azure app settings (baked per-build value takes precedence)'
 } elseif (-not $SkipSwa) {
     Warn 'SWA name not known — skipping app settings (run with -SkipBicep after first deploy to apply)'
 }

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -869,6 +869,73 @@ if (-not $SkipGitHub) {
             Warn 'SWA not known — skipping AZURE_STATIC_WEB_APPS_API_TOKEN'
         }
 
+        # ── OIDC federation for GitHub Actions ───────────────────────────────
+        Step 'Phase 4 · GitHub Actions OIDC federation'
+
+        if ($s.Contains('subscriptionId')) { Switch-ToSubscription $s['subscriptionId'] }
+
+        # Subscription's Entra tenant (separate from the CIAM tenant used for sign-in).
+        $subscriptionTenantId = az account show --query tenantId -o tsv
+
+        $cicdAppName = 'slypn-github-actions'
+        $cicdApp = az ad app list --filter "displayName eq '$cicdAppName'" --query '[0]' -o json 2>$null |
+                   ConvertFrom-Json
+        if ($cicdApp) {
+            $cicdAppId = $cicdApp.appId
+            $cicdObjId = $cicdApp.id
+            Info "Found  $cicdAppName  appId=$cicdAppId"
+        } else {
+            $cicdApp   = az ad app create --display-name $cicdAppName -o json | ConvertFrom-Json
+            $cicdAppId = $cicdApp.appId
+            $cicdObjId = $cicdApp.id
+            Ok "Created  $cicdAppName  appId=$cicdAppId"
+        }
+        $s['cicdAppId']            = $cicdAppId
+        $s['subscriptionTenantId'] = $subscriptionTenantId
+        Save-Secrets $s
+
+        $cicdSpList = az ad sp list --filter "appId eq '$cicdAppId'" -o json 2>$null | ConvertFrom-Json
+        if (-not $cicdSpList -or $cicdSpList.Count -eq 0) {
+            az ad sp create --id $cicdAppId | Out-Null
+            Ok 'Created service principal'
+        } else {
+            Info 'Service principal exists'
+        }
+
+        $scope = "/subscriptions/$($s['subscriptionId'])/resourceGroups/$($s['resourceGroup'])"
+        $roleAssigned = az role assignment list --assignee $cicdAppId --role Contributor --scope $scope -o json 2>$null |
+                        ConvertFrom-Json
+        if (-not $roleAssigned -or $roleAssigned.Count -eq 0) {
+            az role assignment create --assignee $cicdAppId --role Contributor --scope $scope | Out-Null
+            Ok "Contributor granted on $($s['resourceGroup'])"
+        } else {
+            Info 'Contributor already assigned'
+        }
+
+        foreach ($fc in @(
+            @{ name = 'github-main'; subject = "repo:$gitHubRepo`:ref:refs/heads/main" }
+            @{ name = 'github-prs';  subject = "repo:$gitHubRepo`:pull_request" }
+        )) {
+            $exists = az ad app federated-credential list --id $cicdObjId -o json 2>$null |
+                      ConvertFrom-Json | Where-Object { $_.name -eq $fc.name }
+            if (-not $exists) {
+                $params = @{
+                    name      = $fc.name
+                    issuer    = 'https://token.actions.githubusercontent.com'
+                    subject   = $fc.subject
+                    audiences = @('api://AzureADTokenExchange')
+                } | ConvertTo-Json
+                az ad app federated-credential create --id $cicdObjId --parameters $params | Out-Null
+                Ok "Federated credential: $($fc.name)"
+            } else {
+                Info "Federated credential exists: $($fc.name)"
+            }
+        }
+
+        Set-GhSecret 'AZURE_CLIENT_ID'       $cicdAppId
+        Set-GhSecret 'AZURE_TENANT_ID'       $subscriptionTenantId
+        Set-GhSecret 'AZURE_SUBSCRIPTION_ID' $s['subscriptionId']
+
         # VITE_ build-time env vars consumed by azure-static-web-apps.yml.
         Set-GhSecret 'VITE_MSAL_AUTHORITY' $authority
         Set-GhSecret 'VITE_MSAL_CLIENT_ID' $spaClientId
@@ -878,6 +945,8 @@ if (-not $SkipGitHub) {
         if ($s.Contains('faroSourcemapAppId'))    { Set-GhSecret 'FARO_SOURCEMAP_APP_ID'   $s['faroSourcemapAppId'] }
         if ($s.Contains('faroSourcemapStackId'))  { Set-GhSecret 'FARO_SOURCEMAP_STACK_ID' $s['faroSourcemapStackId'] }
         if ($s.Contains('faroSourcemapApiKey'))   { Set-GhSecret 'FARO_SOURCEMAP_API_KEY'  $s['faroSourcemapApiKey'] }
+        if ($grafanaOtlpUrl)                      { Set-GhSecret 'OTEL_ENDPOINT'            $grafanaOtlpUrl }
+        if ($grafanaHeaders)                      { Set-GhSecret 'OTEL_HEADERS'             $grafanaHeaders }
     }
 }
 

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -810,7 +810,6 @@ if (-not $SkipSwa -and $swaName) {
     if ($tenantId)                               { $settings['SignupGate__TenantId']      = $tenantId }
     if ($s['signupExtensionId'])                 { $settings['SignupGate__ExtensionId']   = $s['signupExtensionId'] }
                                                    $settings['Otel__ServiceName']         = 'slypn-api'
-                                                   $settings['Otel__Env']                 = 'prod'
     if ($grafanaOtlpUrl)                          { $settings['Otel__Endpoint']           = $grafanaOtlpUrl }
     if ($grafanaHeaders)                          { $settings['Otel__Headers']            = $grafanaHeaders }
 

--- a/scripts/testLocal.ps1
+++ b/scripts/testLocal.ps1
@@ -233,6 +233,57 @@ if ($covSources.Count -gt 0) {
     Write-Warn 'Coverage not measured (no instrumented suite ran).'
 }
 
+# ── Changed-file (branch diff) coverage ──────────────────────────────────────
+Write-Host ''
+Write-Step 'Changed-file coverage  (current branch vs main)'
+
+$diffBase    = if (git rev-parse --verify origin/main 2>$null) { 'origin/main' } else { 'main' }
+$changedFiles = (git diff "$diffBase...HEAD" --name-only 2>$null) -split "`n" |
+    Where-Object { $_ -match '\.(cs|ts|vue)$' -and $_ -notmatch '\.(spec|test)\.' -and $_ -notmatch '[\\/]test[\\/]' }
+
+if (-not $changedFiles) {
+    Write-Warn 'No changed source files detected on this branch.'
+} elseif ($covSources.Count -eq 0) {
+    Write-Warn 'No coverage data — run without -SkipApi/-SkipUnit to instrument.'
+} else {
+    $allXml = foreach ($c in $covSources) {
+        if (Test-Path $c.File) { [xml](Get-Content $c.File -Raw) }
+    }
+
+    $anyFound = $false
+    foreach ($changed in $changedFiles) {
+        $norm = $changed -replace '\\', '/'
+
+        $classNode = $null
+        foreach ($x in $allXml) {
+            $classNode = $x.SelectNodes('//class') |
+                Where-Object { ($_.filename -replace '\\', '/') -like "*$norm" } |
+                Select-Object -First 1
+            if ($classNode) { break }
+        }
+        if (-not $classNode) { continue }
+        $anyFound = $true
+
+        $lineNodes = $classNode.SelectNodes('lines/line')
+        $lv = $lineNodes.Count
+        $lc = ($lineNodes | Where-Object { [int]$_.hits -gt 0 }).Count
+        $linePct = if ($lv -gt 0) { $lc / $lv * 100 } else { 100.0 }
+
+        $bv = 0; $bc = 0
+        foreach ($ln in ($lineNodes | Where-Object { $_.branch -eq 'true' })) {
+            if ($ln.'condition-coverage' -match '\((\d+)/(\d+)\)') {
+                $bc += [int]$Matches[1]; $bv += [int]$Matches[2]
+            }
+        }
+        $brStr = if ($bv -gt 0) { "  branch $([math]::Round($bc/$bv*100,1))% ($bc/$bv)" } else { '' }
+        $label = ($norm -replace '^src/(api|web)/', '') -replace 'Slypn\.Api[\\/]', ''
+        Write-Rated "  $label" $linePct ("{0}/{1} lines{2}" -f $lc, $lv, $brStr)
+    }
+    if (-not $anyFound) {
+        Write-Warn 'Changed files not found in coverage data (test/config files only?).'
+    }
+}
+
 # ── Verdict / exit ────────────────────────────────────────────────────────────
 Write-Host ''
 if ($totalFailed -gt 0 -or $runError) {

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -29,7 +29,7 @@ internal sealed class FakeContentRepository : IContentRepository
     public Draft? DraftById;
 
     /// <summary>Set to throw from the next write to exercise error mapping.</summary>
-    public Exception? ThrowOnWrite;
+    public Exception? ThrowOnWrite { get; set; }
 
     private T Guard<T>(T value)
     {

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
@@ -18,6 +19,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [Function("GetArticles")]
     [OpenApiOperation(operationId: "articles.list", tags: new[] { "articles" }, Summary = "List articles", Description = "Returns articles filtered by the optional status query parameter.")]
     [OpenApiParameter(name: "status", In = ParameterLocation.Query, Required = false, Type = typeof(string), Description = "Optional article status filter.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article[]), Description = "List of articles")]
     public async Task<HttpResponseData> GetArticles(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles")] HttpRequestData req,
         CancellationToken ct)
@@ -29,6 +31,8 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [Function("GetArticleBySlug")]
     [OpenApiOperation(operationId: "articles.getBySlug", tags: new[] { "articles" }, Summary = "Get article by slug", Description = "Returns a single article identified by slug.")]
     [OpenApiParameter(name: "slug", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Article slug.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article), Description = "Article")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
     public async Task<HttpResponseData> GetArticleBySlug(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles/{slug}")] HttpRequestData req,
         string slug, CancellationToken ct)
@@ -43,6 +47,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiOperation(operationId: "articles.create", tags: new[] { "articles" }, Summary = "Create article", Description = "Creates a new article.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(ArticleInput), Required = true, Description = "Article payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(Article), Description = "Created article")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles")] HttpRequestData req,
         CancellationToken ct)
@@ -65,6 +70,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Article id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(ArticleInput), Required = true, Description = "Article payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article), Description = "Updated article")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "articles/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -87,6 +93,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Article id.")]
     [OpenApiParameter(name: "status", In = ParameterLocation.Query, Required = true, Type = typeof(string), Description = "Article partition key status.")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "Deleted")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "articles/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -112,6 +119,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiOperation(operationId: "articles.publish", tags: new[] { "articles" }, Summary = "Publish article", Description = "Moves an article to published status.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Article id.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article), Description = "Published article")]
     public async Task<HttpResponseData> Publish(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/publish")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -138,6 +146,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiOperation(operationId: "articles.edit", tags: new[] { "articles" }, Summary = "Edit published", Description = "Creates a draft revision of a published article for approval.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Published article id.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(Draft), Description = "Created draft revision")]
     public async Task<HttpResponseData> Edit(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/edit")] HttpRequestData req,
         FunctionContext context,
@@ -165,6 +174,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiOperation(operationId: "articles.requestDeletion", tags: new[] { "articles" }, Summary = "Request deletion", Description = "Flags a published article for deletion, pending admin approval.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Published article id.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article), Description = "Updated article")]
     public async Task<HttpResponseData> RequestDeletion(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/request-deletion")] HttpRequestData req,
         FunctionContext context,
@@ -188,6 +198,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiOperation(operationId: "articles.cancelDeletion", tags: new[] { "articles" }, Summary = "Keep article", Description = "Clears a pending deletion request.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Published article id.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article), Description = "Updated article")]
     public async Task<HttpResponseData> CancelDeletion(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/cancel-deletion")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -212,6 +223,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Article id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(RejectionInput), Required = true, Description = "Revision feedback.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Draft), Description = "Draft with revision feedback")]
     public async Task<HttpResponseData> Revise(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/revise")] HttpRequestData req,
         string id, CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/BlogFunctions.cs
+++ b/src/api/Slypn.Api/Functions/BlogFunctions.cs
@@ -1,8 +1,10 @@
+using System.Net;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
+using Slypn.Api.Models;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
 
@@ -18,6 +20,7 @@ public sealed class BlogFunctions(IContentRepository repo)
     [Function("GetBlogPosts")]
     [OpenApiOperation(operationId: "blog.list", tags: new[] { "blog" }, Summary = "List blog posts", Description = "Returns published blog posts, optionally filtered by status.")]
     [OpenApiParameter(name: "status", In = ParameterLocation.Query, Required = false, Type = typeof(string), Description = "Optional status filter.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article[]), Description = "List of blog posts")]
     public async Task<HttpResponseData> GetBlogPosts(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "blog")] HttpRequestData req,
         CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/DraftsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/DraftsFunctions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Azure;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -19,6 +20,7 @@ public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sani
     [RequireRole("Admin", "Contributor")]
     [OpenApiOperation(operationId: "drafts.listMine", tags: new[] { "drafts" }, Summary = "List my drafts", Description = "Returns drafts for the authenticated author.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Draft[]), Description = "List of drafts")]
     public async Task<HttpResponseData> List(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "drafts")] HttpRequestData req,
         FunctionContext context,
@@ -40,6 +42,8 @@ public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sani
     [OpenApiOperation(operationId: "drafts.get", tags: new[] { "drafts" }, Summary = "Get draft", Description = "Returns a draft owned by the authenticated author.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Draft id.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Draft), Description = "Draft")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
     public async Task<HttpResponseData> Get(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "drafts/{id}")] HttpRequestData req,
         FunctionContext context,
@@ -68,6 +72,7 @@ public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sani
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Draft id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(DraftInput), Required = true, Description = "Draft payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Draft), Description = "Saved draft")]
     public async Task<HttpResponseData> Upsert(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "drafts/{id}")] HttpRequestData req,
         FunctionContext context,
@@ -122,6 +127,7 @@ public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sani
     [OpenApiOperation(operationId: "drafts.delete", tags: new[] { "drafts" }, Summary = "Delete draft", Description = "Deletes a draft owned by the authenticated author.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Draft id.")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "Deleted")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "drafts/{id}")] HttpRequestData req,
         FunctionContext context,
@@ -149,6 +155,7 @@ public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sani
     [OpenApiOperation(operationId: "drafts.submit", tags: new[] { "drafts" }, Summary = "Submit draft", Description = "Submits a draft for review and promotes it to an article.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Draft id.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(Article), Description = "Submitted article")]
     public async Task<HttpResponseData> Submit(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "drafts/{id}/submit")] HttpRequestData req,
         FunctionContext context,

--- a/src/api/Slypn.Api/Functions/EventsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/EventsFunctions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Azure;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -6,6 +7,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
@@ -17,6 +19,8 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     [Function("GetEvent")]
     [OpenApiOperation(operationId: "events.get", tags: new[] { "events" }, Summary = "Get event", Description = "Returns a single event by id.")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Event id.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(CommunityEvent), Description = "Event")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
     public async Task<HttpResponseData> GetEvent(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "events/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -33,6 +37,7 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     [Function("GetEvents")]
     [OpenApiOperation(operationId: "events.list", tags: new[] { "events" }, Summary = "List events", Description = "Returns events with an optional upcoming filter.")]
     [OpenApiParameter(name: "upcoming", In = ParameterLocation.Query, Required = false, Type = typeof(string), Description = "Set to true to return only upcoming events.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(CommunityEvent[]), Description = "List of events")]
     public async Task<HttpResponseData> GetEvents(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "events")] HttpRequestData req,
         CancellationToken ct)
@@ -47,6 +52,7 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     [OpenApiOperation(operationId: "events.create", tags: new[] { "events" }, Summary = "Create event", Description = "Creates a new event. Admins and Contributors may create events.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(EventInput), Required = true, Description = "Event payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(CommunityEvent), Description = "Created event")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "events")] HttpRequestData req,
         FunctionContext context,
@@ -73,6 +79,7 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Event id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(EventInput), Required = true, Description = "Event payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(CommunityEvent), Description = "Updated event")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "events/{id}")] HttpRequestData req,
         string id, FunctionContext context, CancellationToken ct)
@@ -102,6 +109,7 @@ public sealed class EventsFunctions(IContentRepository repo, ILogger<EventsFunct
     [OpenApiOperation(operationId: "events.delete", tags: new[] { "events" }, Summary = "Delete event", Description = "Deletes an event. Admins may delete any event; Contributors may only delete their own.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Event id.")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "Deleted")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "events/{id}")] HttpRequestData req,
         string id, FunctionContext context, CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/MediaFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MediaFunctions.cs
@@ -17,6 +17,7 @@ public sealed class MediaFunctions(IBlobService blob)
     [Function("UploadMedia")]
     [OpenApiOperation(operationId: "media.upload", tags: new[] { "media" }, Summary = "Upload media", Description = "Uploads a media file and returns its blob name and read URL.")]
     [OpenApiRequestBody(contentType: "multipart/form-data", bodyType: typeof(object), Required = true, Description = "Multipart form body with a single file part named file.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(object), Description = "Upload result with blob name and read URL")]
     public async Task<HttpResponseData> Upload(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "media")] HttpRequestData req)
     {

--- a/src/api/Slypn.Api/Functions/MembersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MembersFunctions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Azure;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -26,6 +27,7 @@ public sealed class MembersFunctions(
     [RequireRole("Admin")]
     [OpenApiOperation(operationId: "members.list", tags: new[] { "members" }, Summary = "List members", Description = "Returns all members.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Member[]), Description = "List of members")]
     public async Task<HttpResponseData> List(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "members")] HttpRequestData req,
         CancellationToken ct)
@@ -44,6 +46,7 @@ public sealed class MembersFunctions(
     [OpenApiOperation(operationId: "members.invite", tags: new[] { "members" }, Summary = "Invite member", Description = "Creates or updates a member invitation.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(MemberInviteInput), Required = true, Description = "Invitation payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(object), Description = "Invitation result")]
     public async Task<HttpResponseData> Invite(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "members/invite")] HttpRequestData req,
         FunctionContext context,
@@ -105,6 +108,7 @@ public sealed class MembersFunctions(
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Member id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(MemberRolesInput), Required = true)]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Member), Description = "Updated member")]
     public async Task<HttpResponseData> UpdateRoles(
         [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "members/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -137,6 +141,7 @@ public sealed class MembersFunctions(
     [OpenApiOperation(operationId: "members.delete", tags: new[] { "members" }, Summary = "Delete member", Description = "Removes a member record.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Member id.")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "Deleted")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "members/{id}")] HttpRequestData req,
         string id, FunctionContext context, CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Azure;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -17,6 +18,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
 {
     [Function("GetNewsletters")]
     [OpenApiOperation(operationId: "newsletters.list", tags: new[] { "newsletters" }, Summary = "List newsletters", Description = "Returns all newsletters.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Newsletter[]), Description = "List of newsletters")]
     public async Task<HttpResponseData> GetNewsletters(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "newsletters")] HttpRequestData req,
         CancellationToken ct)
@@ -30,6 +32,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
     [OpenApiOperation(operationId: "newsletters.create", tags: new[] { "newsletters" }, Summary = "Create newsletter", Description = "Creates a newsletter issue.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(NewsletterInput), Required = true, Description = "Newsletter payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(Newsletter), Description = "Created newsletter")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "newsletters")] HttpRequestData req,
         CancellationToken ct)
@@ -51,6 +54,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Newsletter id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(NewsletterInput), Required = true, Description = "Newsletter payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Newsletter), Description = "Updated newsletter")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "newsletters/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -72,6 +76,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Newsletter id.")]
     [OpenApiParameter(name: "year", In = ParameterLocation.Query, Required = true, Type = typeof(string), Description = "Newsletter partition key year.")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "Deleted")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "newsletters/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -97,6 +102,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
     [Function("SubscribeToNewsletter")]
     [OpenApiOperation(operationId: "newsletter.subscribe", tags: new[] { "newsletters" }, Summary = "Subscribe to newsletter", Description = "Subscribes an email address to the newsletter.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(SubscribeInput), Required = true, Description = "Subscription payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(object), Description = "Subscription result")]
     public async Task<HttpResponseData> Subscribe(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "newsletter/subscribe")] HttpRequestData req,
         CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/ResourcesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ResourcesFunctions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Azure;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -6,6 +7,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
@@ -16,6 +18,7 @@ public sealed class ResourcesFunctions(IContentRepository repo, ILogger<Resource
 {
     [Function("GetResources")]
     [OpenApiOperation(operationId: "resources.list", tags: new[] { "resources" }, Summary = "List resources", Description = "Returns all resources.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Resource[]), Description = "List of resources")]
     public async Task<HttpResponseData> GetResources(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "resources")] HttpRequestData req,
         CancellationToken ct)
@@ -29,6 +32,7 @@ public sealed class ResourcesFunctions(IContentRepository repo, ILogger<Resource
     [OpenApiOperation(operationId: "resources.create", tags: new[] { "resources" }, Summary = "Create resource", Description = "Creates a new resource.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(ResourceInput), Required = true, Description = "Resource payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(Resource), Description = "Created resource")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "resources")] HttpRequestData req,
         CancellationToken ct)
@@ -50,6 +54,7 @@ public sealed class ResourcesFunctions(IContentRepository repo, ILogger<Resource
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Resource id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(ResourceInput), Required = true, Description = "Resource payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Resource), Description = "Updated resource")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "resources/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
@@ -71,6 +76,7 @@ public sealed class ResourcesFunctions(IContentRepository repo, ILogger<Resource
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Resource id.")]
     [OpenApiParameter(name: "category", In = ParameterLocation.Query, Required = true, Type = typeof(string), Description = "Resource partition key category.")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "Deleted")]
     public async Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "resources/{id}")] HttpRequestData req,
         string id, CancellationToken ct)

--- a/src/api/Slypn.Api/Infrastructure/OpenApiConfig.cs
+++ b/src/api/Slypn.Api/Infrastructure/OpenApiConfig.cs
@@ -11,6 +11,7 @@ public sealed class OpenApiConfig : IOpenApiConfigurationOptions
     {
         var env = config[$"{OtelOptions.SectionName}:Env"] ?? "dev";
         Info = new OpenApiInfo { Version = "1.0.0", Title = $"Slypn API [{env}]" };
+        DocumentFilters = [new SwaggerOAuthFilter(config)];
     }
 
     public OpenApiInfo Info { get; set; }

--- a/src/api/Slypn.Api/Infrastructure/OpenApiConfig.cs
+++ b/src/api/Slypn.Api/Infrastructure/OpenApiConfig.cs
@@ -1,0 +1,23 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Extensions.Configuration;
+using Microsoft.OpenApi.Models;
+
+namespace Slypn.Api.Infrastructure;
+
+public sealed class OpenApiConfig : IOpenApiConfigurationOptions
+{
+    public OpenApiConfig(IConfiguration config)
+    {
+        var env = config[$"{OtelOptions.SectionName}:Env"] ?? "dev";
+        Info = new OpenApiInfo { Version = "1.0.0", Title = $"Slypn API [{env}]" };
+    }
+
+    public OpenApiInfo Info { get; set; }
+    public List<OpenApiServer> Servers { get; set; } = [];
+    public OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V3;
+    public bool IncludeRequestingHostName { get; set; } = true;
+    public bool ForceHttp { get; set; } = false;
+    public bool ForceHttps { get; set; } = false;
+    public List<IDocumentFilter> DocumentFilters { get; set; } = [];
+}

--- a/src/api/Slypn.Api/Infrastructure/OpenApiConfig.cs
+++ b/src/api/Slypn.Api/Infrastructure/OpenApiConfig.cs
@@ -16,7 +16,7 @@ public sealed class OpenApiConfig : IOpenApiConfigurationOptions
     public OpenApiInfo Info { get; set; }
     public List<OpenApiServer> Servers { get; set; } = [];
     public OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V3;
-    public bool IncludeRequestingHostName { get; set; } = true;
+    public bool IncludeRequestingHostName { get; set; } = false;
     public bool ForceHttp { get; set; } = false;
     public bool ForceHttps { get; set; } = false;
     public List<IDocumentFilter> DocumentFilters { get; set; } = [];

--- a/src/api/Slypn.Api/Infrastructure/SwaggerOAuthFilter.cs
+++ b/src/api/Slypn.Api/Infrastructure/SwaggerOAuthFilter.cs
@@ -1,0 +1,55 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+
+namespace Slypn.Api.Infrastructure;
+
+public sealed class SwaggerOAuthFilter(IConfiguration config) : IDocumentFilter
+{
+    public void Apply(IHttpRequestDataObject req, OpenApiDocument document)
+    {
+        var authority = (config["AzureAd:Authority"] ?? "").TrimEnd('/');
+        var audience  = config["AzureAd:Audience"] ?? "";
+        var spaClient = config["Swagger:SpaClientId"] ?? "";
+        var scope     = $"{audience}/access_as_user";
+
+        document.Components ??= new OpenApiComponents();
+        document.Components.SecuritySchemes ??= new Dictionary<string, OpenApiSecurityScheme>();
+
+        document.Components.SecuritySchemes["oauth2"] = new OpenApiSecurityScheme
+        {
+            Type = SecuritySchemeType.OAuth2,
+            Flows = new OpenApiOAuthFlows
+            {
+                AuthorizationCode = new OpenApiOAuthFlow
+                {
+                    AuthorizationUrl = new Uri($"{authority}/authorize"),
+                    TokenUrl         = new Uri($"{authority}/token"),
+                    Scopes           = new Dictionary<string, string> { [scope] = "Access the SLYPN API" }
+                }
+            },
+            Extensions = new Dictionary<string, IOpenApiExtension>
+            {
+                ["x-client-id"] = new OpenApiString(spaClient)
+            }
+        };
+
+        var oauth2Ref = new OpenApiSecurityScheme
+        {
+            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }
+        };
+
+        foreach (var path in document.Paths.Values)
+        foreach (var op in path.Operations.Values)
+        {
+            if (op.Security is null) continue;
+            var bearerReq = op.Security.FirstOrDefault(
+                r => r.Keys.Any(k => k.Reference?.Id == "bearer_auth"));
+            if (bearerReq is null) continue;
+            op.Security.Remove(bearerReq);
+            op.Security.Add(new OpenApiSecurityRequirement { [oauth2Ref] = [scope] });
+        }
+    }
+}

--- a/src/api/Slypn.Api/Infrastructure/SwaggerOAuthFilter.cs
+++ b/src/api/Slypn.Api/Infrastructure/SwaggerOAuthFilter.cs
@@ -42,6 +42,8 @@ public sealed class SwaggerOAuthFilter(IConfiguration config) : IDocumentFilter
             }
         };
 
+        document.Components.SecuritySchemes.Remove("bearer_auth");
+
         var oauth2Ref = new OpenApiSecurityScheme
         {
             Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }

--- a/src/api/Slypn.Api/Infrastructure/SwaggerOAuthFilter.cs
+++ b/src/api/Slypn.Api/Infrastructure/SwaggerOAuthFilter.cs
@@ -15,6 +15,12 @@ public sealed class SwaggerOAuthFilter(IConfiguration config) : IDocumentFilter
         var spaClient = config["Swagger:SpaClientId"] ?? "";
         var scope     = $"{audience}/access_as_user";
 
+        // authority ends with /v2.0; strip it to get the tenant base URL, then
+        // build the actual OIDC endpoints which live under /oauth2/v2.0/
+        var baseUrl = authority.EndsWith("/v2.0", StringComparison.OrdinalIgnoreCase)
+            ? authority[..^5]
+            : authority;
+
         document.Components ??= new OpenApiComponents();
         document.Components.SecuritySchemes ??= new Dictionary<string, OpenApiSecurityScheme>();
 
@@ -25,8 +31,8 @@ public sealed class SwaggerOAuthFilter(IConfiguration config) : IDocumentFilter
             {
                 AuthorizationCode = new OpenApiOAuthFlow
                 {
-                    AuthorizationUrl = new Uri($"{authority}/authorize"),
-                    TokenUrl         = new Uri($"{authority}/token"),
+                    AuthorizationUrl = new Uri($"{baseUrl}/oauth2/v2.0/authorize"),
+                    TokenUrl         = new Uri($"{baseUrl}/oauth2/v2.0/token"),
                     Scopes           = new Dictionary<string, string> { [scope] = "Access the SLYPN API" }
                 }
             },

--- a/src/api/Slypn.Api/Infrastructure/TracingMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/TracingMiddleware.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace Slypn.Api.Infrastructure;
+
+/// <summary>
+/// Extracts W3C traceparent/tracestate from each incoming HTTP request and
+/// starts a server Activity parented to the caller's trace, so Azure Storage
+/// spans appear as children of the browser span in Grafana Tempo.
+/// </summary>
+public sealed class TracingMiddleware : IFunctionsWorkerMiddleware
+{
+    private static readonly TextMapPropagator Propagator = Propagators.DefaultTextMapPropagator;
+
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        var request = await context.GetHttpRequestDataAsync();
+        if (request is null)
+        {
+            await next(context);
+            return;
+        }
+
+        var parentContext = Propagator.Extract(
+            default,
+            request.Headers,
+            static (headers, key) =>
+                headers.TryGetValues(key, out var values)
+                    ? values
+                    : Enumerable.Empty<string>());
+
+        Baggage.Current = parentContext.Baggage;
+
+        using var activity = OtelSources.Api.StartActivity(
+            context.FunctionDefinition.Name,
+            ActivityKind.Server,
+            parentContext.ActivityContext);
+
+        activity?.SetTag("faas.invocation_id", context.InvocationId);
+        activity?.SetTag("faas.name", context.FunctionDefinition.Name);
+
+        await next(context);
+    }
+}

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -17,6 +17,7 @@ using Slypn.Api.Services;
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults(builder =>
     {
+        builder.UseMiddleware<TracingMiddleware>();
         builder.UseMiddleware<JwtMiddleware>();
     })
     .ConfigureLogging((context, logging) =>

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -11,6 +11,7 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Slypn.Api.Infrastructure;
 using Slypn.Api.Services;
 
@@ -57,6 +58,7 @@ var host = new HostBuilder()
             options.Serializer = new JsonObjectSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         });
 
+        services.AddSingleton<IOpenApiConfigurationOptions, OpenApiConfig>();
         services.AddSingleton<IMockDataService, MockDataService>();
         services.AddSingleton<IContentRepository, ContentRepository>();
         services.AddSingleton<IHtmlSanitizer, HtmlSanitizer>();

--- a/src/api/Slypn.Api/Slypn.Api.csproj
+++ b/src/api/Slypn.Api/Slypn.Api.csproj
@@ -27,6 +27,10 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="appsettings.json" Condition="Exists('appsettings.json')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/web/e2e/personas.spec.ts
+++ b/src/web/e2e/personas.spec.ts
@@ -32,7 +32,7 @@ test.describe('dev persona switcher', () => {
     await expect(page.getByRole('link', { name: 'Admin' })).toHaveCount(0)
 
     // Router guard redirects unauthorised roles back home with ?forbidden=.
-    await page.goto('/admin')
+    await page.goto('/admin/members')
     await expect(page).toHaveURL(/\/\?forbidden=/)
   })
 })

--- a/src/web/public/oauth2-redirect.html
+++ b/src/web/public/oauth2-redirect.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en-US">
+<body onload="run()">
+</body>
+</html>
+<script>
+  'use strict';
+  function run() {
+    var oauth2 = window.opener.swaggerUIRedirectOauth2;
+    var sentState = oauth2.state;
+    var redirectUrl = oauth2.redirectUrl;
+    var isValid, qp, arr;
+    if (/code|token|error/.test(window.location.hash)) {
+      qp = window.location.hash.substring(1).replace('?', '&');
+    } else {
+      qp = location.search.substring(1);
+    }
+    arr = qp.split('&');
+    arr.forEach(function(v, i, _arr) { _arr[i] = '"' + v.replace('=', '":"') + '"'; });
+    qp = qp ? JSON.parse('{' + arr.join() + '}',
+      function(key, value) { return key ? decodeURIComponent(value) : value; }
+    ) : {};
+    isValid = qp.state === sentState;
+    if ((
+      oauth2.auth.schema.get('flow') === 'accessCode' ||
+      oauth2.auth.schema.get('flow') === 'authorizationCode' ||
+      oauth2.auth.schema.get('flow') === 'authorization_code'
+    ) && !oauth2.auth.bearerFormat) {
+      window.opener.swaggerUIRedirectOauth2.callback({ auth: oauth2.auth, redirectUrl: redirectUrl });
+    } else {
+      window.opener.swaggerUIRedirectOauth2.callback({ auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl });
+    }
+    window.close();
+  }
+</script>

--- a/src/web/public/oauth2-redirect.html
+++ b/src/web/public/oauth2-redirect.html
@@ -1,35 +1,43 @@
 <!doctype html>
 <html lang="en-US">
-<body onload="run()">
+<body>
+<script>
+"use strict";
+function run() {
+  var e, r, t,
+      a = window.opener.swaggerUIRedirectOauth2,
+      o = a.state,
+      n = a.redirectUrl;
+  if ((t = (r = /code|token|error/.test(window.location.hash)
+      ? window.location.hash.substring(1).replace("?", "&")
+      : location.search.substring(1)).split("&"))
+      .forEach(function(e, r, t) { t[r] = '"' + e.replace("=", '":"') + '"'; }),
+      e = (r = r ? JSON.parse("{" + t.join() + "}", function(e, r) { return "" === e ? r : decodeURIComponent(r); }) : {}).state === o,
+      "accessCode" !== a.auth.schema.get("flow") &&
+      "authorizationCode" !== a.auth.schema.get("flow") &&
+      "authorization_code" !== a.auth.schema.get("flow") ||
+      a.auth.code) {
+    a.callback({ auth: a.auth, token: r, isValid: e, redirectUrl: n });
+  } else if (e || a.errCb({
+    authId: a.auth.name, source: "auth", level: "warning",
+    message: "Authorization may be unsafe, passed state was changed in server. Passed state wasn't returned from auth server."
+  }), r.code) {
+    delete a.state;
+    a.auth.code = r.code;
+    a.callback({ auth: a.auth, redirectUrl: n });
+  } else {
+    var msg;
+    r.error && (msg = "[" + r.error + "]: " +
+      (r.error_description ? r.error_description + ". " : "no accessCode received from the server. ") +
+      (r.error_uri ? "More info: " + r.error_uri : ""));
+    a.errCb({ authId: a.auth.name, source: "auth", level: "error",
+      message: msg || "[Authorization failed]: no accessCode received from the server" });
+  }
+  window.close();
+}
+"loading" !== document.readyState
+  ? run()
+  : document.addEventListener("DOMContentLoaded", function() { run(); });
+</script>
 </body>
 </html>
-<script>
-  'use strict';
-  function run() {
-    var oauth2 = window.opener.swaggerUIRedirectOauth2;
-    var sentState = oauth2.state;
-    var redirectUrl = oauth2.redirectUrl;
-    var isValid, qp, arr;
-    if (/code|token|error/.test(window.location.hash)) {
-      qp = window.location.hash.substring(1).replace('?', '&');
-    } else {
-      qp = location.search.substring(1);
-    }
-    arr = qp.split('&');
-    arr.forEach(function(v, i, _arr) { _arr[i] = '"' + v.replace('=', '":"') + '"'; });
-    qp = qp ? JSON.parse('{' + arr.join() + '}',
-      function(key, value) { return key ? decodeURIComponent(value) : value; }
-    ) : {};
-    isValid = qp.state === sentState;
-    if ((
-      oauth2.auth.schema.get('flow') === 'accessCode' ||
-      oauth2.auth.schema.get('flow') === 'authorizationCode' ||
-      oauth2.auth.schema.get('flow') === 'authorization_code'
-    ) && !oauth2.auth.bearerFormat) {
-      window.opener.swaggerUIRedirectOauth2.callback({ auth: oauth2.auth, redirectUrl: redirectUrl });
-    } else {
-      window.opener.swaggerUIRedirectOauth2.callback({ auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl });
-    }
-    window.close();
-  }
-</script>

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -13,8 +13,8 @@
     SwaggerUIBundle({
       url: '/api/swagger.json',
       dom_id: '#swagger-ui',
-      presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
-      layout: 'StandaloneLayout',
+      presets: [SwaggerUIBundle.presets.apis],
+      layout: 'BaseLayout',
     })
   </script>
 </body>

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -16,14 +16,14 @@
         const oauth2 = spec.components?.securitySchemes?.oauth2
         const clientId = oauth2?.['x-client-id'] ?? ''
         const scopes = Object.keys(oauth2?.flows?.authorizationCode?.scopes ?? {}).join(' ')
-        SwaggerUIBundle({
+        const ui = SwaggerUIBundle({
           spec,
           dom_id: '#swagger-ui',
           presets: [SwaggerUIBundle.presets.apis],
           layout: 'BaseLayout',
           oauth2RedirectUrl: window.location.origin + '/oauth2-redirect.html',
-          initOAuth: { clientId, scopes, usePkceWithAuthorizationCodeGrant: true },
         })
+        ui.initOAuth({ clientId, scopes, usePkceWithAuthorizationCodeGrant: true })
       })
   </script>
 </body>

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <title>Slypn API docs</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.30.2/swagger-ui.css" />
   <style>body { margin: 0; }</style>
 </head>
 <body>
   <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@5.30.2/swagger-ui-bundle.js"></script>
   <script>
     fetch('/api/swagger.json')
       .then(r => r.json())
@@ -22,6 +22,7 @@
           presets: [SwaggerUIBundle.presets.apis],
           layout: 'BaseLayout',
           oauth2RedirectUrl: window.location.origin + '/oauth2-redirect.html',
+          validatorUrl: null,
           requestInterceptor: (req) => {
             req.url = req.url.replace(/https?:\/\/[^/]+\.azurewebsites\.net\/api/, window.location.origin + '/api')
             return req

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -16,13 +16,16 @@
         const oauth2 = spec.components?.securitySchemes?.oauth2
         const clientId = oauth2?.['x-client-id'] ?? ''
         const scopes = Object.keys(oauth2?.flows?.authorizationCode?.scopes ?? {}).join(' ')
-        spec.servers = [{ url: window.location.origin + '/api' }]
         const ui = SwaggerUIBundle({
-          spec,
+          url: '/api/swagger.json',
           dom_id: '#swagger-ui',
           presets: [SwaggerUIBundle.presets.apis],
           layout: 'BaseLayout',
           oauth2RedirectUrl: window.location.origin + '/oauth2-redirect.html',
+          requestInterceptor: (req) => {
+            req.url = req.url.replace(/https?:\/\/[^/]+\.azurewebsites\.net\/api/, window.location.origin + '/api')
+            return req
+          },
         })
         ui.initOAuth({ clientId, scopes, usePkceWithAuthorizationCodeGrant: true })
       })

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -16,6 +16,7 @@
         const oauth2 = spec.components?.securitySchemes?.oauth2
         const clientId = oauth2?.['x-client-id'] ?? ''
         const scopes = Object.keys(oauth2?.flows?.authorizationCode?.scopes ?? {}).join(' ')
+        spec.servers = [{ url: window.location.origin + '/api' }]
         const ui = SwaggerUIBundle({
           spec,
           dom_id: '#swagger-ui',

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -10,12 +10,21 @@
   <div id="swagger-ui"></div>
   <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
   <script>
-    SwaggerUIBundle({
-      url: '/api/swagger.json',
-      dom_id: '#swagger-ui',
-      presets: [SwaggerUIBundle.presets.apis],
-      layout: 'BaseLayout',
-    })
+    fetch('/api/swagger.json')
+      .then(r => r.json())
+      .then(spec => {
+        const oauth2 = spec.components?.securitySchemes?.oauth2
+        const clientId = oauth2?.['x-client-id'] ?? ''
+        const scopes = Object.keys(oauth2?.flows?.authorizationCode?.scopes ?? {}).join(' ')
+        SwaggerUIBundle({
+          spec,
+          dom_id: '#swagger-ui',
+          presets: [SwaggerUIBundle.presets.apis],
+          layout: 'BaseLayout',
+          oauth2RedirectUrl: window.location.origin + '/oauth2-redirect.html',
+          initOAuth: { clientId, scopes, usePkceWithAuthorizationCodeGrant: true },
+        })
+      })
   </script>
 </body>
 </html>

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Slypn API docs</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  <style>body { margin: 0; }</style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: '/api/swagger.json',
+      dom_id: '#swagger-ui',
+      presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+      layout: 'StandaloneLayout',
+    })
+  </script>
+</body>
+</html>

--- a/src/web/src/components/layout/AppFooter.vue
+++ b/src/web/src/components/layout/AppFooter.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import logoWhiteUrl from '@/assets/logo-white.svg'
+import { useCookieConsent } from '@/composables/useCookieConsent'
 
 const year = new Date().getFullYear()
+const { reset: resetCookies } = useCookieConsent()
 </script>
 
 <template>
@@ -60,15 +62,11 @@ const year = new Date().getFullYear()
     <div class="border-t border-slypn-600/60">
       <div class="page-container flex flex-col items-start justify-between gap-3 py-5 text-xs text-slypn-100/70 sm:flex-row sm:items-center">
         <p>&copy; {{ year }} South London Younger Parkinson&rsquo;s Network.</p>
-        <p>
-          Built with care &mdash;
-          <a
-            href="https://github.com/sinclapa/slypn"
-            class="underline underline-offset-2 hover:text-tulip"
-            rel="noopener"
-            target="_blank"
-          >source on GitHub</a>.
-        </p>
+        <button
+          type="button"
+          class="underline underline-offset-2 hover:text-tulip"
+          @click="resetCookies"
+        >Cookie preferences</button>
       </div>
     </div>
   </footer>

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -43,7 +43,7 @@ const accountLinks = computed(() => ([
 const envMenuOpen = ref(false)
 const swaggerUrl = APP_ENV === 'local'
   ? 'http://localhost:7071/api/swagger/ui'
-  : '/api/swagger/ui'
+  : '/swagger.html'
 
 // Mobile: the hamburger (primary nav) and the avatar (account) are separate
 // panels — opening one closes the other.

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -10,9 +10,6 @@ const envLabel  = APP_ENV !== 'prod' ? APP_ENV : null
 const envClass  = APP_ENV === 'local'
   ? 'bg-green-100 text-green-700 border-green-300'
   : 'bg-amber-100 text-amber-700 border-amber-300'
-const swaggerUrl = APP_ENV === 'local'
-  ? 'http://localhost:7071/api/swagger/ui'
-  : '/api/swagger/ui'
 
 const navItems = [
   { to: '/',           label: 'Home' },
@@ -29,7 +26,6 @@ const approvalsStore = useApprovalsStore()
 const router = useRouter()
 const mobileOpen = ref(false)
 const userMenuOpen = ref(false)
-const envMenuOpen = ref(false)
 
 // Account/admin links, defined once and reused by the desktop dropdown and the
 // mobile account panel. `dividerAfter` renders a separator; `badge` shows the
@@ -43,6 +39,11 @@ const accountLinks = computed(() => ([
   { to: '/admin/members',   label: 'Members',            show: auth.isAdmin },
   { to: '/admin/resources', label: 'Resources',          show: auth.isAdmin },
 ] as { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }[]).filter(l => l.show))
+
+const envMenuOpen = ref(false)
+const swaggerUrl = APP_ENV === 'local'
+  ? 'http://localhost:7071/api/swagger/ui'
+  : '/api/swagger/ui'
 
 // Mobile: the hamburger (primary nav) and the avatar (account) are separate
 // panels — opening one closes the other.

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -10,6 +10,9 @@ const envLabel  = APP_ENV !== 'prod' ? APP_ENV : null
 const envClass  = APP_ENV === 'local'
   ? 'bg-green-100 text-green-700 border-green-300'
   : 'bg-amber-100 text-amber-700 border-amber-300'
+const swaggerUrl = APP_ENV === 'local'
+  ? 'http://localhost:7071/api/swagger/ui'
+  : '/api/swagger/ui'
 
 const navItems = [
   { to: '/',           label: 'Home' },
@@ -26,6 +29,7 @@ const approvalsStore = useApprovalsStore()
 const router = useRouter()
 const mobileOpen = ref(false)
 const userMenuOpen = ref(false)
+const envMenuOpen = ref(false)
 
 // Account/admin links, defined once and reused by the desktop dropdown and the
 // mobile account panel. `dividerAfter` renders a separator; `badge` shows the
@@ -85,11 +89,33 @@ async function onSignOut() {
         <img :src="logoUrl" alt="SLYPN" class="h-16 w-auto" width="684" height="488" />
       </RouterLink>
 
-      <span
-        v-if="envLabel"
-        class="inline-block rounded border px-2.5 py-1 font-mono text-xs font-semibold uppercase tracking-wide"
-        :class="envClass"
-      >{{ envLabel }}</span>
+      <div v-if="envLabel" class="relative">
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded border px-2.5 py-1 font-mono text-xs font-semibold uppercase tracking-wide"
+          :class="envClass"
+          :aria-expanded="envMenuOpen"
+          @click="envMenuOpen = !envMenuOpen"
+        >
+          {{ envLabel }}
+          <svg class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        <div
+          v-if="envMenuOpen"
+          class="absolute left-0 top-full mt-1 min-w-max rounded-md border border-slypn-100 bg-white py-1 shadow-lg"
+          @mouseleave="envMenuOpen = false"
+        >
+          <a
+            :href="swaggerUrl"
+            target="_blank"
+            rel="noopener"
+            class="block px-4 py-2 text-sm font-normal normal-case tracking-normal text-slypn-700 hover:bg-slypn-50"
+            @click="envMenuOpen = false"
+          >API docs</a>
+        </div>
+      </div>
 
       <nav class="hidden items-center gap-1 md:flex" aria-label="Primary">
         <RouterLink

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -34,7 +34,7 @@ const envMenuOpen = ref(false)
 // Account/admin links, defined once and reused by the desktop dropdown and the
 // mobile account panel. `dividerAfter` renders a separator; `badge` shows the
 // pending-approvals count.
-interface AccountLink { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }
+type AccountLink = { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }
 const accountLinks = computed<AccountLink[]>(() => ([
   { to: '/dashboard',       label: 'Dashboard',          show: true, dividerAfter: true },
   { to: '/admin/approvals', label: 'Approvals',          show: auth.isAdmin, badge: true },
@@ -49,6 +49,8 @@ const accountLinks = computed<AccountLink[]>(() => ([
 // panels — opening one closes the other.
 function toggleMobileNav() { mobileOpen.value = !mobileOpen.value; userMenuOpen.value = false }
 function toggleAccount()   { userMenuOpen.value = !userMenuOpen.value; mobileOpen.value = false }
+function toggleEnvMenu()   { envMenuOpen.value = !envMenuOpen.value }
+function closeEnvMenu()    { envMenuOpen.value = false }
 
 onMounted(() => { if (auth.isAdmin) approvalsStore.refresh() })
 watch(() => auth.isAdmin, (isAdmin) => { if (isAdmin) approvalsStore.refresh() })
@@ -95,7 +97,7 @@ async function onSignOut() {
           class="inline-flex items-center gap-1 rounded border px-2.5 py-1 font-mono text-xs font-semibold uppercase tracking-wide"
           :class="envClass"
           :aria-expanded="envMenuOpen"
-          @click="envMenuOpen = !envMenuOpen"
+          @click="toggleEnvMenu"
         >
           {{ envLabel }}
           <svg class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
@@ -105,14 +107,14 @@ async function onSignOut() {
         <div
           v-if="envMenuOpen"
           class="absolute left-0 top-full mt-1 min-w-max rounded-md border border-slypn-100 bg-white py-1 shadow-lg"
-          @mouseleave="envMenuOpen = false"
+          @mouseleave="closeEnvMenu"
         >
           <a
             :href="swaggerUrl"
             target="_blank"
             rel="noopener"
             class="block px-4 py-2 text-sm font-normal normal-case tracking-normal text-slypn-700 hover:bg-slypn-50"
-            @click="envMenuOpen = false"
+            @click="closeEnvMenu"
           >API docs</a>
         </div>
       </div>

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -34,8 +34,7 @@ const envMenuOpen = ref(false)
 // Account/admin links, defined once and reused by the desktop dropdown and the
 // mobile account panel. `dividerAfter` renders a separator; `badge` shows the
 // pending-approvals count.
-type AccountLink = { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }
-const accountLinks = computed<AccountLink[]>(() => ([
+const accountLinks = computed(() => ([
   { to: '/dashboard',       label: 'Dashboard',          show: true, dividerAfter: true },
   { to: '/admin/approvals', label: 'Approvals',          show: auth.isAdmin, badge: true },
   { to: '/admin/content',   label: 'Content management', show: auth.isContributor || auth.isAdmin },
@@ -43,7 +42,7 @@ const accountLinks = computed<AccountLink[]>(() => ([
   { to: '/admin/events',    label: 'Event management',   show: auth.isContributor || auth.isAdmin },
   { to: '/admin/members',   label: 'Members',            show: auth.isAdmin },
   { to: '/admin/resources', label: 'Resources',          show: auth.isAdmin },
-] as AccountLink[]).filter(l => l.show))
+] as { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }[]).filter(l => l.show))
 
 // Mobile: the hamburger (primary nav) and the avatar (account) are separate
 // panels — opening one closes the other.

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -5,6 +5,12 @@ import logoUrl from '@/assets/logo.svg'
 import { useAuthStore } from '@/stores/auth'
 import { useApprovalsStore } from '@/stores/approvals'
 
+const APP_ENV   = import.meta.env.VITE_FARO_ENV ?? 'dev'
+const envLabel  = APP_ENV !== 'prod' ? APP_ENV : null
+const envClass  = APP_ENV === 'local'
+  ? 'bg-green-100 text-green-700 border-green-300'
+  : 'bg-amber-100 text-amber-700 border-amber-300'
+
 const navItems = [
   { to: '/',           label: 'Home' },
   { to: '/about',      label: 'About' },
@@ -78,6 +84,12 @@ async function onSignOut() {
       >
         <img :src="logoUrl" alt="SLYPN" class="h-16 w-auto" width="684" height="488" />
       </RouterLink>
+
+      <span
+        v-if="envLabel"
+        class="inline-block rounded border px-2.5 py-1 font-mono text-xs font-semibold uppercase tracking-wide"
+        :class="envClass"
+      >{{ envLabel }}</span>
 
       <nav class="hidden items-center gap-1 md:flex" aria-label="Primary">
         <RouterLink

--- a/src/web/src/composables/useAutoSave.test.ts
+++ b/src/web/src/composables/useAutoSave.test.ts
@@ -9,6 +9,8 @@ interface Harness {
   lastSavedAt: Ref<Date | null>
 }
 
+let currentWrapper: ReturnType<typeof mount> | null = null
+
 function mountAutoSave<T>(state: Ref<T>, saveFn: (v: T) => Promise<void>, options = {}) {
   let api!: Harness
   const Comp = defineComponent({
@@ -18,13 +20,18 @@ function mountAutoSave<T>(state: Ref<T>, saveFn: (v: T) => Promise<void>, option
     },
     template: '<div />',
   })
-  const wrapper = mount(Comp)
-  return { api, wrapper }
+  currentWrapper = mount(Comp)
+  return { api, wrapper: currentWrapper }
 }
 
 describe('useAutoSave', () => {
   beforeEach(() => vi.useFakeTimers())
-  afterEach(() => vi.useRealTimers())
+  afterEach(() => {
+    vi.clearAllTimers()    // discard any pending debounce timers
+    vi.useRealTimers()
+    currentWrapper?.unmount()  // trigger onBeforeUnmount → clears the timer ref
+    currentWrapper = null
+  })
 
   it('skips the initial change by default', async () => {
     const state = ref('a')

--- a/src/web/src/composables/useCookieConsent.test.ts
+++ b/src/web/src/composables/useCookieConsent.test.ts
@@ -20,6 +20,14 @@ describe('useCookieConsent', () => {
     expect(localStorage.getItem(STORAGE_KEY)).toBe('declined')
   })
 
+  it('reset() clears storage and sets choice to null', () => {
+    const { choice, accept, reset } = useCookieConsent()
+    accept()
+    reset()
+    expect(choice.value).toBeNull()
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
   it('shares one reactive choice across callers (singleton)', () => {
     const a = useCookieConsent()
     const b = useCookieConsent()

--- a/src/web/src/composables/useCookieConsent.ts
+++ b/src/web/src/composables/useCookieConsent.ts
@@ -23,10 +23,20 @@ function persist(next: ConsentChoice) {
   }
 }
 
+function reset() {
+  choice.value = null
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* storage blocked */
+  }
+}
+
 export function useCookieConsent() {
   return {
     choice,
     accept: () => persist('accepted'),
     decline: () => persist('declined'),
+    reset,
   }
 }

--- a/src/web/vitest.config.ts
+++ b/src/web/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
     alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
   },
   test: {
+    // threads avoids the Windows EPERM/timeout issue with the forks pool.
+    pool: 'threads',
     environment: 'happy-dom',
     include: ['src/**/*.{test,spec}.ts'],
     setupFiles: ['./src/test/setup.ts'],


### PR DESCRIPTION
## Summary

- **Swagger UI served from SWA** (`/swagger.html`) to avoid CORS from the extension's built-in UI hitting the raw `azurewebsites.net` host
- **Environment-aware title** (`Slypn API [dev]` / `[prod]`) baked into `appsettings.json` at CI time; `Otel__Env` Azure app setting removed from all SWA environments so the baked value governs
- **OAuth2 PKCE login** in Swagger UI — clicking Authorize opens a CIAM popup (or silently reuses an existing session); tokens are applied automatically to all requests:
  - `SwaggerOAuthFilter` rewrites the spec at serialisation time: replaces `bearer_auth` with an `oauth2` Authorization Code + PKCE scheme; derives URLs from `AzureAd:Authority`; embeds the SPA client ID as `x-client-id`
  - `swagger.html` fetches the spec, reads `x-client-id` and scopes, inits Swagger UI with PKCE, and overrides `servers` to the SWA origin so requests go through the proxy
  - `oauth2-redirect.html` (Swagger UI v5 callback logic) handles the PKCE redirect
- **CI** registers `/oauth2-redirect.html` as a CIAM redirect URI on PR open/close alongside `/auth/callback`; bakes `Swagger:SpaClientId` from `VITE_MSAL_CLIENT_ID` secret into `appsettings.json`
- **`setup.ps1`** adds `Swagger__SpaClientId` to SWA app settings and registers the redirect URI for local dev and prod

## Test plan

- [ ] Open `/swagger.html` on PR preview — title shows `Slypn API [dev]`
- [ ] Click Authorize → CIAM popup (or instant SSO) → padlock closes
- [ ] Execute a protected endpoint → data returned, not 401
- [ ] Unauthenticated Execute → 401
- [ ] PR close removes both CIAM redirect URIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)