### PR TITLE
feat(web): open-book hero icon on Articles page + fix prod Swagger title

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Set Otel__Env=dev on PR preview
         if: github.event_name == 'pull_request'
         run: |
-          ENV_NAME="pr-${{ github.event.pull_request.number }}"
+          ENV_NAME="${{ github.event.pull_request.number }}"
           # SWA preview environments appear in ARM a few seconds after the deploy
           # action completes. Retry for up to 2 minutes before failing.
           for i in $(seq 1 8); do

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -69,14 +69,6 @@ jobs:
             "$OTEL_ENV" "$SPA_CLIENT_ID" > src/api/Slypn.Api/appsettings.json
         shell: bash
 
-      - name: Set Otel__Env production app setting
-        if: github.event_name == 'push'
-        run: |
-          az staticwebapp appsettings set \
-            --name swa-slypn-prod --resource-group rg-slypn-prod \
-            --setting-names Otel__Env=prod
-        shell: bash
-
       - name: Build + deploy to SWA
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -103,6 +95,30 @@ jobs:
           FARO_SOURCEMAP_APP_ID:     ${{ secrets.FARO_SOURCEMAP_APP_ID }}
           FARO_SOURCEMAP_STACK_ID:   ${{ secrets.FARO_SOURCEMAP_STACK_ID }}
           FARO_SOURCEMAP_API_KEY:    ${{ secrets.FARO_SOURCEMAP_API_KEY }}
+
+      - name: Set Otel__Env=prod on production
+        if: github.event_name == 'push'
+        run: |
+          az staticwebapp appsettings set \
+            --name swa-slypn-prod --resource-group rg-slypn-prod \
+            --setting-names Otel__Env=prod
+        shell: bash
+
+      - name: Set Otel__Env=dev on PR preview
+        if: github.event_name == 'pull_request'
+        run: |
+          ENV_NAME="pr-${{ github.event.pull_request.number }}"
+          # SWA preview environments appear in ARM a few seconds after the deploy
+          # action completes. Retry for up to 2 minutes before failing.
+          for i in $(seq 1 8); do
+            az staticwebapp appsettings set \
+              --name swa-slypn-prod --resource-group rg-slypn-prod \
+              --environment-name "$ENV_NAME" \
+              --setting-names Otel__Env=dev && break
+            echo "Preview environment not yet ARM-visible (attempt $i/8) — retrying in 15s..."
+            sleep 15
+          done
+        shell: bash
 
       - name: Register PR preview redirect URI
         if: github.event_name == 'pull_request'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -69,6 +69,14 @@ jobs:
             "$OTEL_ENV" "$SPA_CLIENT_ID" > src/api/Slypn.Api/appsettings.json
         shell: bash
 
+      - name: Set Otel__Env production app setting
+        if: github.event_name == 'push'
+        run: |
+          az staticwebapp appsettings set \
+            --name swa-slypn-prod --resource-group rg-slypn-prod \
+            --setting-names Otel__Env=prod
+        shell: bash
+
       - name: Build + deploy to SWA
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/src/web/src/components/common/ArticlesIcon.vue
+++ b/src/web/src/components/common/ArticlesIcon.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+// Open book with ruled text-line cutouts — articles icon.
+// Monochrome via currentColor; inherits surrounding text colour.
+</script>
+
+<template>
+  <svg viewBox="0 0 280 200" fill="currentColor" stroke="none" aria-hidden="true">
+    <!-- Left page with text-line cutouts (evenodd punches through the fill) -->
+    <path
+      fill-rule="evenodd"
+      d="M0 22 C0 9 9 0 22 0 L130 0 L130 182 Q65 192 0 180 Z
+         M16 38 L114 38 L114 46 L16 46 Z
+         M16 58 L114 58 L114 66 L16 66 Z
+         M16 78 L114 78 L114 86 L16 86 Z
+         M16 98 L114 98 L114 106 L16 106 Z
+         M16 118 L114 118 L114 126 L16 126 Z
+         M16 138 L114 138 L114 146 L16 146 Z
+         M16 158 L72 158 L72 166 L16 166 Z"
+    />
+    <!-- Right page with text-line cutouts -->
+    <path
+      fill-rule="evenodd"
+      d="M150 0 L258 0 C271 0 280 9 280 22 L280 180 Q215 192 150 182 Z
+         M166 38 L264 38 L264 46 L166 46 Z
+         M166 58 L264 58 L264 66 L166 66 Z
+         M166 78 L264 78 L264 86 L166 86 Z
+         M166 98 L264 98 L264 106 L166 106 Z
+         M166 118 L264 118 L264 126 L166 126 Z
+         M166 136 L264 136 L264 144 L166 144 Z
+         M166 156 L220 156 L220 164 L166 164 Z"
+    />
+    <!-- Spine -->
+    <rect x="130" y="0" width="20" height="182" rx="3" />
+  </svg>
+</template>

--- a/src/web/src/views/ArticlesView.vue
+++ b/src/web/src/views/ArticlesView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
+import ArticlesIcon from '@/components/common/ArticlesIcon.vue'
 import ArticleCard from '@/components/common/ArticleCard.vue'
 import PillFilter from '@/components/common/PillFilter.vue'
 import { apiJson } from '@/lib/api'
@@ -39,7 +40,11 @@ const visible = computed(() => {
     eyebrow="Articles"
     title="Considered pieces, written by members"
     subtitle="Longer-form writing from the SLYPN community on living with Parkinson's, navigating treatment, and the small daily things that make a difference."
-  />
+  >
+    <template #brand>
+      <ArticlesIcon class="w-56 text-slypn-700 sm:w-64 md:w-72" />
+    </template>
+  </HeroBanner>
 
   <section class="page-container py-16">
     <PillFilter v-model="selected" :options="categories" />


### PR DESCRIPTION
## Summary

- Adds `ArticlesIcon.vue` — an open book SVG with ruled text-line cutouts, monochrome via `currentColor` — slotted into the `#brand` slot of the Articles page `HeroBanner`, matching the pattern on Home (SLYPN logo) and About (South London skyline)
- Fixes production Swagger UI showing `Slypn API [dev]` instead of `[prod]`: `appsettings.json` is not git-tracked so Oryx skips it during the SWA build; `Otel__Env=prod` is now set as an Azure app setting (already applied to prod) and a CI step keeps it idempotent on future pushes

## Test plan

- [ ] Articles page hero shows the open-book illustration at all breakpoints
- [ ] Production Swagger UI title reads `Slypn API [prod]`
- [ ] PR preview Swagger UI title still reads `Slypn API [dev]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)