### PR TITLE
ci: integrate SonarCloud analysis for API and web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,6 @@ jobs:
           /k:"sinclapa_slypn"
           /o:"cookingcode"
           /d:sonar.host.url="https://sonarcloud.io"
-          /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
           /d:sonar.cs.cobertura.reportsPaths="src/api/Slypn.Api.Tests/TestResults/**/coverage.cobertura.xml"
           /d:sonar.javascript.lcov.reportPaths="src/web/coverage/lcov.info"
           /d:sonar.typescript.lcov.reportPaths="src/web/coverage/lcov.info"
@@ -144,4 +143,4 @@ jobs:
       - name: End SonarCloud analysis
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+        run: dotnet-sonarscanner end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,82 @@ jobs:
 
       - name: Test (API)
         run: dotnet test src/api/Slypn.Api.Tests/Slypn.Api.Tests.csproj --configuration Release --logger "trx;LogFileName=test-results.trx" --verbosity normal
+
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    needs: [web, api]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: src/web/package-lock.json
+
+      - name: Set up JDK 17 (required by SonarScanner)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Install SonarScanner for .NET
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: Install web dependencies
+        working-directory: src/web
+        run: npm ci --no-fund --no-audit --ignore-scripts
+
+      - name: Web unit tests with coverage
+        working-directory: src/web
+        run: npm run test:unit:coverage
+
+      - name: Begin SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: >
+          dotnet-sonarscanner begin
+          /k:"sinclapa_slypn"
+          /o:"cookingcode"
+          /d:sonar.host.url="https://sonarcloud.io"
+          /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.cs.cobertura.reportsPaths="src/api/Slypn.Api.Tests/TestResults/**/coverage.cobertura.xml"
+          /d:sonar.javascript.lcov.reportPaths="src/web/coverage/lcov.info"
+          /d:sonar.typescript.lcov.reportPaths="src/web/coverage/lcov.info"
+          /d:sonar.exclusions="**/node_modules/**,**/dist/**,**/coverage/**,**/playwright-report/**,**/test-results/**,**/bin/**,**/obj/**"
+          /d:sonar.test.inclusions="src/web/src/**/*.spec.ts,src/web/src/**/*.test.ts,src/web/e2e/**"
+
+      - name: Restore (API)
+        run: dotnet restore src/api/Slypn.Api/Slypn.Api.csproj
+
+      - name: Build (API)
+        run: dotnet build src/api/Slypn.Api/Slypn.Api.csproj --no-restore --configuration Release
+
+      - name: Test (API) with coverage
+        run: >
+          dotnet test src/api/Slypn.Api.Tests/Slypn.Api.Tests.csproj
+          --configuration Release
+          --collect:"XPlat Code Coverage"
+          --settings src/api/Slypn.Api.Tests/coverlet.runsettings
+          --results-directory src/api/Slypn.Api.Tests/TestResults
+
+      - name: End SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -973,10 +973,11 @@ if (-not $SkipGitHub) {
         Ok "Authenticated to GitHub"
 
         # Helper: set a secret and report idempotently.
+        $script:setSecretNames = @()
         function Set-GhSecret([string]$name, [string]$value) {
             if ([string]::IsNullOrWhiteSpace($value)) { Warn "Skipping $name — value not available"; return }
             $value | gh secret set $name --repo $gitHubRepo
-            if ($LASTEXITCODE -eq 0) { Ok $name } else { Warn "Failed to set $name" }
+            if ($LASTEXITCODE -eq 0) { Ok $name; $script:setSecretNames += $name } else { Warn "Failed to set $name" }
         }
 
         # SWA deployment token — fetch fresh from Azure each run.
@@ -1077,6 +1078,21 @@ if (-not $SkipGitHub) {
         if ($s.Contains('spaObjectId'))     { Set-GhSecret 'SPA_OBJECT_ID'      $s['spaObjectId'] }
         if ($s.Contains('ciClientId'))      { Set-GhSecret 'CIAM_CLIENT_ID'     $s['ciClientId'] }
         if ($s.Contains('ciClientSecret'))  { Set-GhSecret 'CIAM_CLIENT_SECRET' $s['ciClientSecret'] }
+
+        # SonarCloud analysis token — used by the "sonarcloud" CI job.
+        $sonarToken = Ask $s 'sonarToken' 'SonarCloud token (sonarcloud.io -> My Account -> Security, Enter to skip)'
+        Set-GhSecret 'SONAR_TOKEN' $sonarToken
+
+        # ── Validate all expected secrets are present ────────────────────────
+        Step 'Phase 4 · Validating GitHub secrets'
+        $actualSecretNames   = @(gh secret list --repo $gitHubRepo --json name -q '.[].name' 2>$null)
+        $expectedSecretNames = @($script:setSecretNames | Select-Object -Unique)
+        $missingSecretNames  = @($expectedSecretNames | Where-Object { $_ -notin $actualSecretNames })
+        if ($missingSecretNames.Count -eq 0) {
+            Ok "All $($expectedSecretNames.Count) secret(s) confirmed present on $gitHubRepo"
+        } else {
+            Warn "Missing on $gitHubRepo`: $($missingSecretNames -join ', ')"
+        }
     }
 }
 

--- a/src/web/vitest.config.ts
+++ b/src/web/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     env: { VITE_DEV_SKIP_AUTH: 'true' },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'cobertura'],
+      reporter: ['text', 'cobertura', 'lcov'],
       reportsDirectory: './coverage',
       include: ['src/**/*.{ts,vue}'],
       exclude: [


### PR DESCRIPTION
## Summary
- Adds a `sonarcloud` CI job (after `web`/`api` pass) that runs `dotnet-sonarscanner` across the whole repo in one combined analysis, so both the .NET Functions API and the Vue web app are covered by a single SonarCloud project (`sinclapa_slypn`, org `cookingcode`).
- API coverage: reuses the existing coverlet cobertura output (`--collect:"XPlat Code Coverage"` + `coverlet.runsettings`), imported via `sonar.cs.cobertura.reportsPaths`.
- Web coverage: adds `lcov` to the vitest coverage reporters (alongside the existing `cobertura`) so Sonar's JS/TS analyzer can import it via `sonar.javascript.lcov.reportPaths` / `sonar.typescript.lcov.reportPaths`.
- Extends `infra/setup.ps1`'s GitHub-secrets phase to prompt for and set `SONAR_TOKEN`, and added a validation step that confirms every secret the script manages this run is actually present via `gh secret list`.

`SONAR_TOKEN` has already been set as a repo secret via the updated script (validated: 19/19 secrets present).

## Test plan
- [x] `npm run lint` / `npm run build` (web) pass locally
- [x] `dotnet test` (API) passes with `--collect:"XPlat Code Coverage"` and produces `coverage.cobertura.xml` at the path the workflow expects
- [x] `npm run test:unit:coverage` produces both `lcov.info` and `cobertura-coverage.xml`
- [x] Ran `infra/setup.ps1 -SkipBicep -SkipEntra -SkipSwa -SkipLocal` end to end; all 19 GitHub secrets (including the new `SONAR_TOKEN`) confirmed present
- [ ] CI run on this PR — first live SonarCloud analysis