### PR TITLE
feat(web): scope the events admin list to a contributor's own events

### DIFF
--- a/src/web/src/views/EventManagementView.vue
+++ b/src/web/src/views/EventManagementView.vue
@@ -90,6 +90,7 @@ const filtered = computed(() => {
   const hi = rangeEnd.value ? ym(rangeEnd.value) : Infinity
   return [...(events.value ?? [])]
     .filter(e => {
+      if (!auth.isAdmin && e.createdBy !== auth.oid) return false
       const d = new Date(e.startsAt)
       if (!allDates.value && (ym(d) < lo || ym(d) > hi)) return false
       if (!q) return true
@@ -172,7 +173,7 @@ async function deleteEvent(event: CommunityEvent) {
         >+ Add event</button>
       </div>
       <p class="mt-2 text-sm text-slypn-900/75">
-        Admins can edit or delete any event. Contributors can only edit or delete events they created.
+        Admins see and can edit or delete any event. Contributors only see and can edit or delete events they created.
       </p>
 
       <!-- Search + date range -->


### PR DESCRIPTION
## Summary
- On `/admin/events`, Contributors could already only edit/delete their own events (both the UI's `canEdit` check and the API's ownership check were already correct) — but the list itself showed every event regardless of who created it.
- Scopes the list to match: Contributors now see only events where `createdBy === auth.oid`; Admins still see everything. Client-side only — no API change needed.
- Updated the on-page copy to reflect the new scoping.

## Test plan
- [x] `npm run build` (vue-tsc + vite) — clean
- [x] `npm run test:unit` — 378/378 passing
- [x] Manually verified with the dev persona switcher: Admin sees all events, Contributor sees only their own

🤖 Generated with [Claude Code](https://claude.com/claude-code)