### PR TITLE
docs: clean up stale managed-identity references after Free-tier move

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Early development. The build is tracked in **[GitHub Project #2](https://github.
 |---|---|
 | Frontend | Vue 3 + TypeScript + Vite + Pinia + TailwindCSS |
 | API | ASP.NET Core 8 isolated-worker Functions (deployed as SWA managed Functions) |
-| Hosting | Azure Static Web Apps (Standard tier) |
+| Hosting | Azure Static Web Apps (Free tier) |
 | Data | Azure Table Storage (metadata) + Azure Blob Storage (bodies + media) |
 | Auth | Entra External ID (MSAL.js + JWT bearer) |
 | CMS | Custom in-app editor (TipTap) with draft/in-review/published workflow |

--- a/docs/custom-domain.md
+++ b/docs/custom-domain.md
@@ -4,7 +4,7 @@ After the first Bicep deploy (#42) the SWA is reachable at the auto-generated `h
 
 > **Prerequisites**
 > - You own the domain. Registrar access to edit DNS records.
-> - SWA is on the **Standard** tier (already true via `infra/main.bicep`).
+> - No tier requirement — Free-tier SWA supports up to 2 custom domains (Standard/Premium raise that limit if you need more).
 > - You are signed in as Owner or Contributor on the SWA resource.
 
 ---

--- a/docs/deployment-secrets.md
+++ b/docs/deployment-secrets.md
@@ -49,7 +49,7 @@ Set on the SWA resource via portal or CLI. These flow into the Functions process
 
 | Setting | Purpose | Notes |
 |---|---|---|
-| `Storage__ConnectionString` | Azurite or storage account connection string (Table + Blob) | Set everywhere until managed identity is wired (#38). Prod then relies on the Bicep-granted `Storage Blob Data Contributor` + `Storage Table Data Contributor` roles on the SWA managed identity. |
+| `Storage__ConnectionString` | Azurite or storage account connection string (Table + Blob) | Set everywhere, permanently — Free-tier SWA has no managed identity to grant Storage roles to instead. |
 | `Graph__ClientSecret` | Graph app secret for invitation flow | Required everywhere until Graph supports managed identity for `User.Invite.All` (it doesn't today). Rotate annually. |
 
 ### Set via Azure CLI
@@ -113,7 +113,7 @@ These bake into the JS bundle at SWA build time. Set them as SWA app settings **
 | `Graph__ClientSecret` | Annual | Or sooner if leaked. Generate in Entra → re-set in SWA app settings. |
 | `Otel__Headers` (Grafana access policy token) | Annual | Or sooner. Recreate access policy in Grafana → re-set. |
 | Entra app reg secrets | n/a — public client (SPA uses PKCE, no secret) | — |
-| Storage connection string | n/a — managed identity in prod (#38) | — |
+| Storage connection string | No policy defined yet | Now the permanent auth path (Free-tier SWA has no managed identity) — worth deciding a cadence. |
 
 A failed rotation never breaks running pods because SWA app settings are loaded on cold start; restart the Functions worker via portal after updating.
 

--- a/docs/first-deploy-runbook.md
+++ b/docs/first-deploy-runbook.md
@@ -42,9 +42,8 @@ az deployment group create \
 
 Expected resources after ~5 min:
 
-- `swa-slypn-prod` (Static Web App)
+- `swa-slypn-prod` (Static Web App, Free tier)
 - `slypnprodst<suffix>` (Storage account, with `media` + `content` blob containers and the Table service; the six content tables are created at runtime by `TableBootstrapper`)
-- Two role assignments: SWA managed identity → Storage Blob Data Contributor + Storage Table Data Contributor.
 
 Capture the outputs:
 

--- a/src/api/Slypn.Api/Services/BlobService.cs
+++ b/src/api/Slypn.Api/Services/BlobService.cs
@@ -78,10 +78,9 @@ public sealed class BlobService : IBlobService
         var blob = _container.GetBlobClient(blobName);
         if (!blob.CanGenerateSasUri)
         {
-            // Will be the case once we switch to managed identity in Phase 6;
-            // a user-delegation SAS will be generated via the service client instead.
-            throw new InvalidOperationException(
-                "Cannot generate shared-key SAS. Switch to user-delegation SAS once managed identity is wired (see #41).");
+            // Connection-string clients always support shared-key SAS, so this
+            // shouldn't be reachable in practice — kept as a defensive guard.
+            throw new InvalidOperationException("Cannot generate shared-key SAS for this blob client.");
         }
 
         var lifetime = validFor ?? _opts.ReadSasLifetime;

--- a/src/api/Slypn.Api/Services/IBlobService.cs
+++ b/src/api/Slypn.Api/Services/IBlobService.cs
@@ -16,8 +16,8 @@ public interface IBlobService
 
     /// <summary>
     /// Returns a short-lived (default 15 min) read URL for the given blob name.
-    /// Currently shared-key SAS; user-delegation SAS via managed identity in
-    /// <c>#41</c> (Phase 6) once SWA managed identity has Blob Data Contributor.
+    /// Shared-key SAS, permanently — Free-tier SWA has no managed identity to
+    /// grant Blob Data Contributor to for a user-delegation SAS instead.
     /// </summary>
     Uri GetMediaReadUrl(string blobName, TimeSpan? validFor = null);
 }

--- a/src/api/Slypn.Api/Services/TableStore.cs
+++ b/src/api/Slypn.Api/Services/TableStore.cs
@@ -10,10 +10,8 @@ namespace Slypn.Api.Services;
 /// Backed by the same storage account as <see cref="BlobService"/> via
 /// <see cref="StorageOptions.ConnectionString"/>.
 ///
-/// Auth modes:
-///   - dev  : connection string (Azurite emulator).
-///   - prod : connection string for now; Managed Identity wiring lands in #38 (Phase 6)
-///            — swap to `new TableServiceClient(endpoint, new DefaultAzureCredential())`.
+/// Connection string in both dev (Azurite emulator) and prod, permanently —
+/// Free-tier SWA has no managed identity to grant table access to instead.
 ///
 /// If the connection string is empty the service exposes IsConfigured=false and
 /// every table handle throws. Callers must check the flag first.


### PR DESCRIPTION
## Summary
- README, `docs/deployment-secrets.md`, `docs/custom-domain.md`, `docs/first-deploy-runbook.md`, and 3 C# doc comments (`TableStore.cs`, `IBlobService.cs`, `BlobService.cs`) all referenced a managed-identity migration (#38/#41) that's now permanently abandoned since the SWA moved to Free tier.
- Updates them to describe connection-string auth as the permanent path, removes the incorrect Standard-tier custom-domain prerequisite, and drops the now-nonexistent RBAC role-assignment bullet from the deploy runbook.
- Doc/comment only — no behavior change.

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` — 251 passed
- [x] `npm run test:unit` — 400 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)