### PR TITLE
fix(web): stretch cookie banner full-width on desktop

### DIFF
--- a/src/web/src/components/common/CookieBanner.vue
+++ b/src/web/src/components/common/CookieBanner.vue
@@ -11,7 +11,7 @@ const { choice, accept, decline } = useCookieConsent()
       open
       aria-labelledby="cookie-title"
       aria-describedby="cookie-desc"
-      class="fixed inset-x-0 bottom-0 z-50 m-0 max-w-none border-0 border-t border-slypn-100 bg-white/95 p-0 text-slypn-900 shadow-lg backdrop-blur"
+      class="fixed inset-x-0 bottom-0 z-50 m-0 w-full max-w-none border-0 border-t border-slypn-100 bg-white/95 p-0 text-slypn-900 shadow-lg backdrop-blur"
     >
       <div class="page-container flex flex-col gap-4 py-5 md:flex-row md:items-center md:justify-between">
         <div class="text-sm text-slypn-900/85">


### PR DESCRIPTION
## Summary
The cookie banner's `<dialog>` element inherits `width: fit-content` from the browser's default UA stylesheet, which `max-w-none` doesn't touch (it only clears `max-width`, not `width`). Combined with `inset-x-0`, that meant the banner sized itself to its content and sat pinned to the left edge rather than stretching full-width — most visible on desktop where `md:flex-row` keeps the content compact, leaving open space to the right. Added `w-full` to force it to fill the fixed container.

Verified with a throwaway Playwright script at a 1440px viewport (browser extension wasn't available this session):
- Before: dialog width ~944px, left-aligned, clear gap on the right
- After: dialog spans full width (0 to the scrollbar edge — a `fixed` element correctly stops short of the scrollbar track, that's expected and not a bug)

## Test plan
- [x] `CookieBanner.spec.ts` — 4/4 pass
- [x] `npm run lint`
- [x] Visual verification via Playwright screenshot at desktop viewport (before/after)