### PR TITLE
fix(infra): recreate SWA clean on Free tier to avoid identity-removal bug

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -108,9 +108,14 @@ resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2024-01-0
 // we use westeurope for UK proximity. Preview-environment quota (3
 // concurrent) is enforced in the deploy workflow, not here.
 // ---------------------------------------------------------------------------
-// The Free plan doesn't support managed identity at all, so there's no
-// identity block to add here.
-resource swa 'Microsoft.Web/staticSites@2024-04-01' = { // NOSONAR (S6378) — see comment above
+// The Free plan doesn't support managed identity at all — omitted here
+// deliberately (not identity: { type: 'None' }). On the ORIGINAL resource,
+// removing an existing SystemAssigned identity via any path (CLI, ARM
+// template at two API versions, the Portal's own Identity blade) hit a
+// platform bug: "Parameter IdentityUrl is null or empty". Recreating the
+// resource clean, never attaching an identity in the first place, avoids
+// that code path entirely rather than fighting it.
+resource swa 'Microsoft.Web/staticSites@2025-05-01' = { // NOSONAR (S6378) — see comment above
   name: 'swa-${prefixDash}'
   location: swaLocation
   sku: {


### PR DESCRIPTION
## Summary
- The live SWA's SystemAssigned identity could not be removed via any path: CLI (`az staticwebapp identity remove`), ARM template deploys (two API versions), or the Portal's own Identity blade — all hit an identical platform-level `Parameter IdentityUrl is null or empty` error, confirmed via the Portal's own activity log.
- Resolved by deleting and recreating `swa-slypn-prod` clean: Free tier from creation, no identity ever attached (sidesteps the buggy removal path entirely), bumped to API version `2025-05-01`.
- New resource means a new default hostname (`orange-hill-0f65dde03.7.azurestaticapps.net`, was `thankful-tree-090006c03...`). Already re-applied against the live resource via `infra/setup.ps1`: CIAM `slypn-spa` redirect URIs, all SWA app settings (Storage connection string, JWT validation config, Graph secret, signup-gate secret, Faro/OTel), and the GitHub Actions deploy token.
- Pushing this to `main` also triggers the actual site deploy onto the new resource (previously just the bare infra shell existed).

## Test plan
- [x] `az bicep build` — compiles clean
- [x] `npm run test:unit` — 400 passed
- [x] `dotnet test` — 251 passed
- [x] Live resource confirmed: Free tier, no identity, `HTTP 200` on the new hostname
- [ ] Confirm this PR's own deploy completes and the site serves real content (not just the placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)