### PR TITLE
feat: newsletter archive import + upload admin screen

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -23,7 +23,7 @@ To keep it simple and cheap we:
 | `drafts` | `authorId` | `id` | `content/drafts/{id}` | Drafts are private; queries are "my drafts" (contributor) or a single draft by id. Partitioning on `authorId` keeps those single-partition. |
 | `events` | `yearMonth` (e.g. `2026-05`) | `id` | — | Listing events is by date range; a year-month partition keeps "this month + next" cheap. The API derives `yearMonth` from `startsAt` on write. |
 | `resources` | `category` | `id` | — | The Resources page filters by category. Partitioning matches the access pattern. |
-| `newsletters` | `year` (four digits) | `id` | — | Archive views are by year; ~12 issues per partition. |
+| `newsletters` | `"newsletter"` (constant) | `id` | `content/newsletters/{id}` (attached issue file, PDF/DOCX) | Volumes are small (~12 issues/year); a single partition keeps `ListNewsletters` a single-partition scan. |
 | `members` | `"member"` (constant) | `id` | — | Member counts are small; a single partition makes `ListMembers` and the email/oid lookups single-partition scans, and point reads by id are PK+RK lookups. |
 
 ## Concurrency

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -240,6 +240,26 @@ public class ContentFunctionsTests
     }
 
     [Fact]
+    public async Task Newsletters_replace_preserves_fileName_when_input_has_none()
+    {
+        // Editing title/date/summary/topics goes through the JSON-only Replace
+        // endpoint, which never carries a file. It must not clear an already
+        // attached file's FileName off the row.
+        var repo = new FakeContentRepository
+        {
+            Newsletters = { new Newsletter("n1", "May", new DateOnly(2026, 5, 1), "summary text", new[] { "t" }) { FileName = "issue.pdf" } },
+        };
+        var fn = NewslettersFn(repo);
+        var ctx = new TestFunctionContext();
+        var valid = new { title = "June 2026", issueDate = "2026-06-01", summary = "A long enough summary.", topics = new[] { "x" } };
+
+        var resp = (TestHttpResponseData)await fn.Replace(TestHttp.Json(ctx, "PUT", "http://localhost/api/newsletters/n1", valid), "n1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("issue.pdf", resp.ReadBodyAsString());
+    }
+
+    [Fact]
     public async Task Newsletters_replace_412_when_storage_fails()
     {
         var repo = new FakeContentRepository { ThrowOnWrite = new RequestFailedException(412, "Precondition failed") };
@@ -370,6 +390,95 @@ public class ContentFunctionsTests
             TestHttp.Get(new TestFunctionContext(), $"http://localhost/api/newsletters/{id}/file"), id, Ct);
 
         Assert.Contains("SLYPN-Newsletter-2021-04.bin", resp.Headers.GetValues("Content-Disposition").Single());
+    }
+
+    [Fact]
+    public async Task Newsletters_uploadFile_200_sets_fileName()
+    {
+        var repo = new FakeContentRepository
+        {
+            Newsletters = { new Newsletter("n1", "May", new DateOnly(2026, 5, 1), "summary text", new[] { "t" }) },
+        };
+        var fn = NewslettersFn(repo);
+
+        var resp = (TestHttpResponseData)await fn.UploadFile(
+            NewsletterFileMultipart("n1", "issue.pdf", "application/pdf"), "n1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("issue.pdf", resp.ReadBodyAsString());
+        Assert.Equal("issue.pdf", repo.Newsletters.Single(n => n.Id == "n1").FileName);
+        Assert.True(repo.NewsletterFiles.ContainsKey("n1"));
+    }
+
+    [Fact]
+    public async Task Newsletters_uploadFile_415_when_not_multipart()
+    {
+        var fn = NewslettersFn(new FakeContentRepository());
+        var req = TestHttp.Raw(new TestFunctionContext(), "PUT", "http://localhost/api/newsletters/n1/file", "x",
+            new Dictionary<string, string> { ["Content-Type"] = "application/json" });
+        var resp = (TestHttpResponseData)await fn.UploadFile(req, "n1", Ct);
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Newsletters_uploadFile_400_when_no_file_part()
+    {
+        const string boundary = "testboundary";
+        var body = $"--{boundary}\r\nContent-Disposition: form-data; name=\"field\"\r\n\r\nvalue\r\n--{boundary}--\r\n";
+        var req = TestHttp.Raw(new TestFunctionContext(), "PUT", "http://localhost/api/newsletters/n1/file", body,
+            new Dictionary<string, string> { ["Content-Type"] = $"multipart/form-data; boundary={boundary}" });
+        var resp = (TestHttpResponseData)await NewslettersFn(new FakeContentRepository()).UploadFile(req, "n1", Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Newsletters_uploadFile_415_when_content_type_not_allowed()
+    {
+        var fn = NewslettersFn(new FakeContentRepository());
+        var resp = (TestHttpResponseData)await fn.UploadFile(
+            NewsletterFileMultipart("n1", "photo.png", "image/png"), "n1", Ct);
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Newsletters_uploadFile_503_when_writes_disabled()
+    {
+        var fn = NewslettersFn(new FakeContentRepository { Writes = false });
+        var resp = (TestHttpResponseData)await fn.UploadFile(
+            NewsletterFileMultipart("n1", "issue.pdf", "application/pdf"), "n1", Ct);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Newsletters_uploadFile_404_when_unknown_id()
+    {
+        var fn = NewslettersFn(new FakeContentRepository());
+        var resp = (TestHttpResponseData)await fn.UploadFile(
+            NewsletterFileMultipart("missing", "issue.pdf", "application/pdf"), "missing", Ct);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Newsletters_uploadFile_412_when_storage_fails()
+    {
+        var repo = new FakeContentRepository
+        {
+            Newsletters = { new Newsletter("n1", "May", new DateOnly(2026, 5, 1), "summary text", new[] { "t" }) },
+            ThrowOnWrite = new RequestFailedException(412, "Precondition failed"),
+        };
+        var fn = NewslettersFn(repo);
+        var resp = (TestHttpResponseData)await fn.UploadFile(
+            NewsletterFileMultipart("n1", "issue.pdf", "application/pdf"), "n1", Ct);
+        Assert.Equal(HttpStatusCode.PreconditionFailed, resp.StatusCode);
+    }
+
+    private static TestHttpRequestData NewsletterFileMultipart(string id, string fileName, string mimeType, string content = "bytes")
+    {
+        const string boundary = "testboundary";
+        var body = $"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{fileName}\"\r\nContent-Type: {mimeType}\r\n\r\n{content}\r\n--{boundary}--\r\n";
+        return TestHttp.Raw(
+            new TestFunctionContext(), "PUT", $"http://localhost/api/newsletters/{id}/file", body,
+            new Dictionary<string, string> { ["Content-Type"] = $"multipart/form-data; boundary={boundary}" });
     }
 
     [Fact]

--- a/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
@@ -24,6 +24,7 @@ file sealed class NoopBodyStore : IContentBodyStore
     public Task PutAsync(string prefix, string id, string html, CancellationToken ct) => Task.CompletedTask;
     public Task<string> GetAsync(string prefix, string id, CancellationToken ct) => Task.FromResult("");
     public Task<BlobDownload?> TryOpenFileAsync(string prefix, string id, CancellationToken ct) => Task.FromResult<BlobDownload?>(null);
+    public Task PutFileAsync(string prefix, string id, Stream content, string contentType, CancellationToken ct) => Task.CompletedTask;
     public Task DeleteAsync(string prefix, string id, CancellationToken ct) => Task.CompletedTask;
 }
 
@@ -131,6 +132,8 @@ public class ContentRepositoryReadTests
             () => Repo().CreateArticleAsync(new ArticleInput(), Ct));
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => Repo().CreateResourceAsync(new ResourceInput(), Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Repo().PutNewsletterFileAsync("n1", new MemoryStream(), "application/pdf", "issue.pdf", null, Ct));
     }
 
     [Fact]

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -1,3 +1,4 @@
+using Azure;
 using Slypn.Api.Models;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
@@ -86,7 +87,10 @@ internal sealed class FakeContentRepository : IContentRepository
     public Task<Newsletter> CreateNewsletterAsync(NewsletterInput input, CancellationToken ct)
         => Task.FromResult(Guard(new Newsletter("new-id", input.Title, input.IssueDate, input.Summary, input.Topics)));
     public Task<Newsletter> ReplaceNewsletterAsync(string id, NewsletterInput input, string? ifMatch, CancellationToken ct)
-        => Task.FromResult(Guard(new Newsletter(id, input.Title, input.IssueDate, input.Summary, input.Topics)));
+    {
+        var existingFileName = Newsletters.FirstOrDefault(n => n.Id == id)?.FileName;
+        return Task.FromResult(Guard(new Newsletter(id, input.Title, input.IssueDate, input.Summary, input.Topics) { FileName = existingFileName }));
+    }
     public Task DeleteNewsletterAsync(string id, string? ifMatch, CancellationToken ct)
         => Guard(Task.CompletedTask);
 
@@ -94,6 +98,20 @@ internal sealed class FakeContentRepository : IContentRepository
     public Dictionary<string, BlobDownload> NewsletterFiles = new();
     public Task<BlobDownload?> OpenNewsletterFileAsync(string id, CancellationToken ct)
         => Task.FromResult(NewsletterFiles.TryGetValue(id, out var f) ? f : null);
+
+    public Task<Newsletter> PutNewsletterFileAsync(string id, Stream content, string contentType, string fileName, string? ifMatch, CancellationToken ct)
+    {
+        var idx = Newsletters.FindIndex(n => n.Id == id);
+        if (idx < 0) throw new RequestFailedException(404, $"Newsletter {id} not found.");
+
+        using var ms = new MemoryStream();
+        content.CopyTo(ms);
+        NewsletterFiles[id] = new BlobDownload(new MemoryStream(ms.ToArray()), contentType);
+
+        var updated = Newsletters[idx] with { FileName = fileName };
+        Newsletters[idx] = updated;
+        return Task.FromResult(Guard(updated));
+    }
 
     /// <summary>Set to throw from the next GetMemberByEmailAsync call (e.g. to test lookup-error branches).</summary>
     public Exception? ThrowOnMemberEmailLookup { get; set; }

--- a/src/api/Slypn.Api.Tests/ServicesTests.cs
+++ b/src/api/Slypn.Api.Tests/ServicesTests.cs
@@ -46,6 +46,8 @@ public class ServicesTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => svc.PutAsync("articles", "a1", "<p>x</p>", Ct));
         await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetAsync("articles", "a1", Ct));
         await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteAsync("articles", "a1", Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => svc.PutFileAsync("newsletters", "n1", new MemoryStream(), "application/pdf", Ct));
     }
 
     [Fact]

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -99,14 +99,15 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
         MultipartFormDataParser parsed;
         try
         {
-            parsed = await MultipartFormDataParser.ParseAsync(req.Body);
+            parsed = await MultipartFormDataParser.ParseAsync(req.Body, cancellationToken: ct);
         }
         catch (Exception ex)
         {
             return await BadRequest(req, $"Could not parse multipart body: {ex.Message}");
         }
 
-        var file = parsed.Files.FirstOrDefault(f => f.Name == "file") ?? parsed.Files.FirstOrDefault();
+        var file = parsed.Files.FirstOrDefault(f => f.Name == "file")
+            ?? (parsed.Files.Count > 0 ? parsed.Files[0] : null);
         if (file is null)
         {
             return await BadRequest(req, "No file part in the upload.");
@@ -226,7 +227,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
         Member record;
         if (existing is null)
         {
-            var newDisplayName = string.IsNullOrWhiteSpace(displayName) ? email : displayName!;
+            var newDisplayName = string.IsNullOrWhiteSpace(displayName) ? email : displayName;
             record = new Member(
                 Id:          Guid.NewGuid().ToString("N"),
                 Email:       email,
@@ -241,7 +242,7 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
             // their roles + oid if they're an actual member. For pure
             // subscribers (no roles, no oid), we just refresh the timestamp.
             var isExistingMember = existing.Roles.Count > 0 || existing.Oid is not null;
-            var resolvedDisplayName = string.IsNullOrWhiteSpace(displayName) ? existing.DisplayName : displayName!;
+            var resolvedDisplayName = string.IsNullOrWhiteSpace(displayName) ? existing.DisplayName : displayName;
             record = existing with
             {
                 Status      = isExistingMember ? existing.Status : "subscribed",

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Azure;
+using HttpMultipartParser;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -63,6 +64,73 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
             _ => "bin",
         };
         return $"SLYPN-Newsletter-{stamp}.{ext}";
+    }
+
+    private static readonly HashSet<string> AllowedFileContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/msword",
+    };
+
+    [Function("UploadNewsletterFile")]
+    [RequireRole("Admin")]
+    [OpenApiOperation(operationId: "newsletters.uploadFile", tags: new[] { "newsletters" }, Summary = "Upload newsletter file", Description = "Uploads/replaces the attached issue file (PDF/DOCX) for a newsletter.")]
+    [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
+    [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Newsletter id.")]
+    [OpenApiRequestBody(contentType: "multipart/form-data", bodyType: typeof(object), Required = true, Description = "Multipart form body with a single file part named file.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Newsletter), Description = "Updated newsletter")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Newsletter not found")]
+    public async Task<HttpResponseData> UploadFile(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "newsletters/{id}/file")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+
+        var contentType = req.Headers.TryGetValues("Content-Type", out var ctHeader)
+            ? ctHeader.FirstOrDefault()
+            : null;
+        if (contentType is null || !contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
+        {
+            return await Reject(req, HttpStatusCode.UnsupportedMediaType,
+                "Expected multipart/form-data with a 'file' part.");
+        }
+
+        MultipartFormDataParser parsed;
+        try
+        {
+            parsed = await MultipartFormDataParser.ParseAsync(req.Body);
+        }
+        catch (Exception ex)
+        {
+            return await BadRequest(req, $"Could not parse multipart body: {ex.Message}");
+        }
+
+        var file = parsed.Files.FirstOrDefault(f => f.Name == "file") ?? parsed.Files.FirstOrDefault();
+        if (file is null)
+        {
+            return await BadRequest(req, "No file part in the upload.");
+        }
+
+        if (!AllowedFileContentTypes.Contains(file.ContentType))
+        {
+            return await Reject(req, HttpStatusCode.UnsupportedMediaType,
+                $"Content type '{file.ContentType}' not allowed. Allowed: {string.Join(", ", AllowedFileContentTypes)}.");
+        }
+
+        try
+        {
+            var n = await repo.PutNewsletterFileAsync(id, file.Data, file.ContentType, file.FileName, IfMatch(req), ct);
+            return await Ok(req, n, n.Etag);
+        }
+        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
+    }
+
+    private static async Task<HttpResponseData> Reject(HttpRequestData req, HttpStatusCode code, string message)
+    {
+        var resp = req.CreateResponse(code);
+        await resp.WriteStringAsync(message);
+        return resp;
     }
 
     [Function("CreateNewsletter")]

--- a/src/api/Slypn.Api/Services/ContentBodyStore.cs
+++ b/src/api/Slypn.Api/Services/ContentBodyStore.cs
@@ -58,6 +58,14 @@ public sealed class ContentBodyStore : IContentBodyStore
         }
     }
 
+    public async Task PutFileAsync(string prefix, string id, Stream content, string contentType, CancellationToken ct)
+    {
+        var blob = Blob(prefix, id);
+        await blob.UploadAsync(content,
+            new BlobHttpHeaders { ContentType = contentType },
+            cancellationToken: ct);
+    }
+
     public async Task<BlobDownload?> TryOpenFileAsync(string prefix, string id, CancellationToken ct)
     {
         var blob = Blob(prefix, id);

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -318,7 +318,14 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     public async Task<Newsletter> ReplaceNewsletterAsync(string id, NewsletterInput input, string? ifMatch, CancellationToken ct)
     {
         EnsureWrites();
-        var n = new Newsletter(id, input.Title, input.IssueDate, input.Summary, input.Topics);
+        // Metadata edits go through this JSON-only endpoint and never touch the
+        // attached file, so carry the existing FileName forward — otherwise every
+        // edit would silently detach the issue file from the row (the blob itself
+        // is untouched, but the row would stop pointing at it).
+        var read = await store.Newsletters.GetEntityAsync<TableEntity>(NewslettersPartition, id, cancellationToken: ct);
+        var existingFileName = Deserialize<Newsletter>(read.Value).FileName;
+
+        var n = new Newsletter(id, input.Title, input.IssueDate, input.Summary, input.Topics) { FileName = existingFileName };
         var resp = await store.Newsletters.UpdateEntityAsync(
             Entity(NewslettersPartition, n.Id, n), DecodeEtag(ifMatch), TableUpdateMode.Replace, ct);
         return n with { Etag = EncodeEtag(resp.Headers.ETag!.Value) };
@@ -337,6 +344,21 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     /// <summary>Open the attached issue file (PDF/DOCX) for streaming, or null if there is none.</summary>
     public Task<BlobDownload?> OpenNewsletterFileAsync(string id, CancellationToken ct) =>
         body.TryOpenFileAsync(NewsletterFilePrefix, id, ct);
+
+    /// <summary>Uploads/replaces the attached issue file and records its display filename on the row.</summary>
+    public async Task<Newsletter> PutNewsletterFileAsync(string id, Stream content, string contentType, string fileName, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        var read = await store.Newsletters.GetEntityAsync<TableEntity>(NewslettersPartition, id, cancellationToken: ct);
+        var source = Deserialize<Newsletter>(read.Value);
+
+        await body.PutFileAsync(NewsletterFilePrefix, id, content, contentType, ct);
+
+        var updated = source with { FileName = fileName };
+        var resp = await store.Newsletters.UpdateEntityAsync(
+            Entity(NewslettersPartition, id, updated), DecodeEtag(ifMatch), TableUpdateMode.Replace, ct);
+        return updated with { Etag = EncodeEtag(resp.Headers.ETag!.Value) };
+    }
 
     // ---- Members --------------------------------------------------------------
     public async Task<Member?> GetMemberByEmailAsync(string email, CancellationToken ct)

--- a/src/api/Slypn.Api/Services/IContentBodyStore.cs
+++ b/src/api/Slypn.Api/Services/IContentBodyStore.cs
@@ -25,6 +25,9 @@ public interface IContentBodyStore
     /// </summary>
     Task<BlobDownload?> TryOpenFileAsync(string prefix, string id, CancellationToken ct);
 
+    /// <summary>Write (overwrite) a binary file blob (e.g. a newsletter PDF/DOCX).</summary>
+    Task PutFileAsync(string prefix, string id, Stream content, string contentType, CancellationToken ct);
+
     /// <summary>Delete the body blob. No-op if it doesn't exist.</summary>
     Task DeleteAsync(string prefix, string id, CancellationToken ct);
 }

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -44,6 +44,7 @@ public interface IContentRepository
     Task<Newsletter> ReplaceNewsletterAsync  (string id, NewsletterInput input, string? ifMatch, CancellationToken ct);
     Task             DeleteNewsletterAsync   (string id, string? ifMatch, CancellationToken ct);
     Task<BlobDownload?> OpenNewsletterFileAsync(string id, CancellationToken ct);
+    Task<Newsletter> PutNewsletterFileAsync  (string id, Stream content, string contentType, string fileName, string? ifMatch, CancellationToken ct);
 
     // Members --------------------------------------------------------------
     Task<Member?>              GetMemberByEmailAsync(string email, CancellationToken ct);

--- a/src/web/src/components/layout/AppNav.spec.ts
+++ b/src/web/src/components/layout/AppNav.spec.ts
@@ -72,6 +72,7 @@ describe('AppNav', () => {
     await trigger.trigger('click')
     expect(w.text()).toContain('Dashboard')
     expect(w.text()).toContain('Approvals')
+    expect(w.text()).toContain('Newsletters')
     expect(w.text()).toContain('Sign out')
   })
 
@@ -90,6 +91,7 @@ describe('AppNav', () => {
     const account = w.find('#mobile-account')
     expect(account.text()).toContain('Dashboard')
     expect(account.text()).toContain('Members')
+    expect(account.text()).toContain('Newsletters')
     expect(account.text()).toContain('Sign out')
 
     // The primary-nav drawer holds navigation only — no admin tools.

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -38,6 +38,7 @@ const accountLinks = computed(() => ([
   { to: '/admin/events',    label: 'Event management',   show: auth.isContributor || auth.isAdmin },
   { to: '/admin/members',   label: 'Members',            show: auth.isAdmin },
   { to: '/admin/resources', label: 'Resources',          show: auth.isAdmin },
+  { to: '/admin/newsletters', label: 'Newsletters',      show: auth.isAdmin },
 ] as { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }[]).filter(l => l.show))
 
 const envMenuOpen = ref(false)

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -63,6 +63,8 @@ const router = createRouter({
       meta: { requiresAuth: true, requiresRole: ['Admin', 'Contributor'] } },
     { path: '/admin/resources', name: 'admin-resources', component: () => import('@/views/ResourceManagementView.vue'),
       meta: { requiresAuth: true, requiresRole: ['Admin'] } },
+    { path: '/admin/newsletters', name: 'admin-newsletters', component: () => import('@/views/NewsletterManagementView.vue'),
+      meta: { requiresAuth: true, requiresRole: ['Admin'] } },
     { path: '/admin/approvals', name: 'admin-approvals', component: () => import('@/views/ApprovalsView.vue'),
       meta: { requiresAuth: true, requiresRole: ['Admin'] } },
     { path: '/admin/events', name: 'admin-events', component: EventManagementView,

--- a/src/web/src/views/DashboardView.vue
+++ b/src/web/src/views/DashboardView.vue
@@ -105,6 +105,16 @@ onMounted(() => { if (auth.isAdmin) approvalsStore.refresh() })
           Add, edit, and remove the links on the public Resources page.
         </p>
       </RouterLink>
+      <RouterLink
+        v-if="auth.isAdmin"
+        to="/admin/newsletters"
+        class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+      >
+        <p class="font-display font-bold text-slypn-700">Newsletters</p>
+        <p class="mt-2 text-sm text-slypn-900/75">
+          Add, edit, and remove newsletter issues, and attach their files.
+        </p>
+      </RouterLink>
     </section>
   </main>
 </template>

--- a/src/web/src/views/NewsletterManagementView.spec.ts
+++ b/src/web/src/views/NewsletterManagementView.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({
+  apiJson,
+  apiFetch,
+  apiErrorMessage: async (resp: Response) => `${resp.status} ${resp.statusText}`,
+}))
+
+import NewsletterManagementView from './NewsletterManagementView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const stubs = { RouterLink: RouterLinkStub, teleport: true }
+let pinia: Pinia
+const mountC = () => mount(NewsletterManagementView, { global: { plugins: [pinia], stubs } })
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+}
+
+function fail(status = 400, statusText = 'Bad Request') {
+  return { ok: false, status, statusText, json: () => Promise.resolve({}), text: () => Promise.resolve('') } as unknown as Response
+}
+
+const newsletter = (over = {}) => ({
+  id: 'n1', title: 'May 2026', issueDate: '2026-05-01', summary: 'Summary text', topics: ['t'], _etag: 'e1', ...over,
+})
+
+beforeEach(async () => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiJson.mockReset()
+  apiFetch.mockReset()
+  vi.stubGlobal('confirm', vi.fn(() => true))
+  await useAuthStore().initialize()
+})
+
+describe('NewsletterManagementView', () => {
+  it('lists newsletters', async () => {
+    apiJson.mockResolvedValue([newsletter()])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('May 2026')
+    expect(w.text()).toContain('Summary text')
+  })
+
+  it('shows a download link when a file is attached, and a placeholder when not', async () => {
+    apiJson.mockResolvedValue([newsletter({ fileName: 'issue.pdf' }), newsletter({ id: 'n2', title: 'June 2026' })])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('issue.pdf')
+    expect(w.text()).toContain('No file attached')
+  })
+
+  it('shows the empty state', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('No newsletters yet')
+  })
+
+  it('shows a load error', async () => {
+    apiJson.mockRejectedValue(new Error('boom'))
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain("Couldn’t load newsletters")
+  })
+
+  it('creates a newsletter, then uploads its file as a second call', async () => {
+    apiJson.mockResolvedValue([])
+    apiFetch
+      .mockResolvedValueOnce(ok(newsletter({ _etag: 'e2' })))
+      .mockResolvedValueOnce(ok(newsletter({ _etag: 'e3', fileName: 'issue.pdf' })))
+    const w = mountC()
+    await flushPromises()
+
+    await w.findAll('button').find(b => b.text().includes('Add newsletter'))!.trigger('click')
+    await w.find('#newsletter-title').setValue('May 2026')
+    await w.find('#newsletter-issue-date').setValue('2026-05-01')
+    await w.find('#newsletter-summary').setValue('A long enough summary.')
+
+    const file = new File(['bytes'], 'issue.pdf', { type: 'application/pdf' })
+    const fileInput = w.find('#newsletter-file')
+    Object.defineProperty(fileInput.element, 'files', { value: [file] })
+    await fileInput.trigger('change')
+
+    await w.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(apiFetch).toHaveBeenNthCalledWith(1, '/newsletters', expect.objectContaining({ method: 'POST' }))
+    expect(apiFetch).toHaveBeenNthCalledWith(2, '/newsletters/n1/file', expect.objectContaining({
+      method: 'PUT',
+      headers: { 'If-Match': 'e2' },
+    }))
+    const secondCallBody = apiFetch.mock.calls[1][1].body as FormData
+    expect(secondCallBody.get('file')).toStrictEqual(file)
+  })
+
+  it('surfaces an error from the file upload call without swallowing it', async () => {
+    apiJson.mockResolvedValue([])
+    apiFetch
+      .mockResolvedValueOnce(ok(newsletter({ _etag: 'e2' })))
+      .mockResolvedValueOnce(fail(415, 'Unsupported Media Type'))
+    const w = mountC()
+    await flushPromises()
+
+    await w.findAll('button').find(b => b.text().includes('Add newsletter'))!.trigger('click')
+    await w.find('#newsletter-title').setValue('May 2026')
+    await w.find('#newsletter-issue-date').setValue('2026-05-01')
+    await w.find('#newsletter-summary').setValue('A long enough summary.')
+
+    const file = new File(['bytes'], 'issue.exe', { type: 'application/x-msdownload' })
+    const fileInput = w.find('#newsletter-file')
+    Object.defineProperty(fileInput.element, 'files', { value: [file] })
+    await fileInput.trigger('change')
+
+    await w.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(w.text()).toContain('415')
+  })
+
+  it('creates a newsletter without a file in a single call', async () => {
+    apiJson.mockResolvedValue([])
+    apiFetch.mockResolvedValueOnce(ok(newsletter()))
+    const w = mountC()
+    await flushPromises()
+
+    await w.findAll('button').find(b => b.text().includes('Add newsletter'))!.trigger('click')
+    await w.find('#newsletter-title').setValue('May 2026')
+    await w.find('#newsletter-issue-date').setValue('2026-05-01')
+    await w.find('#newsletter-summary').setValue('A long enough summary.')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(apiFetch).toHaveBeenCalledTimes(1)
+    expect(apiFetch).toHaveBeenCalledWith('/newsletters', expect.objectContaining({ method: 'POST' }))
+  })
+
+  it('replaces an existing newsletter via PUT with If-Match', async () => {
+    apiJson.mockResolvedValue([newsletter()])
+    apiFetch.mockResolvedValueOnce(ok(newsletter({ title: 'May 2026 (updated)' })))
+    const w = mountC()
+    await flushPromises()
+
+    await w.findAll('button').find(b => b.text() === 'Edit')!.trigger('click')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(apiFetch).toHaveBeenCalledWith('/newsletters/n1', expect.objectContaining({
+      method: 'PUT',
+      headers: { 'If-Match': 'e1' },
+    }))
+  })
+
+  it('removes a newsletter after confirmation', async () => {
+    apiJson.mockResolvedValue([newsletter()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/newsletters/n1', expect.objectContaining({
+      method: 'DELETE',
+      headers: { 'If-Match': 'e1' },
+    }))
+  })
+})

--- a/src/web/src/views/NewsletterManagementView.vue
+++ b/src/web/src/views/NewsletterManagementView.vue
@@ -151,12 +151,12 @@ async function remove(n: Newsletter) {
 
     <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load newsletters: {{ error }}.
-      <button class="ml-2 underline" @click="refresh">Retry</button>
+      <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
     <p v-if="listError" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
       {{ listError }}
-      <button class="ml-2 underline" @click="listError = null">Dismiss</button>
+      <button type="button" class="ml-2 underline" @click="listError = null">Dismiss</button>
     </p>
 
     <div class="divide-y divide-slypn-100 rounded-xl border border-slypn-100 bg-white shadow-sm">

--- a/src/web/src/views/NewsletterManagementView.vue
+++ b/src/web/src/views/NewsletterManagementView.vue
@@ -1,0 +1,290 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import { apiFetch, apiJson, apiErrorMessage } from '@/lib/api'
+import { useAsyncData } from '@/composables/useAsyncData'
+
+interface Newsletter {
+  id: string
+  title: string
+  issueDate: string
+  summary: string
+  topics: string[]
+  fileName?: string
+  _etag?: string
+}
+
+const { data: newsletters, loading, error, refresh } = useAsyncData(
+  () => apiJson<Newsletter[]>('/newsletters'),
+)
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+
+// ── Add / edit dialog ────────────────────────────────────────────────────────
+const showForm  = ref(false)
+const editing   = ref<Newsletter | null>(null)
+const form      = ref({ title: '', issueDate: '', summary: '', topics: '' })
+const file      = ref<File | null>(null)
+const fileInput = ref<HTMLInputElement | null>(null)
+const saving    = ref(false)
+const formError = ref<string | null>(null)
+
+function openAdd() {
+  editing.value = null
+  form.value = { title: '', issueDate: '', summary: '', topics: '' }
+  file.value = null
+  formError.value = null
+  showForm.value = true
+}
+
+function openEdit(n: Newsletter) {
+  editing.value = n
+  form.value = {
+    title:     n.title,
+    issueDate: n.issueDate.slice(0, 10),
+    summary:   n.summary,
+    topics:    n.topics.join(', '),
+  }
+  file.value = null
+  formError.value = null
+  showForm.value = true
+}
+
+function onFileChosen(event: Event) {
+  const target = event.target as HTMLInputElement
+  file.value = target.files?.[0] ?? null
+}
+
+const canSave = computed(() =>
+  form.value.title.trim() && form.value.issueDate.trim() && form.value.summary.trim())
+
+async function save() {
+  if (!canSave.value || saving.value) return
+  saving.value = true
+  formError.value = null
+  try {
+    const body = JSON.stringify({
+      title:     form.value.title.trim(),
+      issueDate: form.value.issueDate,
+      summary:   form.value.summary.trim(),
+      topics:    form.value.topics.split(',').map(t => t.trim()).filter(Boolean),
+    })
+    const resp = editing.value
+      ? await apiFetch(`/newsletters/${editing.value.id}`, {
+          method: 'PUT',
+          body,
+          headers: editing.value._etag ? { 'If-Match': editing.value._etag } : {},
+        })
+      : await apiFetch('/newsletters', { method: 'POST', body })
+    if (!resp.ok) throw new Error(await apiErrorMessage(resp))
+    const saved = await resp.json() as Newsletter
+
+    if (file.value) {
+      const fd = new FormData()
+      fd.append('file', file.value)
+      const fileResp = await apiFetch(`/newsletters/${saved.id}/file`, {
+        method: 'PUT',
+        body: fd,
+        headers: saved._etag ? { 'If-Match': saved._etag } : {},
+      })
+      if (!fileResp.ok) throw new Error(await apiErrorMessage(fileResp))
+    }
+
+    showForm.value = false
+    await refresh()
+  } catch (err) {
+    formError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    saving.value = false
+  }
+}
+
+// ── Delete ───────────────────────────────────────────────────────────────────
+const deletingId = ref<string | null>(null)
+const listError  = ref<string | null>(null)
+
+async function remove(n: Newsletter) {
+  if (!confirm(`Delete "${n.title}"? This cannot be undone.`)) return
+  deletingId.value = n.id
+  listError.value = null
+  try {
+    const resp = await apiFetch(`/newsletters/${n.id}`, {
+      method: 'DELETE',
+      headers: n._etag ? { 'If-Match': n._etag } : {},
+    })
+    if (!resp.ok) throw new Error(await apiErrorMessage(resp))
+    await refresh()
+  } catch (err) {
+    listError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    deletingId.value = null
+  }
+}
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Admin"
+    title="Newsletters"
+    subtitle="Add, edit, and remove newsletter issues, and attach their PDF/DOCX files."
+  >
+    <template #actions>
+      <RouterLink
+        :to="{ name: 'dashboard' }"
+        class="text-sm font-semibold text-white/80 hover:text-white"
+      >&larr; Dashboard</RouterLink>
+    </template>
+  </HeroBanner>
+
+  <section class="page-container space-y-6 py-16">
+    <div class="flex items-center justify-between">
+      <h2 class="font-display text-xl font-bold text-slypn-700">All newsletters</h2>
+      <button
+        type="button"
+        class="rounded-md bg-slypn-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700"
+        @click="openAdd"
+      >+ Add newsletter</button>
+    </div>
+
+    <p v-if="loading && !newsletters" class="text-sm text-slypn-900/60">Loading newsletters…</p>
+
+    <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
+      Couldn&rsquo;t load newsletters: {{ error }}.
+      <button class="ml-2 underline" @click="refresh">Retry</button>
+    </div>
+
+    <p v-if="listError" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
+      {{ listError }}
+      <button class="ml-2 underline" @click="listError = null">Dismiss</button>
+    </p>
+
+    <div class="divide-y divide-slypn-100 rounded-xl border border-slypn-100 bg-white shadow-sm">
+      <div
+        v-for="n in newsletters"
+        :key="n.id"
+        class="flex items-start gap-4 px-5 py-4"
+      >
+        <div class="min-w-0 flex-1">
+          <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+            {{ formatDate(n.issueDate) }}
+          </p>
+          <p class="mt-1 font-semibold text-slypn-800">{{ n.title }}</p>
+          <p class="mt-0.5 text-sm text-slypn-900/75">{{ n.summary }}</p>
+          <a
+            v-if="n.fileName"
+            :href="`/api/newsletters/${n.id}/file`"
+            class="mt-1 inline-block text-xs text-slypn-500 underline underline-offset-2 hover:text-slypn-700"
+            download
+          >{{ n.fileName }}</a>
+          <p v-else class="mt-1 text-xs text-slypn-900/50">No file attached</p>
+        </div>
+        <div class="flex shrink-0 gap-2">
+          <button
+            type="button"
+            class="rounded-md border border-slypn-200 bg-white px-3 py-1.5 text-xs font-semibold text-slypn-700 hover:bg-slypn-50"
+            @click="openEdit(n)"
+          >Edit</button>
+          <button
+            type="button"
+            class="rounded-md border border-rose-200 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 hover:bg-rose-50 disabled:opacity-50"
+            :disabled="deletingId === n.id"
+            @click="remove(n)"
+          >{{ deletingId === n.id ? '…' : 'Delete' }}</button>
+        </div>
+      </div>
+    </div>
+
+    <p v-if="newsletters && !newsletters.length" class="text-sm text-slypn-900/60">
+      No newsletters yet. Add the first one.
+    </p>
+  </section>
+
+  <!-- Add / edit dialog -->
+  <Teleport to="body">
+    <div
+      v-if="showForm"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slypn-900/40 p-4"
+      @click.self="showForm = false"
+    >
+      <div class="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+        <h3 class="font-display text-lg font-bold text-slypn-700">
+          {{ editing ? 'Edit newsletter' : 'Add newsletter' }}
+        </h3>
+        <form class="mt-4 space-y-4" @submit.prevent="save">
+          <div>
+            <label for="newsletter-title" class="block text-sm font-medium text-slypn-800">Title</label>
+            <input
+              id="newsletter-title"
+              v-model="form.title"
+              type="text"
+              maxlength="200"
+              required
+              class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+            />
+          </div>
+          <div>
+            <label for="newsletter-issue-date" class="block text-sm font-medium text-slypn-800">Issue date</label>
+            <input
+              id="newsletter-issue-date"
+              v-model="form.issueDate"
+              type="date"
+              required
+              class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+            />
+          </div>
+          <div>
+            <label for="newsletter-summary" class="block text-sm font-medium text-slypn-800">Summary</label>
+            <textarea
+              id="newsletter-summary"
+              v-model="form.summary"
+              rows="3"
+              maxlength="1000"
+              required
+              class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+            />
+          </div>
+          <div>
+            <label for="newsletter-topics" class="block text-sm font-medium text-slypn-800">Topics</label>
+            <input
+              id="newsletter-topics"
+              v-model="form.topics"
+              type="text"
+              placeholder="Comma-separated, e.g. Research, Events"
+              class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+            />
+          </div>
+          <div>
+            <label for="newsletter-file" class="block text-sm font-medium text-slypn-800">
+              Issue file (PDF/DOCX)
+              <span v-if="editing?.fileName" class="font-normal text-slypn-900/60">— replaces &ldquo;{{ editing.fileName }}&rdquo;</span>
+            </label>
+            <input
+              id="newsletter-file"
+              ref="fileInput"
+              type="file"
+              accept=".pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+              class="mt-1 w-full text-sm text-slypn-700 file:mr-3 file:rounded-md file:border-0 file:bg-slypn-50 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-slypn-700 hover:file:bg-slypn-100"
+              @change="onFileChosen"
+            />
+          </div>
+
+          <p v-if="formError" class="rounded-md bg-rose-50 px-3 py-2 text-xs text-rose-700">{{ formError }}</p>
+
+          <div class="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              class="rounded-md border border-slypn-200 px-4 py-2 text-sm font-medium text-slypn-700 hover:bg-slypn-50"
+              @click="showForm = false"
+            >Cancel</button>
+            <button
+              type="submit"
+              class="rounded-md bg-slypn-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slypn-700 disabled:opacity-50"
+              :disabled="!canSave || saving"
+            >{{ saving ? 'Saving…' : (editing ? 'Save changes' : 'Add newsletter') }}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </Teleport>
+</template>


### PR DESCRIPTION
## Summary
- Imports the newsletter archive (PDF/DOCX) via a `Slypn.Seed` CLI job, storing metadata in Table Storage and issue files in Blob Storage, with a public `GET /api/newsletters/{id}/file` download endpoint.
- Adds an admin screen (`/admin/newsletters`) to create/edit/delete newsletter issues and upload/replace their attached file, backed by a new `PUT /api/newsletters/{id}/file` endpoint (Admin-only, multipart).
- Fixes a bug where editing a newsletter's metadata (title/date/summary/topics) silently cleared its attached file's `fileName` off the row.
- Adds the Newsletters admin link to the Dashboard and the account dropdown/mobile nav.
- Aligns the SonarCloud coverage gate with existing coverlet exclusions.

## Test plan
- [x] `dotnet test` — 250/250 passing (`src/api`)
- [x] `npm run test:unit` — 378/378 passing (`src/web`)
- [x] `npm run lint` — clean
- [x] `npm run build` — type-checks clean
- [x] Manual E2E against a local Azurite-backed API: create → upload PDF → download (bytes match) → edit metadata only (file preserved) → replace file → delete; confirmed 403 for non-admin personas on both create and file upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)