### PR TITLE
fix: address sonarcloud issues on main

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -41,7 +41,7 @@ jobs:
           lfs: false
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -172,7 +172,7 @@ jobs:
       id-token: write
     steps:
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/src/web/public/oauth2-redirect.html
+++ b/src/web/public/oauth2-redirect.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html lang="en-US">
+<head>
+  <meta charset="UTF-8" />
+  <title>Slypn API docs — OAuth2 redirect</title>
+</head>
 <body>
-<script src="https://unpkg.com/swagger-ui-dist@5.32.8/oauth2-redirect.js"></script>
+<script src="https://unpkg.com/swagger-ui-dist@5.32.8/oauth2-redirect.js" integrity="sha384-XuY48ztmqRBrZqX+bDrPUqkTumNohu9Bl+yztOEp/hDTS5qXIApmbiD04MrTFpjk" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <title>Slypn API docs</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.32.8/swagger-ui.css" />
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.32.8/swagger-ui.css" integrity="sha384-9Q2fpS+xeS4ffJy6CagnwoUl+4ldAYhOs9pgZuEKxypVModhmZFzeMlvVsAjf7uT" crossorigin="anonymous" />
   <style>body { margin: 0; }</style>
 </head>
 <body>
   <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5.32.8/swagger-ui-bundle.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@5.32.8/swagger-ui-bundle.js" integrity="sha384-IKpAWwsTL0pcw7/Amtnt2eXF4P1BK64WNuY2E/RG15SWLUW5HXzFuyqCSAr/DP8C" crossorigin="anonymous"></script>
   <script>
     fetch('/api/swagger.json')
       .then(r => r.json())

--- a/src/web/src/components/common/PublishedContent.vue
+++ b/src/web/src/components/common/PublishedContent.vue
@@ -226,6 +226,7 @@ onMounted(load)
         <input
           v-model="search"
           type="search"
+          aria-label="Search title or summary"
           placeholder="Search title or summary…"
           class="w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
         />

--- a/src/web/src/views/ResourceManagementView.vue
+++ b/src/web/src/views/ResourceManagementView.vue
@@ -200,8 +200,9 @@ async function remove(r: Resource) {
         </h3>
         <form class="mt-4 space-y-4" @submit.prevent="save">
           <div>
-            <label class="block text-sm font-medium text-slypn-800">Title</label>
+            <label for="resource-title" class="block text-sm font-medium text-slypn-800">Title</label>
             <input
+              id="resource-title"
               v-model="form.title"
               type="text"
               maxlength="200"
@@ -210,8 +211,9 @@ async function remove(r: Resource) {
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-slypn-800">Description</label>
+            <label for="resource-description" class="block text-sm font-medium text-slypn-800">Description</label>
             <textarea
+              id="resource-description"
               v-model="form.description"
               rows="3"
               maxlength="500"
@@ -220,8 +222,9 @@ async function remove(r: Resource) {
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-slypn-800">URL</label>
+            <label for="resource-url" class="block text-sm font-medium text-slypn-800">URL</label>
             <input
+              id="resource-url"
               v-model="form.url"
               type="url"
               maxlength="500"
@@ -231,8 +234,9 @@ async function remove(r: Resource) {
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-slypn-800">Category</label>
+            <label for="resource-category" class="block text-sm font-medium text-slypn-800">Category</label>
             <input
+              id="resource-category"
               v-model="form.category"
               type="text"
               maxlength="60"


### PR DESCRIPTION
## Summary
SonarCloud's automatic analysis (running independently of the CI job added in #126) flagged 13 BUG/VULNERABILITY issues on `main`, which were failing `new_reliability_rating` and `new_security_rating` on the quality gate. This fixes 11 of them — the remaining 2 are a judgment call on already-deployed prod infra, called out below rather than auto-fixed.

- **`githubactions:S7637`** (2x, `azure-static-web-apps.yml:44,175`) — `azure/login@v2` pinned to its current full commit SHA (`a457da9`), matching the convention already used for `Azure/static-web-apps-deploy`.
- **`Web:S5725`** (3x, `oauth2-redirect.html`, `swagger.html`) — added SRI `integrity` + `crossorigin="anonymous"` to the unpkg-hosted `swagger-ui-dist@5.32.8` script/CSS tags (hashes computed from the pinned version, so no drift risk).
- **`Web:PageWithoutTitleCheck`** (`oauth2-redirect.html`) — added a `<title>`.
- **`Web:InputWithoutLabelCheck`** (5x, `ResourceManagementView.vue`, `PublishedContent.vue`) — added `id`/`for` pairs on the resource form fields (matching the pattern already used in `EventFormDialog.vue`), and an `aria-label` on the icon-only search input.

**Not fixed here** — `infra/main.bicep`:
- `azureresourcemanager:S6378` (L60, storage account `identity.type: 'None'`) — intentional per the existing comment (access is via the SWA's managed identity + RBAC, not the storage account's own identity).
- `azureresourcemanager:S6388` (L68-74, missing `requireInfrastructureEncryption`) — this is an **immutable** property on an already-deployed storage account; setting it in Bicep now could make the next `az deployment group create` fail trying to change it on the live resource. Recommend marking both as reviewed/accepted in the SonarCloud UI rather than editing IaC for a live resource — happy to do that or revisit if you'd rather provision a new storage account with it enabled.

## Test plan
- [x] `npm run lint` / `npm run build` (web) pass
- [x] `vitest run` on `views.admin.spec.ts` and `PublishedContent.spec.ts` (both touched) — 72/72 pass
- [ ] CI run on this PR