### PR TITLE
refactor(api,web): remove tags from articles and blog posts

### DIFF
--- a/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
@@ -85,7 +85,7 @@ public class AdminFunctionsTests
         new(repo, new HtmlSanitizer(), NullLogger<DraftsFunctions>.Instance);
 
     private static Draft Draft(string id = "d1") =>
-        new(id, "oid-1", "Author", "article", "T", "s", "Sum", "<p>b</p>", "Community", new[] { "x" }, 3, DateTime.UtcNow, DateTime.UtcNow) { Etag = "e1" };
+        new(id, "oid-1", "Author", "article", "T", "s", "Sum", "<p>b</p>", "Community", 3, DateTime.UtcNow, DateTime.UtcNow) { Etag = "e1" };
 
     [Fact]
     public async Task Drafts_list_requires_oid()
@@ -122,7 +122,7 @@ public class AdminFunctionsTests
         var fn = DraftsFn(repo);
         var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
 
-        var draftBody = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", tags = new[] { "x" }, readingMinutes = 3 };
+        var draftBody = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", readingMinutes = 3 };
         var upsert = (TestHttpResponseData)await fn.Upsert(TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/d1", draftBody), ctx, "d1", Ct);
         Assert.Equal(HttpStatusCode.OK, upsert.StatusCode);
 
@@ -230,7 +230,7 @@ public class AdminFunctionsTests
     [Fact]
     public async Task Drafts_upsert_412_when_get_fails_and_412_when_upsert_fails()
     {
-        var draftBody = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", tags = new[] { "x" }, readingMinutes = 3 };
+        var draftBody = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", readingMinutes = 3 };
         var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
 
         // GetDraftAsync throws → line 96
@@ -401,7 +401,7 @@ public class AdminFunctionsTests
     {
         var fn = DraftsFn(new FakeContentRepository { Writes = false });
         var ctx = new TestFunctionContext().WithUser("oid-1", "A", "Contributor");
-        var body = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", tags = new[] { "x" }, readingMinutes = 3 };
+        var body = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", readingMinutes = 3 };
         var resp = (TestHttpResponseData)await fn.Upsert(TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/d1", body), ctx, "d1", Ct);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
     }
@@ -411,7 +411,7 @@ public class AdminFunctionsTests
     {
         var fn = DraftsFn(new FakeContentRepository());
         var ctx = new TestFunctionContext(); // no principal → no oid
-        var body = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", tags = new[] { "x" }, readingMinutes = 3 };
+        var body = new { type = "article", title = "T", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", readingMinutes = 3 };
         var resp = (TestHttpResponseData)await fn.Upsert(TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/d1", body), ctx, "d1", Ct);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
@@ -428,7 +428,7 @@ public class AdminFunctionsTests
         var ctx = new TestFunctionContext();
         ctx.Items[JwtMiddleware.PrincipalContextKey] = new System.Security.Claims.ClaimsPrincipal(identity);
 
-        var body = new { type = "article", title = "Updated", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", tags = new[] { "x" }, readingMinutes = 3 };
+        var body = new { type = "article", title = "Updated", slug = "s", summary = "Sum", body = "<p>hi</p>", category = "Community", readingMinutes = 3 };
         var resp = (TestHttpResponseData)await fn.Upsert(TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/d1", body), ctx, "d1", Ct);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }

--- a/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
@@ -20,7 +20,7 @@ public class ArticlesFunctionsTests
     }
 
     private static Article Sample(string id = "a1") =>
-        new(id, "slug", "Title", "Summary", "Body", "Author", DateTime.UtcNow, 5, "Community", new[] { "t" }) { Etag = "e1" };
+        new(id, "slug", "Title", "Summary", "Body", "Author", DateTime.UtcNow, 5, "Community") { Etag = "e1" };
 
     [Fact]
     public async Task GetArticles_returns_200_with_list()

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -31,7 +31,7 @@ public class ContentFunctionsTests
     public async Task Blog_list_returns_200()
     {
         var repo = new FakeContentRepository();
-        repo.Blogs.Add(new Article("b1", "s", "T", "Sum", "B", "A", DateTime.UtcNow, 3, "News", new[] { "x" }) { Type = "blog" });
+        repo.Blogs.Add(new Article("b1", "s", "T", "Sum", "B", "A", DateTime.UtcNow, 3, "News") { Type = "blog" });
         var fn = new BlogFunctions(repo);
         var resp = (TestHttpResponseData)await fn.GetBlogPosts(TestHttp.Get(new TestFunctionContext(), "http://localhost/api/blog"), Ct);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -165,7 +165,7 @@ internal sealed class FakeContentRepository : IContentRepository
         id, input?.Slug ?? "slug", input?.Title ?? "Title", input?.Summary ?? "Summary",
         input?.Body ?? "Body", input?.Author ?? "Author", DateTime.UtcNow,
         input?.ReadingMinutes ?? 5, input?.Category ?? "Community",
-        input?.Tags ?? new List<string>(), input?.Status ?? "published") { Etag = "etag-1" };
+        input?.Status ?? "published") { Etag = "etag-1" };
 
     private static CommunityEvent MakeEvent(string id, EventInput input, string? oid, string? name) => new(
         id, input.Title, input.Type, input.StartsAt, input.EndsAt, input.Location,
@@ -173,5 +173,5 @@ internal sealed class FakeContentRepository : IContentRepository
 
     private static Draft MakeDraft(string id, string oid, string name) => new(
         id, oid, name, "article", "Title", "slug", "Summary", "Body", "Community",
-        new List<string>(), 5, DateTime.UtcNow, DateTime.UtcNow) { Etag = "etag-1" };
+        5, DateTime.UtcNow, DateTime.UtcNow) { Etag = "etag-1" };
 }

--- a/src/api/Slypn.Api.Tests/ModelsAndMockDataTests.cs
+++ b/src/api/Slypn.Api.Tests/ModelsAndMockDataTests.cs
@@ -11,7 +11,7 @@ public class ModelsAndMockDataTests
     public void Article_defaults_type_and_status()
     {
         var a = new Article("id", "slug", "Title", "Summary", "Body", "Author",
-            new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc), 5, "Community", new[] { "x" });
+            new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc), 5, "Community");
         Assert.Equal("article", a.Type);
         Assert.Equal("published", a.Status);
         Assert.Null(a.Etag);
@@ -32,7 +32,7 @@ public class ModelsAndMockDataTests
     public void Draft_and_Member_records_round_trip_etag()
     {
         var d = new Draft("id", "auth", "Author", "article", "T", "s", "sum", "body", "cat",
-            new[] { "x" }, 1, DateTime.UtcNow, DateTime.UtcNow) { Etag = "e1" };
+            1, DateTime.UtcNow, DateTime.UtcNow) { Etag = "e1" };
         Assert.Equal("e1", d.Etag);
 
         var m = new Member("id", "a@b.com", "Alice", new[] { "Member" }, "active", DateTime.UtcNow);

--- a/src/api/Slypn.Api/Functions/DraftsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/DraftsFunctions.cs
@@ -107,7 +107,6 @@ public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sani
             Summary:          input.Summary,
             Body:             sanitizer.Sanitize(input.Body),
             Category:         input.Category,
-            Tags:             input.Tags,
             ReadingMinutes:   input.ReadingMinutes,
             CreatedAt:        existing?.CreatedAt ?? now,
             UpdatedAt:        now,

--- a/src/api/Slypn.Api/Models/Article.cs
+++ b/src/api/Slypn.Api/Models/Article.cs
@@ -12,7 +12,6 @@ public sealed record Article(
     DateTime PublishedAt,
     int ReadingMinutes,
     string Category,
-    IReadOnlyList<string> Tags,
     string Status = "published")
 {
     /// <summary>"article" or "blog". Defaults to "article" for rows that predate the field.</summary>

--- a/src/api/Slypn.Api/Models/Draft.cs
+++ b/src/api/Slypn.Api/Models/Draft.cs
@@ -12,7 +12,6 @@ public sealed record Draft(
     string Summary,
     string Body,
     string Category,
-    IReadOnlyList<string> Tags,
     int ReadingMinutes,
     DateTime CreatedAt,
     DateTime UpdatedAt,

--- a/src/api/Slypn.Api/Models/Inputs/ArticleInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/ArticleInput.cs
@@ -25,8 +25,6 @@ public sealed class ArticleInput
     [Required, StringLength(60)]
     public string Category { get; set; } = "";
 
-    public List<string> Tags { get; set; } = new();
-
     [Required, RegularExpression("^(draft|in-review|published|rejected)$",
         ErrorMessage = "Status must be one of: draft, in-review, published, rejected.")]
     public string Status { get; set; } = "draft";

--- a/src/api/Slypn.Api/Models/Inputs/DraftInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/DraftInput.cs
@@ -18,8 +18,6 @@ public sealed class DraftInput
     [StringLength(50_000)] public string Body { get; set; } = "";
     [StringLength(60)]  public string Category { get; set; } = "";
 
-    public List<string> Tags { get; set; } = new();
-
     [Range(0, 60)]
     public int ReadingMinutes { get; set; }
 

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -128,7 +128,6 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             PublishedAt:    DateTime.UtcNow,
             ReadingMinutes: input.ReadingMinutes,
             Category:       input.Category,
-            Tags:           input.Tags,
             Status:         input.Status);
 
         await body.PutAsync(ArticleBodyPrefix, article.Id, article.Body, ct);
@@ -149,7 +148,6 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             PublishedAt:    DateTime.UtcNow,
             ReadingMinutes: input.ReadingMinutes,
             Category:       input.Category,
-            Tags:           input.Tags,
             Status:         input.Status);
 
         await body.PutAsync(ArticleBodyPrefix, article.Id, article.Body, ct);
@@ -496,7 +494,6 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             PublishedAt:    DateTime.UtcNow, // submission time; updated on publish
             ReadingMinutes: draft.ReadingMinutes,
             Category:       draft.Category,
-            Tags:           draft.Tags,
             Status:         InReviewStatus)
         {
             Type = string.Equals(draft.Type, "blog", StringComparison.OrdinalIgnoreCase) ? "blog" : ArticleType,
@@ -550,7 +547,6 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             Summary:           published.Summary,
             Body:              published.Body,
             Category:          published.Category,
-            Tags:              published.Tags,
             ReadingMinutes:    published.ReadingMinutes,
             CreatedAt:         existing?.CreatedAt ?? now,
             UpdatedAt:         now,
@@ -582,7 +578,6 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             Title          = review.Title,
             Summary        = review.Summary,
             Category       = review.Category,
-            Tags           = review.Tags,
             ReadingMinutes = review.ReadingMinutes,
             Type           = review.Type,
             Status         = "published",
@@ -666,7 +661,6 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             Summary:          source.Summary,
             Body:             articleBody,
             Category:         source.Category,
-            Tags:             source.Tags,
             ReadingMinutes:   source.ReadingMinutes,
             CreatedAt:        now,
             UpdatedAt:        now,

--- a/src/api/Slypn.Api/Services/MockDataService.cs
+++ b/src/api/Slypn.Api/Services/MockDataService.cs
@@ -13,8 +13,7 @@ public sealed class MockDataService : IMockDataService
             "A Parkinson's diagnosis at working age often comes with a stack of practical questions about the job.\n\nStart by reading the rights you already have. In the UK, Parkinson's is covered by the Equality Act 2010, meaning employers must make reasonable adjustments.\n\nWhen to disclose is personal. Many SLYPN members tell us they wished they'd waited - and just as many wish they'd told their manager sooner.\n\nFinally, the small daily things compound. Lay out clothes the night before. Tackle the hardest task in your best-medication window.",
             "Helen Stoinanov",
             new DateTime(2026, 5, 12, 9, 0, 0, DateTimeKind.Utc),
-            6, "Living with Parkinson's",
-            new[] { "work", "rights", "adjustments" }),
+            6, "Living with Parkinson's"),
         new Article(
             "a2", "medication-side-effects",
             "Understanding the medication side effects no one warned you about",
@@ -22,8 +21,7 @@ public sealed class MockDataService : IMockDataService
             "Levodopa is still the most effective treatment for Parkinson's, but the body's relationship with it is messy.\n\nDopamine agonists carry their own profile. Impulse-control issues are well documented but under-discussed.\n\nThis article is not medical advice - talk to your specialist nurse - but it's the conversation we wish we'd had earlier.",
             "Kate Wellington",
             new DateTime(2026, 4, 28, 9, 0, 0, DateTimeKind.Utc),
-            8, "Treatment",
-            new[] { "medication", "side-effects", "levodopa" }),
+            8, "Treatment"),
         new Article(
             "a3", "support-network-at-any-age",
             "Building a support network at any age",
@@ -31,8 +29,7 @@ public sealed class MockDataService : IMockDataService
             "We started SLYPN in 2011 because the support that existed at the time wasn't built around working-age people.\n\nFifteen years on, the format has barely changed: coffee meet-ups across South London, occasional drinks, a few activities a year.",
             "Sarah Webb",
             new DateTime(2026, 4, 10, 9, 0, 0, DateTimeKind.Utc),
-            5, "Community",
-            new[] { "peer-support", "history", "founders" }),
+            5, "Community"),
         new Article(
             "a4", "sleep-exercise-parkinsons",
             "Sleep, exercise, and Parkinson's - what the evidence actually says",
@@ -40,8 +37,7 @@ public sealed class MockDataService : IMockDataService
             "There is no shortage of advice online about lifestyle changes for Parkinson's. Some of it is genuinely useful. Some of it is wishful thinking.\n\nExercise - particularly aerobic and resistance training - has the strongest evidence for slowing symptom progression.",
             "Helen Stoinanov",
             new DateTime(2026, 3, 22, 9, 0, 0, DateTimeKind.Utc),
-            7, "Lifestyle",
-            new[] { "sleep", "exercise", "evidence" }),
+            7, "Lifestyle"),
         new Article(
             "a5", "what-to-bring-to-your-first-meetup",
             "What to bring (and expect) at your first SLYPN meet-up",
@@ -49,8 +45,7 @@ public sealed class MockDataService : IMockDataService
             "Just yourself. That's the honest answer.\n\nWe meet in coffee shops or pubs around South London, usually for a couple of hours in the evening.",
             "Kate Wellington",
             new DateTime(2026, 3, 4, 9, 0, 0, DateTimeKind.Utc),
-            3, "Community",
-            new[] { "newcomers", "meet-ups" }),
+            3, "Community"),
     };
 
     public IReadOnlyList<BlogPost> BlogPosts { get; } = new[]

--- a/src/api/Slypn.Seed/DemoContent.cs
+++ b/src/api/Slypn.Seed/DemoContent.cs
@@ -2,7 +2,7 @@ namespace Slypn.Seed;
 
 public sealed record DemoArticle(
     string Title, string Summary, IReadOnlyList<string> Paragraphs,
-    IReadOnlyList<string> Tags, string Category, string Author);
+    string Category, string Author);
 
 public sealed record DemoResource(string Title, string Description, string Url, string Category);
 
@@ -29,7 +29,7 @@ public static class DemoContent
                 "In the UK, Parkinson's is covered by the Equality Act 2010. That means your employer must make reasonable adjustments once they know — flexible hours, a quieter desk, or more time for tasks affected by your best-medication window.",
                 "Go into the conversation with a short list of the adjustments that would actually help. It turns an awkward disclosure into a practical, forward-looking discussion.",
             },
-            new[] { "work", "rights", "disclosure" }, "Living with Parkinson's", "Helen Stoinanov"),
+            "Living with Parkinson's", "Helen Stoinanov"),
 
         new DemoArticle(
             "Understanding levodopa and your medication window",
@@ -40,7 +40,7 @@ public static class DemoContent
                 "Many people notice their medication working in a window — a couple of good hours after a dose, then a dip as it wears off. Keeping a simple diary of doses and how you feel helps your specialist nurse fine-tune the timing.",
                 "If you are getting \"off\" periods before your next dose is due, that is worth raising at your next appointment rather than quietly tolerating it.",
             },
-            new[] { "medication", "levodopa", "symptoms" }, "Treatment", "Kate Wellington"),
+            "Treatment", "Kate Wellington"),
 
         new DemoArticle(
             "Exercise and Parkinson's: what the evidence says",
@@ -51,7 +51,7 @@ public static class DemoContent
                 "You do not need a gym. Brisk walking, cycling, dancing and boxing-style classes all count, and many members find a class easier to stick with than exercising alone.",
                 "Start small and build a habit. Twenty minutes most days beats an ambitious plan you abandon after a fortnight.",
             },
-            new[] { "exercise", "evidence", "wellbeing" }, "Lifestyle", "Daniel Okafor"),
+            "Lifestyle", "Daniel Okafor"),
 
         new DemoArticle(
             "Sleep, fatigue and the non-motor side of Parkinson's",
@@ -62,7 +62,7 @@ public static class DemoContent
                 "Good sleep hygiene helps: a consistent bedtime, less screen time late on, and reviewing whether any medications are affecting your rest.",
                 "Fatigue is real and not a sign of laziness. Pacing your day around your best hours, and being honest with the people around you, makes a genuine difference.",
             },
-            new[] { "sleep", "fatigue", "non-motor" }, "Living with Parkinson's", "Sarah Webb"),
+            "Living with Parkinson's", "Sarah Webb"),
 
         new DemoArticle(
             "Deep brain stimulation: who it might suit",
@@ -73,7 +73,7 @@ public static class DemoContent
                 "DBS is not for everyone, and it is not a cure. A specialist team assesses whether the likely benefits outweigh the risks for you specifically.",
                 "If you are curious, the first step is a conversation with your neurologist about whether a referral for assessment makes sense.",
             },
-            new[] { "DBS", "treatment", "surgery" }, "Treatment", "Priya Iyer"),
+            "Treatment", "Priya Iyer"),
 
         new DemoArticle(
             "Driving and Parkinson's: what you need to know",
@@ -84,7 +84,7 @@ public static class DemoContent
                 "You will usually keep a licence that is reviewed periodically, and you should also inform your insurer.",
                 "If the time does come to stop, planning ahead for alternatives — local transport, lifts from the network — makes the change feel less abrupt.",
             },
-            new[] { "driving", "DVLA", "independence" }, "Living with Parkinson's", "Helen Stoinanov"),
+            "Living with Parkinson's", "Helen Stoinanov"),
 
         new DemoArticle(
             "Eating well when medication and food compete",
@@ -95,7 +95,7 @@ public static class DemoContent
                 "A common approach is to take levodopa around 30–45 minutes before eating, and to spread protein across the day rather than in one big hit.",
                 "Everyone is different — a dietitian or your specialist nurse can help you find a pattern that protects your medication without making food a chore.",
             },
-            new[] { "diet", "levodopa", "nutrition" }, "Treatment", "Kate Wellington"),
+            "Treatment", "Kate Wellington"),
 
         new DemoArticle(
             "Building a support network at any age",
@@ -106,7 +106,7 @@ public static class DemoContent
                 "Peer support is not about swapping symptoms. It is the relief of being in a room where you do not have to explain yourself.",
                 "If you are new, you do not need to bring anything but yourself. Come for a coffee and see how it feels.",
             },
-            new[] { "peer-support", "community", "newcomers" }, "Community", "Sarah Webb"),
+            "Community", "Sarah Webb"),
 
         new DemoArticle(
             "Talking to your children about your diagnosis",
@@ -117,7 +117,7 @@ public static class DemoContent
                 "Keep it concrete and age-appropriate: a part of the brain makes less of a chemical that helps movement, the medicine helps, and you are still you.",
                 "Let them ask questions over time. One conversation rarely covers everything, and that is fine.",
             },
-            new[] { "family", "children", "wellbeing" }, "Living with Parkinson's", "Daniel Okafor"),
+            "Living with Parkinson's", "Daniel Okafor"),
 
         new DemoArticle(
             "Mindfulness, mood and managing anxiety",
@@ -128,7 +128,7 @@ public static class DemoContent
                 "Simple practices help some people: breathing exercises, gentle routine, time outdoors, and staying socially connected even when you do not feel like it.",
                 "If low mood persists, talk to your GP or specialist nurse. Effective support exists, and asking for it early is a strength.",
             },
-            new[] { "mental-health", "anxiety", "wellbeing" }, "Lifestyle", "Priya Iyer"),
+            "Lifestyle", "Priya Iyer"),
     };
 
     public static readonly IReadOnlyList<DemoArticle> Blogs = new[]
@@ -142,7 +142,7 @@ public static class DemoContent
                 "As ever, the conversation ranged from medication timing to the football. That mix is exactly the point.",
                 "Next month we are back on the South Bank. Bring a friend.",
             },
-            new[] { "meet-up", "recap" }, "Community", "Sarah Webb"),
+            "Community", "Sarah Webb"),
 
         new DemoArticle(
             "Welcome to our newest members",
@@ -153,7 +153,7 @@ public static class DemoContent
                 "If you have just joined, your first meet-up can feel like a big step. It is not — people will be glad to see you.",
                 "Come and say hello at the next coffee morning.",
             },
-            new[] { "welcome", "members" }, "Community", "Helen Stoinanov"),
+            "Community", "Helen Stoinanov"),
 
         new DemoArticle(
             "Thank you to our spring 10k runners",
@@ -164,7 +164,7 @@ public static class DemoContent
                 "Between sponsorship and matched donations we raised a fantastic total for Parkinson's research.",
                 "Thank you to everyone who took part, and to the friends and family who stood in the rain to cheer.",
             },
-            new[] { "fundraising", "events" }, "Fundraising", "Kate Wellington"),
+            "Fundraising", "Kate Wellington"),
 
         new DemoArticle(
             "Q&A with a movement-disorder nurse",
@@ -175,7 +175,7 @@ public static class DemoContent
                 "The biggest theme was medication timing — and how a simple diary makes appointments far more productive.",
                 "We will share a fuller write-up in the next newsletter.",
             },
-            new[] { "q-and-a", "treatment" }, "News", "Priya Iyer"),
+            "News", "Priya Iyer"),
 
         new DemoArticle(
             "Notes from the carers' catch-up",
@@ -186,7 +186,7 @@ public static class DemoContent
                 "This month the conversation turned to looking after your own wellbeing — and why that is not selfish.",
                 "If you care for someone in the network, you are very welcome to come along.",
             },
-            new[] { "carers", "support" }, "Community", "Daniel Okafor"),
+            "Community", "Daniel Okafor"),
 
         new DemoArticle(
             "Summer social by the river",
@@ -197,7 +197,7 @@ public static class DemoContent
                 "No agenda, no talks — just good company and a chance to catch up properly.",
                 "Photos to follow in the next newsletter.",
             },
-            new[] { "social", "events" }, "Events", "Sarah Webb"),
+            "Events", "Sarah Webb"),
 
         new DemoArticle(
             "Five things we learned this year",
@@ -208,7 +208,7 @@ public static class DemoContent
                 "People value consistency — the same time, the same place — more than big one-off events.",
                 "And new members almost always say the same thing afterwards: I wish I'd come sooner.",
             },
-            new[] { "retrospective", "community" }, "News", "Helen Stoinanov"),
+            "News", "Helen Stoinanov"),
 
         new DemoArticle(
             "A member's story: the first year",
@@ -219,7 +219,7 @@ public static class DemoContent
                 "Exercise gave me something to control. The network gave me people who got it without explanation.",
                 "If you are at the start of this, be kind to yourself. It gets less overwhelming.",
             },
-            new[] { "member-story", "newly-diagnosed" }, "Community", "Kate Wellington"),
+            "Community", "Kate Wellington"),
 
         new DemoArticle(
             "Volunteers wanted for the autumn programme",
@@ -230,7 +230,7 @@ public static class DemoContent
                 "We are looking for a few volunteers to help with the autumn programme — nothing onerous, just a few hours here and there.",
                 "If you can help, have a word with one of the organisers at the next meet-up.",
             },
-            new[] { "volunteering", "events" }, "News", "Daniel Okafor"),
+            "News", "Daniel Okafor"),
 
         new DemoArticle(
             "Why we meet on the South Bank",
@@ -241,7 +241,7 @@ public static class DemoContent
                 "It is step-free, easy to reach by train and bus, and there is always somewhere to sit and talk.",
                 "If you have never been, the last Saturday of the month is the one to put in your diary.",
             },
-            new[] { "venue", "meet-up" }, "Community", "Priya Iyer"),
+            "Community", "Priya Iyer"),
     };
 
     public static readonly IReadOnlyList<DemoResource> Resources = new[]

--- a/src/api/Slypn.Seed/SeedDemo.cs
+++ b/src/api/Slypn.Seed/SeedDemo.cs
@@ -15,7 +15,7 @@ public sealed record SeedEvent(
 
 public sealed record SeedArticle(
     string Id, string Slug, string Title, string Summary, string Body, string Author,
-    DateTime PublishedAt, int ReadingMinutes, string Category, IReadOnlyList<string> Tags,
+    DateTime PublishedAt, int ReadingMinutes, string Category,
     string Status, string Type, string? AuthorId);
 
 public sealed record SeedResource(
@@ -145,7 +145,6 @@ public static class SeedDemo
                 PublishedAt:    DateTime.UtcNow.AddDays(-(i * 18 + 3)),
                 ReadingMinutes: ReadingMinutes(body),
                 Category:       c.Category,
-                Tags:           c.Tags,
                 Status:         "published",
                 Type:           type,
                 AuthorId:       null);

--- a/src/web/src/components/common/ApprovalsQueue.vue
+++ b/src/web/src/components/common/ApprovalsQueue.vue
@@ -13,7 +13,6 @@ interface PendingArticle {
   authorId?: string
   publishedAt: string
   category: string
-  tags: string[]
   status: string
   readingMinutes: number
   type?: 'article' | 'blog'

--- a/src/web/src/components/common/ArticleCard.spec.ts
+++ b/src/web/src/components/common/ArticleCard.spec.ts
@@ -13,7 +13,6 @@ const article: Article = {
   publishedAt: '2026-05-01T10:00:00Z',
   readingMinutes: 4,
   category: 'Community',
-  tags: ['x'],
 }
 
 function mountCard(a: Article = article) {

--- a/src/web/src/components/editor/DraftEditor.spec.ts
+++ b/src/web/src/components/editor/DraftEditor.spec.ts
@@ -22,7 +22,7 @@ function resp(body: unknown, init: { ok?: boolean; status?: number; etag?: strin
 
 const draftPayload = {
   type: 'article', title: 'My draft', slug: '', summary: 'A summary',
-  body: '<p>Real content here</p>', category: 'Community', tags: [], readingMinutes: 1,
+  body: '<p>Real content here</p>', category: 'Community', readingMinutes: 1,
 }
 
 function mockApi(over: (url: string, method: string) => Response | undefined = () => undefined) {

--- a/src/web/src/components/editor/DraftEditor.vue
+++ b/src/web/src/components/editor/DraftEditor.vue
@@ -36,7 +36,7 @@ const loadedSnapshot = ref('')
 function snapshot(d: DraftPayload): string {
   return JSON.stringify({
     type: d.type, title: d.title, slug: d.slug,
-    summary: d.summary, body: d.body, category: d.category, tags: d.tags,
+    summary: d.summary, body: d.body, category: d.category,
   })
 }
 function isDirty(): boolean {

--- a/src/web/src/lib/draft.test.ts
+++ b/src/web/src/lib/draft.test.ts
@@ -5,7 +5,6 @@ describe('draft helpers', () => {
   it('EMPTY_DRAFT is an article skeleton with sane defaults', () => {
     expect(EMPTY_DRAFT.type).toBe('article')
     expect(EMPTY_DRAFT.title).toBe('')
-    expect(EMPTY_DRAFT.tags).toEqual([])
     expect(EMPTY_DRAFT.readingMinutes).toBe(1)
   })
 

--- a/src/web/src/lib/draft.ts
+++ b/src/web/src/lib/draft.ts
@@ -7,7 +7,6 @@ export interface DraftPayload {
   summary: string
   body: string
   category: string
-  tags: string[]
   readingMinutes: number
   revisionFeedback?: string | null
 }
@@ -22,7 +21,7 @@ export interface DraftSummary {
 
 export const EMPTY_DRAFT: DraftPayload = {
   type: 'article', title: '', slug: '', summary: '',
-  body: '', category: '', tags: [], readingMinutes: 1,
+  body: '', category: '', readingMinutes: 1,
 }
 
 export function makeDraftId(): string {

--- a/src/web/src/types/content.ts
+++ b/src/web/src/types/content.ts
@@ -19,7 +19,6 @@ export interface Article {
   publishedAt: string
   readingMinutes: number
   category: ArticleCategory
-  tags: string[]
   prev?: ArticleNeighbour
   next?: ArticleNeighbour
 }

--- a/src/web/src/views/ArticleDetailView.vue
+++ b/src/web/src/views/ArticleDetailView.vue
@@ -48,16 +48,6 @@ const formatDate = (iso: string) =>
 
     <div class="prose prose-slypn mt-8 max-w-none text-slypn-900/85" v-html="article.body" />
 
-    <ul class="mt-12 flex flex-wrap gap-2">
-      <li
-        v-for="tag in article.tags"
-        :key="tag"
-        class="rounded-full bg-slypn-50 px-3 py-1 text-xs font-medium text-slypn-700"
-      >
-        #{{ tag }}
-      </li>
-    </ul>
-
     <nav
       v-if="article.prev || article.next"
       class="mt-16 grid grid-cols-2 gap-4 border-t border-slypn-100 pt-8"

--- a/src/web/src/views/EditorView.spec.ts
+++ b/src/web/src/views/EditorView.spec.ts
@@ -30,7 +30,7 @@ const adminOid = '11111111-1111-1111-1111-111111111111'
 const draftSummary = (over = {}) => ({ id: 'd1', title: 'A draft', type: 'article', updatedAt: '2026-05-01T00:00:00Z', _etag: 'e1', ...over })
 const pendingItem = (over = {}) => ({
   id: 'r1', title: 'Pending Article', type: 'article', slug: 'pa-1',
-  summary: 'sum', body: 'body', category: 'Community', tags: [],
+  summary: 'sum', body: 'body', category: 'Community',
   readingMinutes: 3, publishedAt: '2026-05-01T00:00:00Z',
   authorId: adminOid, replacesArticleId: null, ...over,
 })

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -41,7 +41,6 @@ interface PendingItem {
   summary?: string
   body?: string
   category?: string
-  tags?: string[]
   readingMinutes?: number
   publishedAt: string
   authorId?: string
@@ -126,7 +125,6 @@ async function openReadonly(item: PendingItem) {
     summary:        item.summary ?? '',
     body:           item.body ?? '',
     category:       item.category ?? '',
-    tags:           item.tags ?? [],
     readingMinutes: item.readingMinutes ?? 1,
   }
   draftId.value = item.id

--- a/src/web/src/views/views.admin.spec.ts
+++ b/src/web/src/views/views.admin.spec.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 
 const pending = (over = {}) => ({
   id: 'p1', slug: 's', title: 'Pending piece', summary: 'sum', body: '<p>body</p>',
-  author: 'Jess', publishedAt: '2026-05-01T10:00:00Z', category: 'Community', tags: [],
+  author: 'Jess', publishedAt: '2026-05-01T10:00:00Z', category: 'Community',
   status: 'in-review', readingMinutes: 3, type: 'article', ...over,
 })
 

--- a/src/web/src/views/views.misc.spec.ts
+++ b/src/web/src/views/views.misc.spec.ts
@@ -342,7 +342,7 @@ describe('EventDetailView', () => {
 })
 
 describe('ArticleDetailView', () => {
-  const art = (over = {}) => ({ id: 'a1', slug: 's', title: 'Deep dive', summary: 'sum', body: '<p>hi</p>', author: 'Jo', publishedAt: '2026-05-01T00:00:00Z', readingMinutes: 5, category: 'Community', tags: ['t'], ...over })
+  const art = (over = {}) => ({ id: 'a1', slug: 's', title: 'Deep dive', summary: 'sum', body: '<p>hi</p>', author: 'Jo', publishedAt: '2026-05-01T00:00:00Z', readingMinutes: 5, category: 'Community', ...over })
 
   it('renders the fetched article', async () => {
     route.params = { slug: 's' }

--- a/src/web/src/views/views.public.spec.ts
+++ b/src/web/src/views/views.public.spec.ts
@@ -28,7 +28,7 @@ const mountView = (C: unknown) => mount(C as never, { global: { plugins: [create
 const article = (over = {}) => ({
   id: 'a1', slug: 'a-1', title: 'Article One', summary: 's', body: 'b',
   author: 'Jane', publishedAt: '2026-05-01T00:00:00Z', readingMinutes: 3,
-  category: 'Community', tags: [], ...over,
+  category: 'Community', ...over,
 })
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- Tags on Articles/Blog posts was write-only plumbing: no tag-input UI, no search/filter feature, and only one place (article detail page) rendered it as static `#tag` pills.
- Removed the field from the API models (`Article`, `Draft`, `ArticleInput`, `DraftInput`), `ContentRepository`, `MockDataService`, `DraftsFunctions`, and the `Slypn.Seed` demo content/records.
- Removed the equivalent web-side plumbing: `types/content.ts`, `lib/draft.ts` (`DraftPayload`/`EMPTY_DRAFT` — this stops `tags: []` being silently sent on every draft save), the editor's dirty-check snapshot, `EditorView`'s read-only review mapping, and the tag-pill block on `ArticleDetailView.vue`.
- Updated tests accordingly (some fixtures were type-checked and wouldn't compile otherwise).

## Test plan
- [x] `dotnet build` / `dotnet test` — 250/250 passing
- [x] `npm run build` (vue-tsc + vite) and `npm run lint` — clean
- [x] `npm run test:unit` — 378/378 passing
- [x] Re-ran `Slypn.Seed --demo` against local Azurite and smoke-tested `/api/articles` and `/api/blog` on the local Functions host — 200 OK, no `tags` field in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)