### PR TITLE
fix(web): stop the DOCX newsletter preview overflowing on mobile

### DIFF
--- a/src/web/src/views/NewsletterDetailView.spec.ts
+++ b/src/web/src/views/NewsletterDetailView.spec.ts
@@ -105,7 +105,7 @@ describe('NewsletterDetailView', () => {
     const [, bodyContainer, styleContainer, options] = renderAsync.mock.calls[0]
     expect(bodyContainer).toBe(styleContainer)
     expect(w.element.contains(bodyContainer)).toBe(true)
-    expect(options).toMatchObject({ useBase64URL: true })
+    expect(options).toMatchObject({ useBase64URL: true, ignoreWidth: true })
   })
 
   it('falls back to a download prompt for legacy .doc files', async () => {

--- a/src/web/src/views/NewsletterDetailView.vue
+++ b/src/web/src/views/NewsletterDetailView.vue
@@ -79,8 +79,10 @@ async function loadFile() {
       if (docxContainer.value) {
         docxContainer.value.innerHTML = ''
         // useBase64URL avoids docx-preview's own un-revoked internal object
-        // URLs for embedded images.
-        await renderAsync(await resp.arrayBuffer(), docxContainer.value, docxContainer.value, { useBase64URL: true })
+        // URLs for embedded images. ignoreWidth stops it forcing the
+        // document's physical page width (e.g. A4, ~794px) regardless of
+        // viewport, which otherwise overflows on mobile.
+        await renderAsync(await resp.arrayBuffer(), docxContainer.value, docxContainer.value, { useBase64URL: true, ignoreWidth: true })
       }
     } else {
       // Legacy .doc (application/msword) or anything unexpected — no viable
@@ -177,8 +179,40 @@ const formatDate = (iso: string) =>
 
         <!-- Always mounted once a newsletter is resolved (visibility only via
              v-show) so the ref exists before renderAsync needs it. -->
-        <div v-show="fileKind === 'docx'" ref="docxContainer" class="docx-container rounded-xl border border-slypn-100 bg-white p-6" />
+        <div v-show="fileKind === 'docx'" ref="docxContainer" class="docx-container max-w-full overflow-x-auto rounded-xl border border-slypn-100 bg-white p-6" />
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+/* docx-preview centres its page section in a flex wrapper (align-items:
+   center), which — combined with ignoreWidth letting the page shrink below
+   its natural content width — overflows equally on both sides and clips the
+   left edge when the container is narrower than the page. Left-align by
+   default so any excess width only overflows right, where
+   .docx-container's overflow-x-auto can scroll to it without cutting
+   content off; restore centring once there's reliably enough room (roughly
+   a full A4/Letter page's width plus padding) for it to look intentional. */
+.docx-container :deep(.docx-wrapper) {
+  align-items: flex-start;
+}
+@media (min-width: 1024px) {
+  .docx-container :deep(.docx-wrapper) {
+    align-items: center;
+  }
+}
+
+/* Word's own "tab" columns (e.g. a label followed by a run of individual
+   space characters before a value) have no single unbreakable run, but as a
+   non-stretched flex item the page section still sizes itself to fit its
+   content's preferred width rather than shrinking with its container.
+   max-width caps that at the container's width, and overflow-wrap (which
+   inherits down to every paragraph/span) lets whatever specific text would
+   otherwise force it wider break instead, so the whole document wraps to
+   fit on narrow screens instead of needing horizontal scroll. */
+.docx-container :deep(section.docx) {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+</style>


### PR DESCRIPTION
## Summary
Two compounding issues in the DOCX newsletter viewer (`NewsletterDetailView.vue`) on narrow viewports:

1. `docx-preview` centres its rendered page (`align-items: center` on its own flex wrapper). Once the page was wider than its container, that overflowed equally on both sides — clipping text off the **left** edge, which is what made it look broken rather than just scrollable.
2. Even after fixing the alignment, the page section still sized itself to fit its content's *preferred* width rather than shrinking with its container, because it's a non-stretched flex item. Word's tab-stop columns (e.g. `Founder of SLYPN:` + a run of individually-breakable space characters + `Sarah Webb`) have no single unbreakable run, but collectively kept the section wide enough to lay each one out on a single line before wrapping ever got a chance to apply — so the container needed horizontal scroll to read anything.

## Fix
- `align-items: flex-start` by default (scoped `:deep(.docx-wrapper)` override), restored to `center` at `≥1024px` where there's reliably enough room for it to look intentional.
- `max-width: 100%` on the page section caps it at its container's actual width.
- `overflow-wrap: anywhere` (inherits down to every paragraph/span) lets text wrap to fit once the width is capped, instead of forcing the box wider.

## Verification
- `npm run lint` / `npm run build` / `npm run test:unit` — clean, 400/400 passing.
- Direct DOM measurement (not just screenshots — caught myself misreading one along the way): mobile now shows `container.scrollWidth === container.clientWidth`, i.e. **zero** horizontal scroll needed, confirmed across the full length of a real rendered document from the imported archive.
- Desktop's rendered section width is pixel-identical to before this change (978px @ 1280px viewport) — confirms the new rules only engage when the content would actually overflow, no visual regression where there's already room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)