### PR TITLE
chore(api): upgrade Functions Worker + SDK to 2.x

### DIFF
--- a/src/api/Slypn.Api/Slypn.Api.csproj
+++ b/src/api/Slypn.Api/Slypn.Api.csproj
@@ -15,10 +15,10 @@
     <PackageReference Include="HttpMultipartParser" Version="8.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />


### PR DESCRIPTION
## Why

Core Tools 4.13.0 prints this on every host start, including in CI:

> Running 'func start' directly against a .NET Isolated project may not correctly load function extensions. Use 'dotnet run' instead, which builds the project and starts the Functions host from the correct output directory.

That advice was **unusable on the current packages**. `dotnet run` on Worker SDK 1.17.4 launches the *worker* rather than the host, and the worker dies immediately looking for a host that isn't there:

```
System.InvalidOperationException: The gRPC channel URI 'http://:' could not be parsed.
   at GrpcServiceCollectionExtensions.GetFunctionsHostGrpcUri(IConfiguration configuration)
```

The mechanism the message relies on is a `RunCommand`/`RunArguments` pair mapping `dotnet run` onto `func start`. I checked both SDK targets files: **1.17.4 doesn't define it; 2.1.0 does.** So adopting the guidance requires this upgrade first.

## What

| Package | From | To |
|---|---|---|
| `Microsoft.Azure.Functions.Worker` | 1.22.0 | 2.52.0 |
| `Microsoft.Azure.Functions.Worker.Sdk` | 1.17.4 | 2.1.0 |
| `Microsoft.Azure.Functions.Worker.Extensions.Http` | 3.1.0 | 3.3.0 |
| `Microsoft.Extensions.Options.ConfigurationExtensions` | 9.0.0 | 10.0.0 |

The last one is **required, not incidental**. The new resolution graph surfaced an `NU1605` downgrade error: OpenTelemetry 1.15.3 already pulls `Microsoft.Extensions.Logging.Configuration` 10.0.0, which wants `Options.ConfigurationExtensions >= 10.0.0`, while the project pinned 9.0.0.

**No source changes were needed.** `HostBuilder`, `ConfigureFunctionsWorkerDefaults`, both middlewares (`TracingMiddleware`, `JwtMiddleware`) and every `HttpRequestData` signature compile unchanged.

## Verification

Against a live host on Azurite, not just a build:

- **251/251 API tests pass**
- **`dotnet run` now starts Core Tools** and indexes all functions (healthy in 8s) — the point of the upgrade
- **Swagger survives** — `/api/swagger/ui`, `/api/swagger.json` and `/api/openapi/v3.json` all 200, and the document is fully populated (**26 paths, 39 operations**). This was the main risk: `Microsoft.Azure.Functions.Worker.Extensions.OpenApi` has no 2.x release and still declares a dependency on `Worker.Core >= 1.8.0`, so it's running against a major version it predates. It works, but it's the thing to watch.
- **Write path** — draft `PUT` → read-back → `DELETE` through Table + Blob storage
- **Auth intact** — dev persona resolves to the right principal (`authorId`/`authorName` correct on the stored draft), a `member` gets 403 on an Admin/Contributor route, `/me` returns `Contributor`/`active`

## Scope

Callers still use `func start` and are unaffected by this PR. Switching `scripts/startLocal.ps1` and the e2e harness (`e2e/support/backend.ts`, on #147) to `dotnet run` is deliberately left to follow-ups so each can be verified on its own — this PR is the dependency change alone.

Worth noting the two PRs touch no common files, so they can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgNGtwnw2NcfL6KuZRhrhb
