### PR TITLE
perf(e2e): run the CI suite on 3 workers

### DIFF
--- a/src/web/playwright.config.ts
+++ b/src/web/playwright.config.ts
@@ -21,8 +21,12 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  // One Functions host serves every worker, so more workers mostly queue.
-  workers: process.env.CI ? 2 : 4,
+  // Every worker shares one Functions host and one Azurite, so this scales with
+  // contention rather than cores. 3 on CI (4-vCPU runners) was measured against
+  // 2: the test phase is the largest single slice of the job, but the ceiling is
+  // low — beyond roughly 20s faster the SonarCloud job becomes the critical path
+  // instead, so there is nothing to win by pushing it higher.
+  workers: process.env.CI ? 3 : 4,
   timeout: 60_000,
   expect: { timeout: 10_000 },
 


### PR DESCRIPTION
## Where CI time actually goes

Measured rather than guessed. Wall clock is ~190s, and **e2e is the critical path by only ~19s**:

```
t=0    web, api, e2e all start (no needs:)
t=50   web (49s) and api (46s) finish; sonarcloud starts
t=170  sonarcloud finishes
t=189  e2e finishes   ◄── critical path
```

E2E job breakdown (189s):

| Step | Time |
|---|---|
| Setup, caches, `npm ci`, Chromium | ~41s |
| Install Core Tools | 17s |
| **Run e2e suite** | **123s** |
| — backend startup → API healthy | 30s |
| — 122 tests, 2 workers | **83s** |

The test phase is the largest single slice and the only one with real headroom.

## The change

CI workers 2 → 3. Runners have 4 vCPU, but every worker shares one Functions host and one Azurite, so this scales with **contention**, not cores — 4 would likely just queue.

## The ceiling is low, and that's the point

Once e2e drops below ~170s, **SonarCloud becomes the critical path instead**. So this is worth ~20s and then the well is dry. I'd rather say that up front than keep filing micro-optimisation PRs against a job that has stopped mattering.

For the same reason I'm *not* proposing:

- **Caching Core Tools** — the archive is ~600 MB; restoring it from cache likely costs about as much as the 17s download
- **Sharding e2e** — halves 83s of tests but pays another ~57s of setup on the second runner. Net loss
- **`--no-build` on `dotnet test`** — saves 5–10s in a job that finishes at 46s and isn't on the critical path
- **Dropping SonarCloud's `needs: [web, api]`** — it idles ~50s, but genuinely needs those coverage artifacts

## Treat this as an experiment

Under contention the failure mode is Playwright **teardown timeouts**, not assertion failures — I saw exactly that locally when stray processes accumulated, and it cost a confusing 12-minute run before I spotted the cause.

If this run or the next few show any flakiness, **revert to 2 rather than adding retries to mask it**. Flaky CI costs far more than 25 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgNGtwnw2NcfL6KuZRhrhb
