### PR TITLE
feat(web): open newsletters inline, latest/past split, and members role-guard

### DIFF
--- a/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
@@ -56,13 +56,30 @@ public class AdminFunctionsTests
     {
         var repo = new FakeContentRepository();
         var fn = MembersFn(repo);
+        var ctx = new TestFunctionContext();
         var notFound = (TestHttpResponseData)await fn.UpdateRoles(
-            TestHttp.Json(new TestFunctionContext(), "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Admin" } }), "m1", Ct);
+            TestHttp.Json(ctx, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Admin" } }), "m1", ctx, Ct);
         Assert.Equal(HttpStatusCode.NotFound, notFound.StatusCode);
 
         repo.MemberById = Member();
         var ok = (TestHttpResponseData)await fn.UpdateRoles(
-            TestHttp.Json(new TestFunctionContext(), "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Contributor" } }), "m1", Ct);
+            TestHttp.Json(ctx, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Contributor" } }), "m1", ctx, Ct);
+        Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+    }
+
+    [Fact]
+    public async Task Members_update_roles_blocks_self_and_allows_other()
+    {
+        var repo = new FakeContentRepository { MemberById = Member(oid: "self-oid") };
+        var fn = MembersFn(repo);
+        var self = new TestFunctionContext().WithUser("self-oid", "Me", "Admin");
+        var blocked = (TestHttpResponseData)await fn.UpdateRoles(
+            TestHttp.Json(self, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Member" } }), "m1", self, Ct);
+        Assert.Equal(HttpStatusCode.BadRequest, blocked.StatusCode);
+
+        var other = new TestFunctionContext().WithUser("admin-oid", "Admin", "Admin");
+        var ok = (TestHttpResponseData)await fn.UpdateRoles(
+            TestHttp.Json(other, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Contributor" } }), "m1", other, Ct);
         Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
     }
 
@@ -304,13 +321,13 @@ public class AdminFunctionsTests
         var fn = MembersFn(repo);
         var ctx = new TestFunctionContext();
         var badRole = (TestHttpResponseData)await fn.UpdateRoles(
-            TestHttp.Json(ctx, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Wizard" } }), "m1", Ct);
+            TestHttp.Json(ctx, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Wizard" } }), "m1", ctx, Ct);
         Assert.Equal(HttpStatusCode.BadRequest, badRole.StatusCode);
 
         // GetMemberByIdAsync throws → line 127
         var repo2 = new FakeContentRepository { ThrowOnRead = new RequestFailedException(500, "Storage error") };
         var readErr = (TestHttpResponseData)await MembersFn(repo2).UpdateRoles(
-            TestHttp.Json(ctx, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Admin" } }), "m1", Ct);
+            TestHttp.Json(ctx, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Admin" } }), "m1", ctx, Ct);
         Assert.Equal(HttpStatusCode.InternalServerError, readErr.StatusCode);
 
         // UpsertMemberAsync throws → line 136 (with If-Match header to cover FunctionHelpers.IfMatch line 41)
@@ -318,7 +335,7 @@ public class AdminFunctionsTests
         var writeErr = (TestHttpResponseData)await MembersFn(repo3).UpdateRoles(
             TestHttp.Json(ctx, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Admin" } },
                 new Dictionary<string, string> { ["If-Match"] = "\"etag-1\"" }),
-            "m1", Ct);
+            "m1", ctx, Ct);
         Assert.Equal(HttpStatusCode.PreconditionFailed, writeErr.StatusCode);
     }
 
@@ -476,8 +493,9 @@ public class AdminFunctionsTests
     public async Task Members_update_roles_503_when_writes_disabled()
     {
         var fn = MembersFn(new FakeContentRepository { Writes = false });
+        var ctx = new TestFunctionContext();
         var resp = (TestHttpResponseData)await fn.UpdateRoles(
-            TestHttp.Json(new TestFunctionContext(), "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Admin" } }), "m1", Ct);
+            TestHttp.Json(ctx, "PATCH", "http://localhost/api/members/m1", new { roles = new[] { "Admin" } }), "m1", ctx, Ct);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
     }
 

--- a/src/api/Slypn.Api/Functions/MembersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MembersFunctions.cs
@@ -118,7 +118,7 @@ public sealed class MembersFunctions(
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Member), Description = "Updated member")]
     public async Task<HttpResponseData> UpdateRoles(
         [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "members/{id}")] HttpRequestData req,
-        string id, CancellationToken ct)
+        string id, FunctionContext context, CancellationToken ct)
     {
         if (!repo.SupportsWrites) return await WritesDisabled(req);
 
@@ -133,6 +133,9 @@ public sealed class MembersFunctions(
         try { existing = await repo.GetMemberByIdAsync(id, ct); }
         catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
         if (existing is null) return await NotFound(req, "Member not found.");
+
+        if (existing.Oid is not null && existing.Oid == context.GetUserOid())
+            return await BadRequest(req, "You cannot change your own role.");
 
         var updated = existing with { Roles = input.Roles.Distinct(StringComparer.OrdinalIgnoreCase).ToList() };
         try

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -18,6 +18,7 @@
         "@tiptap/pm": "^2.10.3",
         "@tiptap/starter-kit": "^2.10.3",
         "@tiptap/vue-3": "^2.10.3",
+        "docx-preview": "^0.4.0",
         "pinia": "^2.2.6",
         "vue": "^3.5.13",
         "vue-router": "^4.4.5"
@@ -3641,6 +3642,11 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -3751,6 +3757,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "node_modules/docx-preview": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/docx-preview/-/docx-preview-0.4.0.tgz",
+      "integrity": "sha512-OdKtE/uj3M4RfGarLkGjahUzRg8/kBp0Sraj1r1NAY1tp/sTpHOBqDrzVf9onMBt9vxP6SdQ6bpLCUCsFwjgcA==",
+      "dependencies": {
+        "jszip": ">=3.0.0"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -4472,6 +4486,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4507,6 +4526,11 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -4582,6 +4606,11 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4764,6 +4793,17 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4784,6 +4824,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -5188,6 +5236,11 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5540,6 +5593,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prosemirror-changeset": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
@@ -5790,6 +5848,20 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5934,6 +6006,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -5959,6 +6036,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6018,6 +6100,14 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -26,6 +26,7 @@
     "@tiptap/pm": "^2.10.3",
     "@tiptap/starter-kit": "^2.10.3",
     "@tiptap/vue-3": "^2.10.3",
+    "docx-preview": "^0.4.0",
     "pinia": "^2.2.6",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"

--- a/src/web/src/components/common/NewsletterCard.spec.ts
+++ b/src/web/src/components/common/NewsletterCard.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, RouterLinkStub } from '@vue/test-utils'
 import NewsletterCard from './NewsletterCard.vue'
 import type { Newsletter } from '@/types/content'
 
@@ -11,16 +11,23 @@ const newsletter: Newsletter = {
   topics: ['Meet-ups', 'Fundraising'],
 }
 
+function mountCard(n: Newsletter = newsletter) {
+  return mount(NewsletterCard, {
+    props: { newsletter: n },
+    global: { stubs: { RouterLink: RouterLinkStub } },
+  })
+}
+
 describe('NewsletterCard', () => {
   it('renders the title, summary and formatted issue date', () => {
-    const w = mount(NewsletterCard, { props: { newsletter } })
+    const w = mountCard()
     expect(w.text()).toContain('May 2026 issue')
     expect(w.text()).toContain('What happened in May')
     expect(w.text()).toMatch(/May 2026/)
   })
 
   it('lists each topic', () => {
-    const w = mount(NewsletterCard, { props: { newsletter } })
+    const w = mountCard()
     const items = w.findAll('li')
     expect(items).toHaveLength(2)
     expect(w.text()).toContain('Meet-ups')
@@ -28,16 +35,21 @@ describe('NewsletterCard', () => {
   })
 
   it('shows a download link to the file endpoint when a file is attached', () => {
-    const w = mount(NewsletterCard, {
-      props: { newsletter: { ...newsletter, fileName: 'SLYPN-Newsletter-2026-05.docx' } },
-    })
+    const w = mountCard({ ...newsletter, fileName: 'SLYPN-Newsletter-2026-05.docx' })
     const link = w.get('a[download]')
     expect(link.attributes('href')).toBe('/api/newsletters/n1/file')
     expect(w.text()).toContain('Download issue')
   })
 
-  it('omits the download link when no file is attached', () => {
-    const w = mount(NewsletterCard, { props: { newsletter } })
+  it('links to the newsletter detail route when a file is attached', () => {
+    const w = mountCard({ ...newsletter, fileName: 'SLYPN-Newsletter-2026-05.docx' })
+    expect(w.findComponent(RouterLinkStub).props('to')).toEqual({ name: 'newsletter-detail', params: { id: 'n1' } })
+    expect(w.text()).toContain('View')
+  })
+
+  it('omits the view and download links when no file is attached', () => {
+    const w = mountCard()
     expect(w.find('a[download]').exists()).toBe(false)
+    expect(w.findComponent(RouterLinkStub).exists()).toBe(false)
   })
 })

--- a/src/web/src/components/common/NewsletterCard.vue
+++ b/src/web/src/components/common/NewsletterCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router'
 import type { Newsletter } from '@/types/content'
 
 defineProps<{ newsletter: Newsletter }>()
@@ -23,17 +24,27 @@ const formatDate = (iso: string) =>
         {{ topic }}
       </li>
     </ul>
-    <a
-      v-if="newsletter.fileName"
-      :href="`/api/newsletters/${newsletter.id}/file`"
-      class="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-slypn-600 hover:text-slypn-700 hover:underline"
-      download
-    >
-      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path d="M10 2a1 1 0 0 1 1 1v7.586l2.293-2.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 1 1 1.414-1.414L9 10.586V3a1 1 0 0 1 1-1Z" />
-        <path d="M3 14a1 1 0 0 1 1 1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-1a1 1 0 1 1 2 0v1a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3v-1a1 1 0 0 1 1-1Z" />
-      </svg>
-      Download issue
-    </a>
+    <div v-if="newsletter.fileName" class="mt-4 flex items-center gap-4">
+      <RouterLink
+        :to="{ name: 'newsletter-detail', params: { id: newsletter.id } }"
+        class="inline-flex items-center gap-1.5 text-sm font-semibold text-slypn-600 hover:text-slypn-700 hover:underline"
+      >
+        <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0z" clip-rule="evenodd" />
+        </svg>
+        View
+      </RouterLink>
+      <a
+        :href="`/api/newsletters/${newsletter.id}/file`"
+        class="inline-flex items-center gap-1.5 text-sm font-semibold text-slypn-600 hover:text-slypn-700 hover:underline"
+        download
+      >
+        <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M10 2a1 1 0 0 1 1 1v7.586l2.293-2.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 1 1 1.414-1.414L9 10.586V3a1 1 0 0 1 1-1Z" />
+          <path d="M3 14a1 1 0 0 1 1 1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-1a1 1 0 1 1 2 0v1a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3v-1a1 1 0 0 1 1-1Z" />
+        </svg>
+        Download issue
+      </a>
+    </div>
   </article>
 </template>

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -50,6 +50,7 @@ const router = createRouter({
     { path: '/events/:id',       name: 'event-detail',    component: () => import('@/views/EventDetailView.vue') },
     { path: '/resources',         name: 'resources',       component: ResourcesView },
     { path: '/newsletter',        name: 'newsletter',      component: NewsletterView },
+    { path: '/newsletter/:id',    name: 'newsletter-detail', component: () => import('@/views/NewsletterDetailView.vue') },
     { path: '/login',             name: 'login',           component: LoginView },
     { path: '/auth/callback',     name: 'auth-callback',   component: AuthCallbackView },
 

--- a/src/web/src/router/router.spec.ts
+++ b/src/web/src/router/router.spec.ts
@@ -69,6 +69,11 @@ describe('router lazy routes', () => {
     expect(router.currentRoute.value.name).toBe('event-detail')
   })
 
+  it('resolves /newsletter/:id as newsletter-detail', async () => {
+    await router.push('/newsletter/n1')
+    expect(router.currentRoute.value.name).toBe('newsletter-detail')
+  })
+
   it('resolves /admin/content as admin-content', async () => {
     await router.push('/admin/content')
     expect(router.currentRoute.value.name).toBe('admin-content')

--- a/src/web/src/views/HomeView.vue
+++ b/src/web/src/views/HomeView.vue
@@ -7,7 +7,7 @@ import ArticleCard from '@/components/common/ArticleCard.vue'
 import EventCard from '@/components/common/EventCard.vue'
 import { apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
-import type { Article, CommunityEvent } from '@/types/content'
+import type { Article, CommunityEvent, Newsletter } from '@/types/content'
 
 const { data: articles } = useAsyncData(
   () => apiJson<Article[]>('/articles?status=published'),
@@ -18,6 +18,11 @@ const { data: blogs } = useAsyncData(
 const { data: events } = useAsyncData(
   () => apiJson<CommunityEvent[]>('/events?upcoming=true'),
 )
+// API already returns newsletters newest-first (OrderByDescending IssueDate).
+const { data: newsletters } = useAsyncData(
+  () => apiJson<Newsletter[]>('/newsletters'),
+)
+const latestIssue = computed(() => newsletters.value?.[0] ?? null)
 
 const featuredArticles = computed(() =>
   [...(articles.value ?? [])]
@@ -133,12 +138,21 @@ const upcomingEvents = computed(() =>
       <p class="mt-3 text-slypn-900/80">
         Meet-up dates, a featured article, fundraising progress, and the odd member story. About five minutes to read.
       </p>
-      <RouterLink
-        to="/newsletter"
-        class="mt-6 inline-block rounded-md bg-slypn-600 px-6 py-3 text-sm font-semibold text-white hover:bg-slypn-700"
-      >
-        Subscribe
-      </RouterLink>
+      <div class="mt-6 flex flex-wrap justify-center gap-3">
+        <RouterLink
+          to="/newsletter"
+          class="rounded-md bg-slypn-600 px-6 py-3 text-sm font-semibold text-white hover:bg-slypn-700"
+        >
+          Subscribe
+        </RouterLink>
+        <RouterLink
+          v-if="latestIssue"
+          :to="{ name: 'newsletter-detail', params: { id: latestIssue.id } }"
+          class="rounded-md border border-slypn-200 bg-white px-6 py-3 text-sm font-semibold text-slypn-700 hover:bg-slypn-50"
+        >
+          Read the latest issue
+        </RouterLink>
+      </div>
     </div>
   </section>
 </template>

--- a/src/web/src/views/MemberManagementView.spec.ts
+++ b/src/web/src/views/MemberManagementView.spec.ts
@@ -69,6 +69,27 @@ describe('MemberManagementView', () => {
     expect(removeBtn.attributes('disabled')).toBeDefined()
   })
 
+  it('disables changing your own role', async () => {
+    // admin persona oid
+    apiJson.mockResolvedValue([member({ id: 'me', oid: '11111111-1111-1111-1111-111111111111' })])
+    const w = mountC()
+    await flushPromises()
+    for (const role of ['Admin', 'Contributor', 'Member']) {
+      const btn = w.findAll('button').find(b => b.text() === role)!
+      expect(btn.attributes('disabled')).toBeDefined()
+      expect(btn.attributes('title')).toBe('You cannot change your own role')
+    }
+  })
+
+  it('leaves another member’s role controls enabled', async () => {
+    apiJson.mockResolvedValue([member()]) // oid: 'oidA', not the signed-in admin
+    const w = mountC()
+    await flushPromises()
+    const adminBtn = w.findAll('button').find(b => b.text() === 'Admin')!
+    expect(adminBtn.attributes('disabled')).toBeUndefined()
+    expect(adminBtn.attributes('title')).toBeUndefined()
+  })
+
   it('sends an invite and shows the redeem link', async () => {
     apiJson.mockResolvedValue([])
     apiFetch.mockResolvedValue(ok({ member: { email: 'new@x.com' }, inviteSent: true, redeemUrl: 'https://redeem/abc', inviteReason: null }))

--- a/src/web/src/views/MemberManagementView.vue
+++ b/src/web/src/views/MemberManagementView.vue
@@ -271,7 +271,8 @@ const fmtDate = (iso: string) =>
               v-for="r in allRoles"
               :key="r"
               type="button"
-              :disabled="savingId === m.id || deletingId === m.id"
+              :disabled="savingId === m.id || deletingId === m.id || m.oid === auth.oid"
+              :title="m.oid === auth.oid ? 'You cannot change your own role' : undefined"
               :class="[
                 'rounded-md px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50',
                 m.roles.includes(r)

--- a/src/web/src/views/NewsletterDetailView.spec.ts
+++ b/src/web/src/views/NewsletterDetailView.spec.ts
@@ -164,4 +164,22 @@ describe('NewsletterDetailView', () => {
     expect(router.back).toHaveBeenCalled()
     expect(router.push).not.toHaveBeenCalled()
   })
+
+  it('uses router.back() and labels the button "Home" when the back state is /', async () => {
+    router.options.history.state.back = '/'
+    apiJson.mockResolvedValue([newsletter({ fileName: undefined })])
+    const w = mountView()
+    await flushPromises()
+    expect(w.find('button').text()).toContain('Home')
+    await w.find('button').trigger('click')
+    expect(router.back).toHaveBeenCalled()
+    expect(router.push).not.toHaveBeenCalled()
+  })
+
+  it('labels the button "Newsletters" by default', async () => {
+    apiJson.mockResolvedValue([newsletter({ fileName: undefined })])
+    const w = mountView()
+    await flushPromises()
+    expect(w.find('button').text()).toContain('Newsletters')
+  })
 })

--- a/src/web/src/views/NewsletterDetailView.spec.ts
+++ b/src/web/src/views/NewsletterDetailView.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub, flushPromises } from '@vue/test-utils'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+
+const { renderAsync } = vi.hoisted(() => ({ renderAsync: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('docx-preview', () => ({ renderAsync }))
+
+const route = { params: {} as Record<string, string>, query: {}, hash: '', fullPath: '/newsletter/n1' }
+const router = {
+  push: vi.fn(), replace: vi.fn(), back: vi.fn(),
+  options: { history: { state: { back: undefined as string | undefined } } },
+}
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>)
+  return { ...actual, useRoute: () => route, useRouter: () => router }
+})
+
+import NewsletterDetailView from './NewsletterDetailView.vue'
+
+const stubs = { RouterLink: RouterLinkStub }
+const mountView = () => mount(NewsletterDetailView, { global: { stubs } })
+
+const newsletter = (over: Record<string, unknown> = {}) => ({
+  id: 'n1', title: 'May 2026 issue', issueDate: '2026-05-01', summary: 'What happened in May',
+  topics: ['Meet-ups'], fileName: 'SLYPN-Newsletter-2026-05.docx', ...over,
+})
+
+const PDF = 'application/pdf'
+const DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+const DOC = 'application/msword'
+
+function fileResponse(contentType: string, init: { ok?: boolean; status?: number; statusText?: string } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? contentType : null) },
+    blob: () => Promise.resolve(new Blob(['dummy'], { type: contentType })),
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  apiJson.mockReset()
+  apiFetch.mockReset()
+  renderAsync.mockClear().mockResolvedValue(undefined)
+  Object.assign(route, { params: { id: 'n1' }, fullPath: '/newsletter/n1' })
+  router.push.mockClear(); router.replace.mockClear(); router.back.mockClear()
+  router.options.history.state.back = undefined
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url')
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+})
+
+describe('NewsletterDetailView', () => {
+  it('shows a loading state before the metadata resolves', async () => {
+    apiJson.mockReturnValue(new Promise(() => {})) // never resolves
+    const w = mountView()
+    await flushPromises()
+    expect(w.text()).toContain('Loading')
+  })
+
+  it('shows an error message when the metadata fetch fails', async () => {
+    apiJson.mockRejectedValue(new Error('boom'))
+    const w = mountView()
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load this issue');
+    expect(w.text()).toContain('boom')
+  })
+
+  it('shows a not-found message when no newsletter matches the id', async () => {
+    apiJson.mockResolvedValue([newsletter({ id: 'other' })])
+    const w = mountView()
+    await flushPromises()
+    expect(w.text()).toContain('Newsletter not found')
+  })
+
+  it('shows a placeholder and skips the file fetch when no file is attached', async () => {
+    apiJson.mockResolvedValue([newsletter({ fileName: undefined })])
+    const w = mountView()
+    await flushPromises()
+    expect(w.text()).toContain('No file has been attached')
+    expect(apiFetch).not.toHaveBeenCalled()
+  })
+
+  it('renders a PDF in an iframe using an object URL', async () => {
+    apiJson.mockResolvedValue([newsletter()])
+    apiFetch.mockResolvedValue(fileResponse(PDF))
+    const w = mountView()
+    await flushPromises()
+    const iframe = w.get('iframe')
+    expect(iframe.attributes('src')).toBe('blob:mock-url')
+    expect(iframe.attributes('title')).toContain('May 2026 issue')
+    expect(URL.createObjectURL).toHaveBeenCalled()
+  })
+
+  it('renders a DOCX via docx-preview', async () => {
+    apiJson.mockResolvedValue([newsletter()])
+    apiFetch.mockResolvedValue(fileResponse(DOCX))
+    const w = mountView()
+    await flushPromises()
+    expect(renderAsync).toHaveBeenCalledTimes(1)
+    const [, bodyContainer, styleContainer, options] = renderAsync.mock.calls[0]
+    expect(bodyContainer).toBe(styleContainer)
+    expect(w.element.contains(bodyContainer)).toBe(true)
+    expect(options).toMatchObject({ useBase64URL: true })
+  })
+
+  it('falls back to a download prompt for legacy .doc files', async () => {
+    apiJson.mockResolvedValue([newsletter()])
+    apiFetch.mockResolvedValue(fileResponse(DOC))
+    const w = mountView()
+    await flushPromises()
+    expect(w.text()).toContain('can’t be previewed')
+    expect(w.find('a[download]').exists()).toBe(true)
+    expect(renderAsync).not.toHaveBeenCalled()
+  })
+
+  it('shows an error and a download link when the file fetch fails', async () => {
+    apiJson.mockResolvedValue([newsletter()])
+    apiFetch.mockResolvedValue(fileResponse(PDF, { ok: false, status: 500, statusText: 'Server Error' }))
+    const w = mountView()
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load the preview')
+    expect(w.find('a[download]').exists()).toBe(true)
+  })
+
+  it('revokes the object URL on unmount', async () => {
+    apiJson.mockResolvedValue([newsletter()])
+    apiFetch.mockResolvedValue(fileResponse(PDF))
+    const w = mountView()
+    await flushPromises()
+    w.unmount()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('goes back to /newsletter by default', async () => {
+    apiJson.mockResolvedValue([newsletter({ fileName: undefined })])
+    const w = mountView()
+    await flushPromises()
+    await w.find('button').trigger('click')
+    expect(router.push).toHaveBeenCalledWith('/newsletter')
+    expect(router.back).not.toHaveBeenCalled()
+  })
+
+  it('uses router.back() when the back state is /newsletter', async () => {
+    router.options.history.state.back = '/newsletter'
+    apiJson.mockResolvedValue([newsletter({ fileName: undefined })])
+    const w = mountView()
+    await flushPromises()
+    await w.find('button').trigger('click')
+    expect(router.back).toHaveBeenCalled()
+    expect(router.push).not.toHaveBeenCalled()
+  })
+
+  it('uses router.back() when the back state is /admin/newsletters', async () => {
+    router.options.history.state.back = '/admin/newsletters'
+    apiJson.mockResolvedValue([newsletter({ fileName: undefined })])
+    const w = mountView()
+    await flushPromises()
+    await w.find('button').trigger('click')
+    expect(router.back).toHaveBeenCalled()
+    expect(router.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/src/views/NewsletterDetailView.vue
+++ b/src/web/src/views/NewsletterDetailView.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
+import { renderAsync } from 'docx-preview'
+import { apiFetch, apiJson } from '@/lib/api'
+import { useAsyncData } from '@/composables/useAsyncData'
+import type { Newsletter } from '@/types/content'
+
+const route = useRoute()
+const router = useRouter()
+
+// Reachable from both the public list and the admin list, so recognise both
+// as "came from a list" origins for the back button.
+function backToNewsletters() {
+  const back = router.options.history.state.back
+  if (typeof back === 'string') {
+    const path = back.split('?')[0]
+    if (path === '/newsletter' || path === '/admin/newsletters') {
+      router.back()
+      return
+    }
+  }
+  router.push('/newsletter')
+}
+
+// No single-newsletter endpoint exists — find it in the same list the list
+// pages already fetch. lazy: true because this view has two chained async
+// steps (metadata, then the file) rather than the sibling views' one.
+const { data: newsletter, loading, error, refresh: refreshMeta } = useAsyncData(async () => {
+  const list = await apiJson<Newsletter[]>('/newsletters')
+  return list.find(n => n.id === route.params.id) ?? null
+}, { lazy: true })
+
+type FileKind = 'pdf' | 'docx' | 'unsupported'
+
+const fileLoading = ref(false)
+const fileError = ref<string | null>(null)
+const fileKind = ref<FileKind | null>(null)
+const objectUrl = ref<string | null>(null)
+const docxContainer = ref<HTMLElement | null>(null)
+
+function revokeObjectUrl() {
+  if (objectUrl.value) {
+    URL.revokeObjectURL(objectUrl.value)
+    objectUrl.value = null
+  }
+}
+
+// Content-Disposition: attachment on the file endpoint only affects direct
+// browser navigation, not fetch() — reading the bytes here and rendering
+// from a client-side Blob/ArrayBuffer sidesteps it entirely.
+async function loadFile() {
+  revokeObjectUrl()
+  fileKind.value = null
+  fileError.value = null
+  if (!newsletter.value?.fileName) return
+
+  fileLoading.value = true
+  try {
+    const resp = await apiFetch(`/newsletters/${newsletter.value.id}/file`)
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`)
+    const contentType = (resp.headers.get('Content-Type') ?? '').toLowerCase()
+
+    if (contentType.startsWith('application/pdf')) {
+      objectUrl.value = URL.createObjectURL(await resp.blob())
+      fileKind.value = 'pdf'
+    } else if (contentType.startsWith('application/vnd.openxmlformats-officedocument.wordprocessingml.document')) {
+      fileKind.value = 'docx'
+      if (docxContainer.value) {
+        docxContainer.value.innerHTML = ''
+        // useBase64URL avoids docx-preview's own un-revoked internal object
+        // URLs for embedded images.
+        await renderAsync(await resp.arrayBuffer(), docxContainer.value, docxContainer.value, { useBase64URL: true })
+      }
+    } else {
+      // Legacy .doc (application/msword) or anything unexpected — no viable
+      // client-side renderer exists; fall back to download.
+      fileKind.value = 'unsupported'
+    }
+  } catch (err) {
+    fileError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    fileLoading.value = false
+  }
+}
+
+async function load() {
+  await refreshMeta()
+  await loadFile()
+}
+
+onMounted(load)
+watch(() => route.params.id, load)
+onUnmounted(revokeObjectUrl)
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+</script>
+
+<template>
+  <div class="page-container py-12">
+    <button type="button" class="mb-8 flex items-center gap-1.5 text-sm text-slypn-500 hover:text-slypn-700" @click="backToNewsletters">
+      &larr; Newsletters
+    </button>
+
+    <p v-if="loading" class="text-center text-slypn-900/60">Loading&hellip;</p>
+
+    <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
+      Couldn&rsquo;t load this issue: {{ error }}
+    </div>
+
+    <div v-else-if="!newsletter" class="text-center">
+      <h1 class="font-display text-2xl font-bold text-slypn-700">Newsletter not found</h1>
+      <RouterLink to="/newsletter" class="mt-6 inline-block text-slypn-600 underline underline-offset-4 hover:text-slypn-700">
+        Back to newsletters
+      </RouterLink>
+    </div>
+
+    <div v-else>
+      <div class="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p class="font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
+            {{ formatDate(newsletter.issueDate) }}
+          </p>
+          <h1 class="mt-2 text-3xl font-extrabold text-slypn-700 sm:text-4xl">{{ newsletter.title }}</h1>
+          <p class="mt-3 max-w-2xl text-sm text-slypn-900/75">{{ newsletter.summary }}</p>
+        </div>
+        <a
+          v-if="newsletter.fileName"
+          :href="`/api/newsletters/${newsletter.id}/file`"
+          class="inline-flex shrink-0 items-center gap-1.5 text-sm font-semibold text-slypn-600 hover:text-slypn-700 hover:underline"
+          download
+        >
+          <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M10 2a1 1 0 0 1 1 1v7.586l2.293-2.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 1 1 1.414-1.414L9 10.586V3a1 1 0 0 1 1-1Z" />
+            <path d="M3 14a1 1 0 0 1 1 1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-1a1 1 0 1 1 2 0v1a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3v-1a1 1 0 0 1 1-1Z" />
+          </svg>
+          Download issue
+        </a>
+      </div>
+
+      <div class="mt-8">
+        <p v-if="!newsletter.fileName" class="text-slypn-900/70">
+          No file has been attached to this issue yet.
+        </p>
+
+        <template v-else>
+          <p v-if="fileLoading" class="text-slypn-900/60">Loading preview&hellip;</p>
+
+          <div v-else-if="fileError" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
+            Couldn&rsquo;t load the preview: {{ fileError }}. You can still
+            <a :href="`/api/newsletters/${newsletter.id}/file`" class="underline underline-offset-2" download>download the file</a>.
+          </div>
+
+          <div v-else-if="fileKind === 'unsupported'" class="rounded-md bg-slypn-50 px-4 py-3 text-sm text-slypn-700">
+            This issue can&rsquo;t be previewed &mdash;
+            <a :href="`/api/newsletters/${newsletter.id}/file`" class="underline underline-offset-2" download>download it instead</a>.
+          </div>
+
+          <iframe
+            v-if="fileKind === 'pdf' && objectUrl"
+            :src="objectUrl"
+            :title="`${newsletter.title} — PDF preview`"
+            class="h-[80vh] w-full rounded-xl border border-slypn-100"
+          />
+        </template>
+
+        <!-- Always mounted once a newsletter is resolved (visibility only via
+             v-show) so the ref exists before renderAsync needs it. -->
+        <div v-show="fileKind === 'docx'" ref="docxContainer" class="docx-container rounded-xl border border-slypn-100 bg-white p-6" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/web/src/views/NewsletterDetailView.vue
+++ b/src/web/src/views/NewsletterDetailView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { renderAsync } from 'docx-preview'
 import { apiFetch, apiJson } from '@/lib/api'
@@ -9,16 +9,26 @@ import type { Newsletter } from '@/types/content'
 const route = useRoute()
 const router = useRouter()
 
-// Reachable from both the public list and the admin list, so recognise both
-// as "came from a list" origins for the back button.
+// Reachable from the public list, the admin list, and Home's "latest issue"
+// link — recognise all three as "came from here" origins for the back
+// button, and label it to match wherever it'll actually land.
+const knownBackOrigins: Record<string, string> = {
+  '/newsletter': 'Newsletters',
+  '/admin/newsletters': 'Newsletters',
+  '/': 'Home',
+}
+
+const backLabel = computed(() => {
+  const back = router.options.history.state.back
+  const path = typeof back === 'string' ? back.split('?')[0] : undefined
+  return (path && knownBackOrigins[path]) || 'Newsletters'
+})
+
 function backToNewsletters() {
   const back = router.options.history.state.back
-  if (typeof back === 'string') {
-    const path = back.split('?')[0]
-    if (path === '/newsletter' || path === '/admin/newsletters') {
-      router.back()
-      return
-    }
+  if (typeof back === 'string' && back.split('?')[0] in knownBackOrigins) {
+    router.back()
+    return
   }
   router.push('/newsletter')
 }
@@ -100,7 +110,7 @@ const formatDate = (iso: string) =>
 <template>
   <div class="page-container py-12">
     <button type="button" class="mb-8 flex items-center gap-1.5 text-sm text-slypn-500 hover:text-slypn-700" @click="backToNewsletters">
-      &larr; Newsletters
+      &larr; {{ backLabel }}
     </button>
 
     <p v-if="loading" class="text-center text-slypn-900/60">Loading&hellip;</p>

--- a/src/web/src/views/NewsletterManagementView.spec.ts
+++ b/src/web/src/views/NewsletterManagementView.spec.ts
@@ -54,6 +54,15 @@ describe('NewsletterManagementView', () => {
     expect(w.text()).toContain('No file attached')
   })
 
+  it('shows a View link to the newsletter detail route only when a file is attached', async () => {
+    apiJson.mockResolvedValue([newsletter({ fileName: 'issue.pdf' }), newsletter({ id: 'n2', title: 'June 2026' })])
+    const w = mountC()
+    await flushPromises()
+    const viewLinks = w.findAllComponents(RouterLinkStub).filter(l => (l.props('to') as { name?: string })?.name === 'newsletter-detail')
+    expect(viewLinks).toHaveLength(1)
+    expect(viewLinks[0].props('to')).toEqual({ name: 'newsletter-detail', params: { id: 'n1' } })
+  })
+
   it('shows the empty state', async () => {
     apiJson.mockResolvedValue([])
     const w = mountC()

--- a/src/web/src/views/NewsletterManagementView.vue
+++ b/src/web/src/views/NewsletterManagementView.vue
@@ -171,12 +171,17 @@ async function remove(n: Newsletter) {
           </p>
           <p class="mt-1 font-semibold text-slypn-800">{{ n.title }}</p>
           <p class="mt-0.5 text-sm text-slypn-900/75">{{ n.summary }}</p>
-          <a
-            v-if="n.fileName"
-            :href="`/api/newsletters/${n.id}/file`"
-            class="mt-1 inline-block text-xs text-slypn-500 underline underline-offset-2 hover:text-slypn-700"
-            download
-          >{{ n.fileName }}</a>
+          <div v-if="n.fileName" class="mt-1 flex items-center gap-3">
+            <RouterLink
+              :to="{ name: 'newsletter-detail', params: { id: n.id } }"
+              class="text-xs font-semibold text-slypn-600 underline underline-offset-2 hover:text-slypn-700"
+            >View</RouterLink>
+            <a
+              :href="`/api/newsletters/${n.id}/file`"
+              class="text-xs text-slypn-500 underline underline-offset-2 hover:text-slypn-700"
+              download
+            >{{ n.fileName }}</a>
+          </div>
           <p v-else class="mt-1 text-xs text-slypn-900/50">No file attached</p>
         </div>
         <div class="flex shrink-0 gap-2">

--- a/src/web/src/views/NewsletterView.vue
+++ b/src/web/src/views/NewsletterView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import NewsletterIcon from '@/components/common/NewsletterIcon.vue'
 import NewsletterCard from '@/components/common/NewsletterCard.vue'
@@ -12,9 +12,13 @@ const submitting = ref(false)
 const submitted = ref(false)
 const submitError = ref<string | null>(null)
 
+// API already returns newsletters newest-first (OrderByDescending IssueDate).
 const { data: newsletters, loading, error, refresh } = useAsyncData(
   () => apiJson<Newsletter[]>('/newsletters'),
 )
+
+const latestIssue = computed(() => newsletters.value?.[0] ?? null)
+const pastIssues = computed(() => (newsletters.value ?? []).slice(1))
 
 async function subscribe() {
   if (!email.value || submitting.value) return
@@ -77,25 +81,35 @@ async function subscribe() {
   </HeroBanner>
 
   <section class="page-container py-16">
-    <h2 class="font-display text-2xl font-bold text-slypn-700">Past issues</h2>
+    <p v-if="loading && !newsletters" class="text-slypn-900/70">Loading&hellip;</p>
 
-    <p v-if="loading && !newsletters" class="mt-6 text-slypn-900/70">Loading&hellip;</p>
-
-    <div v-else-if="error" class="mt-6 rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
+    <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load newsletters: {{ error }}.
       <button class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
-    <div v-else class="mt-6 grid gap-5 sm:grid-cols-2">
-      <NewsletterCard
-        v-for="n in newsletters ?? []"
-        :key="n.id"
-        :newsletter="n"
-      />
-    </div>
-
-    <p v-if="!loading && !error && !newsletters?.length" class="mt-6 text-slypn-900/70">
+    <p v-else-if="!newsletters?.length" class="text-slypn-900/70">
       No newsletters yet.
     </p>
+
+    <template v-else>
+      <div>
+        <h2 class="font-display text-2xl font-bold text-slypn-700">Latest issue</h2>
+        <div class="mt-6 max-w-xl">
+          <NewsletterCard v-if="latestIssue" :newsletter="latestIssue" />
+        </div>
+      </div>
+
+      <div v-if="pastIssues.length" class="mt-16">
+        <h2 class="font-display text-2xl font-bold text-slypn-700">Past issues</h2>
+        <div class="mt-6 grid gap-5 sm:grid-cols-2">
+          <NewsletterCard
+            v-for="n in pastIssues"
+            :key="n.id"
+            :newsletter="n"
+          />
+        </div>
+      </div>
+    </template>
   </section>
 </template>

--- a/src/web/src/views/views.public.spec.ts
+++ b/src/web/src/views/views.public.spec.ts
@@ -244,12 +244,13 @@ describe('LoginView', () => {
 })
 
 describe('NewsletterView', () => {
-  it('lists past issues and subscribes on submit', async () => {
+  it('shows the latest issue and subscribes on submit', async () => {
     apiJson.mockResolvedValue([{ id: 'n1', title: 'May 2026', issueDate: '2026-05-01', summary: 's', topics: ['x'] }])
     apiFetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
     const w = mountView(NewsletterView)
     await flushPromises()
-    expect(w.text()).toContain('Past issues')
+    expect(w.text()).toContain('Latest issue')
+    expect(w.text()).not.toContain('Past issues')
     expect(w.text()).toContain('May 2026')
 
     await w.find('input[type="email"]').setValue('me@example.com')
@@ -257,6 +258,24 @@ describe('NewsletterView', () => {
     await flushPromises()
     expect(apiFetch).toHaveBeenCalledWith('/newsletter/subscribe', expect.objectContaining({ method: 'POST' }))
     expect(w.text()).toContain('you’re on the list')
+  })
+
+  it('separates the latest issue (API-returned newest-first) from past issues', async () => {
+    apiJson.mockResolvedValue([
+      { id: 'n2', title: 'June 2026', issueDate: '2026-06-01', summary: 's2', topics: ['x'] },
+      { id: 'n1', title: 'May 2026', issueDate: '2026-05-01', summary: 's1', topics: ['x'] },
+    ])
+    const w = mountView(NewsletterView)
+    await flushPromises()
+    expect(w.text()).toContain('Latest issue')
+    expect(w.text()).toContain('Past issues')
+
+    const latestSection = w.text().split('Past issues')[0]
+    expect(latestSection).toContain('June 2026')
+    expect(latestSection).not.toContain('May 2026')
+
+    const pastSection = w.text().split('Past issues')[1]
+    expect(pastSection).toContain('May 2026')
   })
 
   it('surfaces a subscribe error', async () => {
@@ -316,6 +335,28 @@ describe('HomeView', () => {
     expect(w.text()).toContain('Article One')
     expect(w.text()).toContain('Blog One')
     expect(w.text()).toContain('Coffee')
+  })
+
+  it('links to the latest newsletter issue when one exists', async () => {
+    apiJson.mockImplementation((path: string) => {
+      if (path.startsWith('/newsletters')) return Promise.resolve([
+        { id: 'n2', title: 'June 2026', issueDate: '2026-06-01', summary: 's', topics: [] },
+        { id: 'n1', title: 'May 2026', issueDate: '2026-05-01', summary: 's', topics: [] },
+      ])
+      return Promise.resolve([])
+    })
+    const w = mountView(HomeView)
+    await flushPromises()
+    const link = w.findAllComponents(RouterLinkStub).find(l => l.text() === 'Read the latest issue')
+    expect(link).toBeTruthy()
+    expect(link!.props('to')).toEqual({ name: 'newsletter-detail', params: { id: 'n2' } })
+  })
+
+  it('omits the latest-issue link when there are no newsletters', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountView(HomeView)
+    await flushPromises()
+    expect(w.findAllComponents(RouterLinkStub).find(l => l.text() === 'Read the latest issue')).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
- New page at `/newsletter/:id`: clicking "View" on a newsletter (public list or admin management screen) now renders the issue in-app instead of just downloading it.
- **PDF** → fetched as a Blob → rendered via `<iframe>` + object URL, using the browser's own native PDF viewer. No `pdf.js` dependency.
- **DOCX** → fetched as an ArrayBuffer → rendered client-side via `docx-preview` into a plain container. Nothing leaves SLYPN's own infra.
- **Legacy `.doc` / unrecognized type / fetch failure** → graceful fallback message + the existing Download link (no client-side renderer exists for the old binary Word format; zero current files hit this, but the backend still allows uploading it).
- **Zero backend changes.** The file endpoint's `Content-Disposition: attachment` header only affects direct browser navigation, not `fetch()` — reading the bytes client-side and rendering from a Blob/ArrayBuffer sidesteps it entirely. There's also no single-newsletter `GET` endpoint, so the detail view finds its newsletter in the same `/newsletters` list the existing list pages already fetch (small archive, ~56 issues, negligible extra cost).
- The existing "Download issue" link is untouched on both list views — "View" sits alongside it, not instead of it.

### Follow-up: separate latest newsletter from past issues
- The newsletter list now features the latest issue as a full-width card above a "Past issues" grid, instead of one undifferentiated list.
- Adds a "Read the latest issue" link on Home next to the newsletter Subscribe CTA.
- The detail page's back button now recognises Home (`/`) as a third valid origin alongside the newsletter list and admin list — landing there from the Home link returns to Home via `router.back()` instead of the newsletter list, and its label switches between "Home" and "Newsletters" to match wherever it'll actually go.

### Follow-up: prevent an admin from changing their own role
- Unrelated fix bundled into this branch at the user's request. Mirrors the existing self-delete guard exactly: a real server-side check on `PATCH /members/{id}` (400 "You cannot change your own role"), not just a UI nicety, plus the same disabled+tooltip treatment on the role-picker buttons that the Remove button already had.

## Verification
- `npm run lint`, `npm run build`, `npm run test:unit` — clean, 400/400 web tests passing.
- `dotnet build`, `dotnet test` — clean, 251/251 API tests passing.
- Confirmed via the production build output that `docx-preview` + `jszip` land in their own lazy-loaded chunk (`NewsletterDetailView-*.js`, ~179 KB), not the shared bundle every page loads.
- Live end-to-end checks against the real imported newsletter archive (56 issues, mixed PDF/DOCX): DOCX renders with full formatting preserved (headings, links, layout) — visually confirmed. PDF: confirmed the fetched blob is a valid 98 KB `application/pdf` file correctly wired to the iframe's `src`/`title` — the native viewer's rendered pixels didn't show up in a headless-Chromium screenshot (a known limitation of automating browser PDF-plugin rendering, not a code issue), so worth a quick manual look in a real browser tab before merging.
- Live-checked the Home → latest issue → back-to-Home flow, the latest/past newsletter split, and the members admin screen (signed-in admin's own role/remove controls visibly disabled; another admin's fully enabled).

## Test plan
- [x] `npm run lint` / `npm run build` / `npm run test:unit`
- [x] `dotnet build` / `dotnet test`
- [ ] Manually open a PDF issue in a real browser tab to visually confirm native rendering (see note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
