### PR TITLE
refactor(api): separate the auth decision from rendering it, and cover the refusals

### DIFF
--- a/src/api/Slypn.Api.Tests/JwtMiddlewareTests.cs
+++ b/src/api/Slypn.Api.Tests/JwtMiddlewareTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Security.Claims;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Slypn.Api.Infrastructure;
@@ -8,20 +10,62 @@ namespace Slypn.Api.Tests;
 
 file sealed class StubJwtValidator : IJwtValidator
 {
-    public StubJwtValidator(bool isConfigured) => IsConfigured = isConfigured;
+    private readonly ClaimsPrincipal? _principal;
+    private readonly Exception? _throws;
+
+    /// <param name="principal">Returned on validation. Null means validation fails.</param>
+    /// <param name="throws">Exception to fail with; defaults to SecurityTokenException.</param>
+    public StubJwtValidator(bool isConfigured, ClaimsPrincipal? principal = null, Exception? throws = null)
+    {
+        IsConfigured = isConfigured;
+        _principal = principal;
+        _throws = throws;
+    }
+
     public bool IsConfigured { get; }
-    public Task<System.Security.Claims.ClaimsPrincipal> ValidateAsync(string token, CancellationToken ct)
-        => throw new Microsoft.IdentityModel.Tokens.SecurityTokenException("invalid");
+
+    /// The token the middleware actually chose — the only way to assert which
+    /// header won when several carry usable tokens.
+    public string? LastToken { get; private set; }
+
+    public Task<ClaimsPrincipal> ValidateAsync(string token, CancellationToken ct)
+    {
+        LastToken = token;
+        return _principal is not null
+            ? Task.FromResult(_principal)
+            : throw (_throws ?? new Microsoft.IdentityModel.Tokens.SecurityTokenException("invalid"));
+    }
 }
 
 public class JwtMiddlewareTests
 {
-    private static JwtMiddleware Make(bool skipAuth = false, bool validatorConfigured = true) =>
+    private static JwtMiddleware Make(
+        bool skipAuth = false,
+        bool validatorConfigured = true,
+        ClaimsPrincipal? principal = null,
+        Exception? validatorThrows = null,
+        FakeContentRepository? repo = null) =>
         new(
-            new StubJwtValidator(validatorConfigured),
+            new StubJwtValidator(validatorConfigured, principal, validatorThrows),
             Options.Create(new EntraOptions { SkipAuth = skipAuth }),
-            new FakeContentRepository(),
+            repo ?? new FakeContentRepository(),
             NullLogger<JwtMiddleware>.Instance);
+
+    private static ClaimsPrincipal PrincipalWith(params string[] roles)
+    {
+        var identity = new ClaimsIdentity("test", "name", "roles");
+        identity.AddClaim(new Claim("oid", "11111111-1111-1111-1111-111111111111"));
+        identity.AddClaim(new Claim("name", "Test User"));
+        foreach (var role in roles)
+            identity.AddClaim(new Claim("roles", role));
+        return new ClaimsPrincipal(identity);
+    }
+
+    /// A request carrying the given headers. AuthenticateAsync takes the request
+    /// directly, so no FunctionContext plumbing is needed.
+    private static TestHttpRequestData Request(params (string Name, string Value)[] headers) =>
+        new(new TestFunctionContext(), "GET", "http://localhost/api/review/articles", null,
+            headers.ToDictionary(h => h.Name, h => h.Value));
 
     // BlogFunctions.GetBlogPosts has no [RequireRole] → middleware must call next immediately.
     [Fact]
@@ -72,5 +116,195 @@ public class JwtMiddlewareTests
     public void PrincipalContextKey_is_stable()
     {
         Assert.Equal("Slypn.Principal", JwtMiddleware.PrincipalContextKey);
+    }
+
+    // ── Authentication decisions ─────────────────────────────────────────────
+    // None of these had any coverage. They are unreachable through Invoke() in a
+    // test — that needs IFunctionBindingsFeature, internal to the Worker SDK —
+    // and unreachable from e2e too, which runs with SkipAuth=true where a
+    // missing persona header resolves to the default admin persona.
+
+    private static readonly RequireRoleAttribute AdminOnly = new("Admin");
+    private static readonly RequireRoleAttribute AnyAuthenticated = new();
+
+    [Fact]
+    public async Task Unauthorized_when_no_token_is_present()
+    {
+        var result = await Make().AuthenticateAsync(Request(), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Unauthorized, result.RefusalCode);
+        Assert.Equal("Missing Bearer token.", result.RefusalMessage);
+    }
+
+    [Theory]
+    // No empty or whitespace-only case: HttpHeaders.Add rejects both with a
+    // FormatException, so such a header cannot reach the app at all. The
+    // IsNullOrWhiteSpace branch in ExtractBearer is therefore defensive only.
+    [InlineData("Basic abc")]              // wrong scheme
+    [InlineData("Bearer ")]                // scheme with no token
+    [InlineData("Bearer not-a-jwt")]       // unparseable
+    public async Task Unauthorized_when_the_authorization_header_is_unusable(string header)
+    {
+        var result = await Make().AuthenticateAsync(
+            Request(("Authorization", header)), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Unauthorized, result.RefusalCode);
+    }
+
+    [Fact]
+    public async Task Unauthorized_when_the_token_fails_validation()
+    {
+        // A structurally valid JWT with a kid, so it gets past ExtractBearer and
+        // actually reaches the validator.
+        var result = await Make().AuthenticateAsync(
+            Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Unauthorized, result.RefusalCode);
+        Assert.Contains("Invalid token", result.RefusalMessage);
+    }
+
+    [Fact]
+    public async Task Unauthorized_when_validation_throws_something_unexpected()
+    {
+        var result = await Make(validatorThrows: new InvalidOperationException("boom"))
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Unauthorized, result.RefusalCode);
+        Assert.Equal("Token validation error.", result.RefusalMessage);
+    }
+
+    [Fact]
+    public async Task ServiceUnavailable_when_auth_is_not_configured()
+    {
+        var result = await Make(validatorConfigured: false)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, result.RefusalCode);
+    }
+
+    [Fact]
+    public async Task Forbidden_when_the_token_is_valid_but_the_role_is_wrong()
+    {
+        var result = await Make(principal: PrincipalWith("Member"))
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Forbidden, result.RefusalCode);
+        Assert.Equal("Required role: Admin.", result.RefusalMessage);
+    }
+
+    [Fact]
+    public async Task Allows_when_the_token_is_valid_and_the_role_matches()
+    {
+        var result = await Make(principal: PrincipalWith("Admin"))
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.RefusalCode);
+        Assert.Contains(result.Principal!.Claims, c => c.Type == "roles" && c.Value == "Admin");
+    }
+
+    [Fact]
+    public async Task Allows_any_authenticated_caller_when_no_roles_are_listed()
+    {
+        // [RequireRole] with no roles means "signed in", used by /me and /whoami.
+        var result = await Make(principal: PrincipalWith("Member"))
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AnyAuthenticated, default);
+
+        Assert.True(result.IsAllowed);
+    }
+
+    [Fact]
+    public async Task Prefers_X_Slypn_Token_over_Authorization()
+    {
+        // SWA's gateway overwrites Authorization with its own session token. The
+        // real one arrives in X-Slypn-Token, and reading Authorization first
+        // would break every authenticated call in production while looking fine
+        // locally.
+        //
+        // Both headers carry a usable kid-bearing token here on purpose. If one
+        // were kid-less, ExtractBearer would skip it and fall through to the
+        // other, so the test would still pass with the precedence reversed and
+        // prove nothing. Asserting which token reached the validator is the only
+        // way to pin the ordering.
+        var authorizationToken = TokenWithKid("from-authorization");
+        var slypnToken = TokenWithKid("from-x-slypn-token");
+        var validator = new StubJwtValidator(true, PrincipalWith("Admin"));
+        var middleware = new JwtMiddleware(
+            validator,
+            Options.Create(new EntraOptions { SkipAuth = false }),
+            new FakeContentRepository(),
+            NullLogger<JwtMiddleware>.Instance);
+
+        var result = await middleware.AuthenticateAsync(
+            Request(("Authorization", $"Bearer {authorizationToken}"),
+                    ("X-Slypn-Token", $"Bearer {slypnToken}")),
+            AdminOnly, default);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal(slypnToken, validator.LastToken);
+    }
+
+    [Fact]
+    public async Task Ignores_a_kid_less_token_rather_than_sending_it_to_the_validator()
+    {
+        // SWA session tokens have no kid. They must be skipped, not forwarded —
+        // forwarding produces a confusing IDX10517 instead of a plain 401.
+        var result = await Make(principal: PrincipalWith("Admin"))
+            .AuthenticateAsync(Request(("Authorization", "Bearer swa.session.token")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal("Missing Bearer token.", result.RefusalMessage);
+    }
+
+    // ── Dev-persona path (SkipAuth) ──────────────────────────────────────────
+
+    [Fact]
+    public async Task SkipAuth_synthesises_the_requested_persona()
+    {
+        var result = await Make(skipAuth: true).AuthenticateAsync(
+            Request((DevPersonas.HeaderName, "contributor")), AnyAuthenticated, default);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal("22222222-2222-2222-2222-222222222222", result.Principal!.FindFirst("oid")?.Value);
+    }
+
+    [Fact]
+    public async Task SkipAuth_still_enforces_the_role_gate()
+    {
+        // The escape hatch bypasses token validation, not authorisation — this is
+        // what lets the e2e suite assert 403s per persona.
+        var result = await Make(skipAuth: true).AuthenticateAsync(
+            Request((DevPersonas.HeaderName, "member")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Forbidden, result.RefusalCode);
+    }
+
+    [Fact]
+    public async Task SkipAuth_falls_back_to_the_default_persona_without_a_header()
+    {
+        var result = await Make(skipAuth: true)
+            .AuthenticateAsync(Request(), AdminOnly, default);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal("11111111-1111-1111-1111-111111111111", result.Principal!.FindFirst("oid")?.Value);
+    }
+
+    /// <summary>An unsigned JWT carrying a kid header, so ExtractBearer accepts it
+    /// and the stub validator decides the outcome.</summary>
+    private static string TokenWithKid(string marker = "default")
+    {
+        static string Chunk(string json) =>
+            Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json))
+                .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        return $"{Chunk("{\"alg\":\"RS256\",\"kid\":\"test-key\"}")}." +
+               $"{Chunk($"{{\"oid\":\"{marker}\"}}")}.sig";
     }
 }

--- a/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
@@ -44,46 +44,63 @@ public sealed class JwtMiddleware(
             throw new InvalidOperationException("[RequireRole] is only supported on HTTP-triggered functions.");
         }
 
+        var result = await AuthenticateAsync(httpReq, attr, context.CancellationToken);
+
+        if (!result.IsAllowed)
+        {
+            await ShortCircuit(context, httpReq, result.RefusalCode!.Value, result.RefusalMessage!);
+            return;
+        }
+
+        context.Items[PrincipalContextKey] = result.Principal!;
+        await next(context);
+    }
+
+    /// <summary>
+    /// Decide whether this caller may run the function, without touching the
+    /// FunctionContext or writing anything. Returns the principal to run as, or
+    /// the refusal for <see cref="Invoke"/> to render.
+    ///
+    /// Deliberately free of FunctionContext. Writing a response needs
+    /// GetInvocationResult() and reading the request needs
+    /// GetHttpRequestDataAsync(); both go through IFunctionBindingsFeature,
+    /// which is internal to the Worker SDK and cannot be implemented from a test
+    /// assembly. Every refusal path was therefore unreachable in a unit test.
+    /// Separating the decision from rendering it makes them all testable.
+    /// </summary>
+    internal async Task<AuthResult> AuthenticateAsync(
+        HttpRequestData httpReq, RequireRoleAttribute attr, CancellationToken ct)
+    {
         // Local-dev escape hatch — synthesise a principal for the requested test
         // persona when SkipAuth=true. The role gate is still enforced below so the
         // member persona correctly gets 403 on Admin-only endpoints.
         if (options.Value.SkipAuth)
         {
-            await InvokeDevPersonaAsync(context, httpReq, attr, next);
-            return;
+            logger.LogWarning("AzureAd:SkipAuth=true — bypassing JWT validation. DO NOT use in production.");
+            return EnforceRole(attr, DevPrincipal(httpReq));
         }
 
         if (!validator.IsConfigured)
         {
-            await ShortCircuit(context, httpReq, HttpStatusCode.ServiceUnavailable,
+            return AuthResult.Refuse(HttpStatusCode.ServiceUnavailable,
                 "Auth is not configured. Set AzureAd__Authority / AzureAd__Audience or AzureAd__SkipAuth=true.");
-            return;
         }
 
         var token = ExtractBearer(httpReq);
         if (token is null)
-        {
-            await ShortCircuit(context, httpReq, HttpStatusCode.Unauthorized, "Missing Bearer token.");
-            return;
-        }
+            return AuthResult.Refuse(HttpStatusCode.Unauthorized, "Missing Bearer token.");
 
-        var principal = await ValidateTokenAsync(token, context, httpReq);
+        var (principal, tokenRefusal) = await ValidateTokenAsync(token, ct);
         if (principal is null)
-            return;
+            return tokenRefusal;
 
-        await EnrichRolesFromCosmosAsync(principal, context.CancellationToken);
+        await EnrichRolesFromCosmosAsync(principal, ct);
 
-        if (!await EnforceRoleAsync(context, httpReq, attr, principal))
-            return;
-
-        context.Items[PrincipalContextKey] = principal;
-        await next(context);
+        return EnforceRole(attr, principal);
     }
 
-    private async Task InvokeDevPersonaAsync(
-        FunctionContext context, HttpRequestData httpReq, RequireRoleAttribute attr, FunctionExecutionDelegate next)
+    private static ClaimsPrincipal DevPrincipal(HttpRequestData httpReq)
     {
-        logger.LogWarning("AzureAd:SkipAuth=true — bypassing JWT validation. DO NOT use in production.");
         var persona = DevPersonas.Resolve(GetHeader(httpReq, DevPersonas.HeaderName));
         var identity = new ClaimsIdentity("dev", "name", RolesClaimType);
         identity.AddClaim(new Claim("name",  persona.Name));
@@ -91,32 +108,25 @@ public sealed class JwtMiddleware(
         identity.AddClaim(new Claim("email", persona.Email));
         foreach (var role in persona.Roles)
             identity.AddClaim(new Claim(RolesClaimType, role));
-        var devPrincipal = new ClaimsPrincipal(identity);
-
-        if (!await EnforceRoleAsync(context, httpReq, attr, devPrincipal))
-            return;
-
-        context.Items[PrincipalContextKey] = devPrincipal;
-        await next(context);
+        return new ClaimsPrincipal(identity);
     }
 
-    private async Task<ClaimsPrincipal?> ValidateTokenAsync(string token, FunctionContext context, HttpRequestData httpReq)
+    private async Task<(ClaimsPrincipal? Principal, AuthResult Refusal)> ValidateTokenAsync(
+        string token, CancellationToken ct)
     {
         try
         {
-            return await validator.ValidateAsync(token, context.CancellationToken);
+            return (await validator.ValidateAsync(token, ct), default);
         }
         catch (SecurityTokenException ex)
         {
             logger.LogInformation(ex, "JWT validation failed: {Message}", ex.Message);
-            await ShortCircuit(context, httpReq, HttpStatusCode.Unauthorized, $"Invalid token: {ex.Message}");
-            return null;
+            return (null, AuthResult.Refuse(HttpStatusCode.Unauthorized, $"Invalid token: {ex.Message}"));
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Unexpected error validating JWT");
-            await ShortCircuit(context, httpReq, HttpStatusCode.Unauthorized, "Token validation error.");
-            return null;
+            return (null, AuthResult.Refuse(HttpStatusCode.Unauthorized, "Token validation error."));
         }
     }
 
@@ -142,16 +152,11 @@ public sealed class JwtMiddleware(
         }
     }
 
-    private static async Task<bool> EnforceRoleAsync(
-        FunctionContext context, HttpRequestData httpReq, RequireRoleAttribute attr, ClaimsPrincipal principal)
-    {
-        if (attr.Roles.Length == 0 || attr.Roles.Any(r => principal.IsInRole(r)))
-            return true;
-
-        await ShortCircuit(context, httpReq, HttpStatusCode.Forbidden,
-            $"Required role: {string.Join(" or ", attr.Roles)}.");
-        return false;
-    }
+    private static AuthResult EnforceRole(RequireRoleAttribute attr, ClaimsPrincipal principal) =>
+        attr.Roles.Length == 0 || attr.Roles.Any(r => principal.IsInRole(r))
+            ? AuthResult.Allow(principal)
+            : AuthResult.Refuse(HttpStatusCode.Forbidden,
+                $"Required role: {string.Join(" or ", attr.Roles)}.");
 
     private static RequireRoleAttribute? GetRoleAttribute(FunctionContext context)
     {
@@ -216,6 +221,22 @@ public sealed class JwtMiddleware(
         await resp.WriteStringAsync(message);
         context.GetInvocationResult().Value = resp;
     }
+}
+
+/// <summary>
+/// Outcome of an authentication + authorisation decision: either the principal
+/// to run as, or the status and message to refuse with. Exactly one is set.
+/// </summary>
+internal readonly record struct AuthResult(
+    ClaimsPrincipal? Principal,
+    HttpStatusCode? RefusalCode,
+    string? RefusalMessage)
+{
+    public static AuthResult Allow(ClaimsPrincipal principal) => new(principal, null, null);
+
+    public static AuthResult Refuse(HttpStatusCode code, string message) => new(null, code, message);
+
+    public bool IsAllowed => Principal is not null;
 }
 
 public static class FunctionContextExtensions

--- a/src/api/Slypn.Api/Slypn.Api.csproj
+++ b/src/api/Slypn.Api/Slypn.Api.csproj
@@ -9,6 +9,13 @@
     <UserSecretsId>slypn-api-dev</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <!-- JwtMiddleware.AuthenticateAsync and AuthResult are internal: the auth
+         decision is unit tested directly, because reaching it through Invoke()
+         needs IFunctionBindingsFeature, internal to the Worker SDK. -->
+    <InternalsVisibleTo Include="Slypn.Api.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />


### PR DESCRIPTION
Closes the 401 coverage gap flagged during the e2e work (#147, #150).

## Why it needed a refactor rather than just tests

Every refusal path in `JwtMiddleware` — 401, 403, 503 — had **no coverage at all**, and was unreachable by any means:

- Going through `Invoke()` needs `GetHttpRequestDataAsync()`
- Writing the response needs `GetInvocationResult()`

Both route through `IFunctionBindingsFeature`, which is **internal to the Worker SDK** and cannot be implemented from a test assembly. The e2e suite can't reach them either: it runs with `SkipAuth=true`, where a missing persona header resolves to the default admin persona.

I tried twice during #150 and reverted both attempts rather than ship something half-working. This is the fix they pointed at.

## The change

The decision moves into a method that takes no `FunctionContext` and writes nothing:

```csharp
internal async Task<AuthResult> AuthenticateAsync(
    HttpRequestData httpReq, RequireRoleAttribute attr, CancellationToken ct)
```

It returns either the principal to run as, or the status and message to refuse with. `Invoke` renders it. `ValidateTokenAsync` and `EnforceRole` become pure decisions too, and the dev-persona path returns a result instead of calling `next()` itself — so there is now exactly one place a principal is accepted and one place a refusal is written.

**Behaviour is unchanged**: same status codes, same messages, same logging, same ordering.

## Coverage

**15 new tests, 261 → 276.** Missing token, wrong scheme, unparseable token, validation failure, unexpected validator exception, unconfigured validator, wrong role, valid-and-allowed, roleless `[RequireRole]` (the `/me` and `/whoami` case), kid-less token skipping, header precedence, and the three `SkipAuth` persona paths.

## I checked the tests actually bite

Injecting regressions, each fails exactly one test:

| Injected regression | Caught by |
|---|---|
| `X-Slypn-Token` / `Authorization` precedence reversed | `Prefers_X_Slypn_Token_over_Authorization` |
| Role gate dropped | `Forbidden_when_the_token_is_valid_but_the_role_is_wrong` |

That first check earned its keep. **My initial precedence test was worthless**: with the order reversed, the kid-less token in `Authorization` is skipped by `ExtractBearer` and the call falls through to the right header, so it passed either way. It now gives both headers usable kid-bearing tokens and asserts which one reached the validator. That regression would break every authenticated call in production while looking fine locally — SWA's gateway overwrites `Authorization`, and only production has a gateway.

## One thing deliberately not covered

No empty or whitespace-only `Authorization` case: `HttpHeaders.Add` rejects both with `FormatException`, so such a header cannot reach the app at all. The `IsNullOrWhiteSpace` branch in `ExtractBearer` is defensive only — noted in the test rather than faked.

## Verification

- **276 API tests**
- **122 e2e** against a live host, confirming the refactor preserved real behaviour end to end

An earlier e2e run showed 7 failures, all `Tearing down "context" exceeded the test timeout` — resource contention from ~20 stray processes left by manual host testing, not assertion failures. Cleaned and re-ran: 122/122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgNGtwnw2NcfL6KuZRhrhb
