### PR TITLE
chore(dev): start the API with dotnet run; always upload e2e backend logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,19 @@ jobs:
 
       # Traces, videos and screenshots for the failing tests, plus the func and
       # azurite logs — a CI-only failure is near-undiagnosable without them.
+      # Backend logs go up even on success. They are small, and they are the
+      # only evidence of HOW the API ran — which configuration it built, which
+      # functions it indexed. Without them a green run cannot be distinguished
+      # from a green run that quietly did the wrong thing.
+      - name: Upload backend logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-backend-logs
+          path: .testresults/e2e-backend
+          retention-days: 7
+
+      # Traces, videos and screenshots are large, so only when something failed.
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
@@ -184,7 +197,6 @@ jobs:
           path: |
             src/web/playwright-report
             src/web/test-results
-            .testresults/e2e-backend
           retention-days: 7
 
   sonarcloud:

--- a/scripts/_lib.ps1
+++ b/scripts/_lib.ps1
@@ -34,6 +34,17 @@ function Test-Port($port) {
     return [bool](Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue)
 }
 
+# Kill a process and everything beneath it, depth-first.
+# The API host is a tree (dotnet -> cmd -> func -> worker), so killing only the
+# recorded PID, or only its direct children, leaves the listener alive and the
+# port bound.
+function Stop-ProcessTree($procId) {
+    if (-not $procId) { return }
+    $children = Get-CimInstance Win32_Process -Filter "ParentProcessId=$procId" -ErrorAction SilentlyContinue
+    foreach ($child in $children) { Stop-ProcessTree $child.ProcessId }
+    Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+}
+
 function Stop-Port($port) {
     $procIds = (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).OwningProcess
     foreach ($procId in ($procIds | Sort-Object -Unique)) {

--- a/scripts/startLocal.ps1
+++ b/scripts/startLocal.ps1
@@ -7,7 +7,7 @@
   Starts:
     - slypn-azurite (Docker)    blob/queue/table emulator on :10000-10002
     - vite (npm)                Vue dev server on http://localhost:5173/
-    - func (Functions Core)     .NET API host on http://localhost:7071/
+    - dotnet run (Functions)    .NET API host on http://localhost:7071/
 
   Emulator containers persist between start/stop cycles so seeded data
   survives. Use scripts/cleanLocal.ps1 to wipe them. Vite + func PIDs are
@@ -121,6 +121,11 @@ Show-Ok "vite PID $($webProc.Id), logging to $webLog"
 
 # --- API --------------------------------------------------------------------
 Show-Step 'Starting Functions host (API)'
+# Started via `dotnet run`, not `func start`: Core Tools warns that running it
+# directly against a .NET isolated project "may not correctly load function
+# extensions". The Worker SDK maps `dotnet run` onto `func start` with
+# RunWorkingDirectory set to the build output, which is the supported path.
+# `func` must still be on PATH — the SDK shells out to it.
 $funcExe = Resolve-WinExe 'func'
 if (-not $funcExe) {
     $funcHome = Join-Path $env:LOCALAPPDATA 'AzureFunctionsCoreTools'
@@ -128,16 +133,20 @@ if (-not $funcExe) {
     if (Test-Path $candidate) { $funcExe = $candidate }
 }
 if (-not $funcExe) {
-    Show-Err 'func not on PATH. Run setupLocal.ps1 first.'
+    Show-Err 'func not on PATH. The Functions SDK shells out to Core Tools, so it is still required. Run setupLocal.ps1 first.'
     Stop-Process -Id $webProc.Id -Force -ErrorAction SilentlyContinue
     exit 1
 }
-$apiProc = Start-Process -FilePath $funcExe -ArgumentList 'start' `
+# Debug (the dotnet run default) rather than Release: this is the interactive
+# dev stack, so fast incremental builds and debugger attach matter more than
+# matching the deployed configuration. The e2e suite uses Release for that.
+$apiProc = Start-Process -FilePath 'dotnet' `
+    -ArgumentList 'run', '--no-launch-profile', '--', '--port', "$ApiPort" `
     -WorkingDirectory $ApiDir `
     -RedirectStandardOutput $apiLog `
     -RedirectStandardError  "$apiLog.err" `
     -WindowStyle Hidden -PassThru
-Show-Ok "func PID $($apiProc.Id), logging to $apiLog"
+Show-Ok "dotnet run PID $($apiProc.Id), logging to $apiLog"
 
 @{ web = $webProc.Id; api = $apiProc.Id } | ConvertTo-Json | Out-File -FilePath $pidFile -Encoding UTF8
 

--- a/scripts/stopLocal.ps1
+++ b/scripts/stopLocal.ps1
@@ -36,10 +36,10 @@ if (Test-Path $pidFile) {
             $name = (Get-Process -Id $procId -ErrorAction SilentlyContinue).ProcessName
             if ($name) {
                 Write-Host "    killing PID $procId ($name) [$key]" -ForegroundColor DarkGray
-                Get-CimInstance Win32_Process |
-                    Where-Object { $_.ParentProcessId -eq $procId } |
-                    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-                Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+                # Whole tree, not just direct children: the API is now
+                # dotnet -> cmd -> func -> worker, so a one-level sweep would
+                # leave func holding the port and rely on Stop-Port to catch it.
+                Stop-ProcessTree $procId
             }
         }
     }


### PR DESCRIPTION
Two follow-ups from the e2e work (#147).

## `startLocal.ps1` → `dotnet run`

Core Tools warns on every start that running `func start` directly against a .NET isolated project *"may not correctly load function extensions"*. Worker SDK 2.x (merged in #148) maps `dotnet run` onto `func start` with `RunWorkingDirectory` set to the build output, which is the supported path.

`func` must still be on PATH — the SDK shells out to it — so the presence check stays; only its error message got clearer about why it's needed.

**Debug is kept here**, not Release. This is the interactive dev stack, where fast incremental builds and debugger attach matter more than matching the deployed configuration. The e2e suite uses Release for fidelity; local dev doesn't need to.

## `stopLocal.ps1` — recursive teardown

That change makes the process tree deeper:

```
dotnet.exe
  cmd.exe
    func.exe          <- holds port 7071
      dotnet.exe      <- worker
```

`stopLocal.ps1` killed only the recorded PID and its **direct children**, so `func` and the worker would have survived and kept 7071 bound. It happened to be caught by the `Stop-Port` sweep afterwards — luck, not design. Added `Stop-ProcessTree` to `_lib.ps1` and used that instead.

## CI: backend logs on success too

`api.log` (Azurite + func) previously uploaded only on failure, bundled with the Playwright report. It's now its own small artifact uploaded with `if: always()`.

They're the only record of *how* the API ran — which configuration it built, which functions it indexed. Without them a green run can't be told apart from a green run that quietly did the wrong thing, which is exactly the class of problem #147 exists to prevent. The heavy traces and videos stay failure-only.

## Verification

Ran the real thing rather than reasoning about it:

- `startLocal.ps1` brought the stack up on `dotnet run` — API and Vite both serving
- the process tree was four levels deep, as predicted
- `stopLocal.ps1` then reported **"Port 7071 free"**, meaning the recursive kill had already cleaned up and the port sweep found nothing left. That's the specific evidence the one-level version could not have produced.
- all three scripts parse clean; the workflow YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgNGtwnw2NcfL6KuZRhrhb
