### PR TITLE
fix(api): make publishing Admin-only on article create and replace

### DIFF
--- a/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
@@ -110,7 +110,7 @@ public class ArticlesFunctionsTests
         repo.Writes = false;
         var ctx = new TestFunctionContext();
         var req = TestHttp.Json(ctx, "POST", "http://localhost/api/articles", new { });
-        var resp = (TestHttpResponseData)await fn.Create(req, Ct);
+        var resp = (TestHttpResponseData)await fn.Create(req, ctx, Ct);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
     }
 
@@ -120,7 +120,7 @@ public class ArticlesFunctionsTests
         var (fn, _) = Make();
         var ctx = new TestFunctionContext();
         var req = TestHttp.Json(ctx, "POST", "http://localhost/api/articles", new { title = "x" });
-        var resp = (TestHttpResponseData)await fn.Create(req, Ct);
+        var resp = (TestHttpResponseData)await fn.Create(req, ctx, Ct);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
@@ -136,7 +136,7 @@ public class ArticlesFunctionsTests
             category = "Community", status = "draft",
         };
         var req = TestHttp.Json(ctx, "POST", "http://localhost/api/articles", input);
-        var resp = (TestHttpResponseData)await fn.Create(req, Ct);
+        var resp = (TestHttpResponseData)await fn.Create(req, ctx, Ct);
         Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
         Assert.Equal("new-id", resp.ReadBodyAs<Article>()!.Id);
     }
@@ -188,11 +188,11 @@ public class ArticlesFunctionsTests
             category = "Community", status = "draft",
         };
 
-        var disabled = (TestHttpResponseData)await fn.Replace(TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", input), "a1", Ct);
+        var disabled = (TestHttpResponseData)await fn.Replace(TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", input), ctx, "a1", Ct);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, disabled.StatusCode);
 
         repo.Writes = true;
-        var ok = (TestHttpResponseData)await fn.Replace(TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", input), "a1", Ct);
+        var ok = (TestHttpResponseData)await fn.Replace(TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", input), ctx, "a1", Ct);
         Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
     }
 
@@ -201,7 +201,7 @@ public class ArticlesFunctionsTests
     {
         var (fn, _) = Make();
         var ctx = new TestFunctionContext();
-        var resp = (TestHttpResponseData)await fn.Replace(TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", new { }), "a1", Ct);
+        var resp = (TestHttpResponseData)await fn.Replace(TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", new { }), ctx, "a1", Ct);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
@@ -287,7 +287,7 @@ public class ArticlesFunctionsTests
         var (fn, repo) = Make();
         repo.ThrowOnWrite = new RequestFailedException(412, "Precondition failed");
         var ctx = new TestFunctionContext();
-        var resp = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ValidArticleInput()), Ct);
+        var resp = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ValidArticleInput()), ctx, Ct);
         Assert.Equal(HttpStatusCode.PreconditionFailed, resp.StatusCode);
     }
 
@@ -297,7 +297,7 @@ public class ArticlesFunctionsTests
         var (fn, repo) = Make();
         repo.ThrowOnWrite = new RequestFailedException(409, "Conflict");
         var ctx = new TestFunctionContext();
-        var resp = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ValidArticleInput()), Ct);
+        var resp = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ValidArticleInput()), ctx, Ct);
         Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
     }
 
@@ -307,7 +307,7 @@ public class ArticlesFunctionsTests
         var (fn, repo) = Make();
         repo.ThrowOnWrite = new RequestFailedException(500, "Internal storage error");
         var ctx = new TestFunctionContext();
-        var resp = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ValidArticleInput()), Ct);
+        var resp = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ValidArticleInput()), ctx, Ct);
         Assert.Equal(HttpStatusCode.InternalServerError, resp.StatusCode);
     }
 
@@ -339,7 +339,7 @@ public class ArticlesFunctionsTests
         var (fn, _) = Make();
         var ctx = new TestFunctionContext();
         var req = TestHttp.Raw(ctx, "POST", "http://localhost/api/articles", "not-json");
-        var resp = (TestHttpResponseData)await fn.Create(req, Ct);
+        var resp = (TestHttpResponseData)await fn.Create(req, ctx, Ct);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
@@ -352,7 +352,7 @@ public class ArticlesFunctionsTests
         var resp = (TestHttpResponseData)await fn.Replace(
             TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", ValidArticleInput(),
                 new Dictionary<string, string> { ["If-Match"] = "\"etag-1\"" }),
-            "a1", Ct);
+            ctx, "a1", Ct);
         Assert.Equal(HttpStatusCode.PreconditionFailed, resp.StatusCode);
     }
 
@@ -434,5 +434,126 @@ public class ArticlesFunctionsTests
         var err = (TestHttpResponseData)await fn.Revise(
             TestHttp.Json(ctx, "POST", "http://localhost/api/articles/a1/revise", validFeedback), "a1", Ct);
         Assert.Equal(HttpStatusCode.PreconditionFailed, err.StatusCode);
+    }
+
+    // ── SEC-2: publishing is Admin-only ─────────────────────────────────────
+    // Create/Replace took Status straight from the request body, validated only
+    // against the enum in ArticleInput. A Contributor could POST status=published
+    // and go live without review, or PUT over an existing published article —
+    // even though Publish and Delete are both [RequireRole("Admin")].
+
+    private static object ArticleInputWith(string status) => new
+    {
+        slug = "valid-slug", title = "A valid title", summary = "A long enough summary.",
+        body = "Body content long enough.", author = "Jane", readingMinutes = 5,
+        category = "Community", status,
+    };
+
+    private static TestFunctionContext Contributor() =>
+        new TestFunctionContext().WithUser("oid-contrib", "Carla", "Contributor");
+
+    private static TestFunctionContext Admin() =>
+        new TestFunctionContext().WithUser("oid-admin", "Ada", "Admin");
+
+    [Theory]
+    [InlineData("published")]
+    [InlineData("rejected")]
+    public async Task Create_forbids_non_admin_setting_admin_only_status(string status)
+    {
+        var (fn, repo) = Make();
+        // Throwing on write proves the refusal happens BEFORE the repository is
+        // touched — a 403 here cannot be the storage error path in disguise.
+        repo.ThrowOnWrite = new RequestFailedException(500, "should not be reached");
+        var ctx = Contributor();
+
+        var resp = (TestHttpResponseData)await fn.Create(
+            TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ArticleInputWith(status)), ctx, Ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Contains("Only an Admin", resp.ReadBodyAsString());
+    }
+
+    [Theory]
+    [InlineData("draft")]
+    [InlineData("in-review")]
+    public async Task Create_allows_non_admin_to_file_for_review(string status)
+    {
+        var (fn, _) = Make();
+        var ctx = Contributor();
+
+        var resp = (TestHttpResponseData)await fn.Create(
+            TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ArticleInputWith(status)), ctx, Ct);
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_allows_admin_to_publish_directly()
+    {
+        var (fn, _) = Make();
+        var ctx = Admin();
+
+        var resp = (TestHttpResponseData)await fn.Create(
+            TestHttp.Json(ctx, "POST", "http://localhost/api/articles", ArticleInputWith("published")), ctx, Ct);
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Replace_forbids_non_admin_setting_published()
+    {
+        var (fn, _) = Make();
+        var ctx = Contributor();
+
+        var resp = (TestHttpResponseData)await fn.Replace(
+            TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", ArticleInputWith("published")),
+            ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Replace_forbids_non_admin_overwriting_a_published_article()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample("a1");           // a1 exists in the published partition
+        repo.ThrowOnWrite = new RequestFailedException(500, "should not be reached");
+        var ctx = Contributor();
+
+        var resp = (TestHttpResponseData)await fn.Replace(
+            TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", ArticleInputWith("draft")),
+            ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Equal("published", repo.LastArticleLookupStatus);
+        Assert.Contains("/edit", resp.ReadBodyAsString());
+    }
+
+    [Fact]
+    public async Task Replace_allows_admin_to_overwrite_a_published_article()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample("a1");
+        var ctx = Admin();
+
+        var resp = (TestHttpResponseData)await fn.Replace(
+            TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", ArticleInputWith("published")),
+            ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Replace_allows_non_admin_when_the_article_is_not_published()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = null;                   // nothing in the published partition
+        var ctx = Contributor();
+
+        var resp = (TestHttpResponseData)await fn.Replace(
+            TestHttp.Json(ctx, "PUT", "http://localhost/api/articles/a1", ArticleInputWith("in-review")),
+            ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }
 }

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -169,7 +169,19 @@ internal sealed class FakeContentRepository : IContentRepository
         => Task.FromResult(Guard(MakeArticle(id, null)));
     public Task<Article> CancelArticleDeletionAsync(string id, CancellationToken ct)
         => Task.FromResult(Guard(MakeArticle(id, null)));
-    public Task<Article?> GetArticleAsync(string id, string status, CancellationToken ct) => Task.FromResult<Article?>(MakeArticle(id, null));
+    /// <summary>Article returned by <see cref="GetArticleAsync"/>. Null by default so a
+    /// lookup means "no article in that partition" — set it to make one exist, e.g. to
+    /// stand up a published article that a non-Admin must not be allowed to replace.</summary>
+    public Article? ArticleByIdAndStatus;
+
+    /// <summary>Status the last <see cref="GetArticleAsync"/> call asked for.</summary>
+    public string? LastArticleLookupStatus { get; private set; }
+
+    public Task<Article?> GetArticleAsync(string id, string status, CancellationToken ct)
+    {
+        LastArticleLookupStatus = status;
+        return Task.FromResult(ArticleByIdAndStatus);
+    }
     public Task<Article> PublishArticleAsync(string id, CancellationToken ct) => Task.FromResult(Guard(MakeArticle(id, null)));
     public Task<Draft> ReviseArticleAsync(string id, string feedback, CancellationToken ct)
         => Task.FromResult(Guard(MakeDraft(id, "oid", "name") with { RevisionFeedback = feedback }));

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -17,6 +17,32 @@ namespace Slypn.Api.Functions;
 public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sanitizer, ILogger<ArticlesFunctions> log)
 {
     /// <summary>
+    /// Statuses a non-Admin caller may set on an article. Publishing is deliberately
+    /// Admin-only — it goes through POST /articles/{id}/publish — and "rejected" is the
+    /// other half of that same review decision. Without this, Contributors could set
+    /// status=published straight from the create/replace body and skip review entirely.
+    /// </summary>
+    private static readonly HashSet<string> AuthorSettableStatuses =
+        new(StringComparer.OrdinalIgnoreCase) { "draft", InReviewStatus };
+
+    private const string PublishedReplaceRefusal =
+        "This article is published — only an Admin can replace it. "
+        + "Use POST /api/articles/{id}/edit to propose a revision, which keeps the live version up until an Admin approves.";
+
+    /// <summary>
+    /// Returns the refusal message when <paramref name="status"/> is out of bounds for this
+    /// caller, or null when the write may proceed.
+    ///
+    /// Refusing beats silently downgrading the status: an author who asked to publish should
+    /// be told the request was denied, not left to discover a different status later.
+    /// </summary>
+    private static string? StatusRefusal(FunctionContext context, string status) =>
+        context.IsAdmin() || AuthorSettableStatuses.Contains(status)
+            ? null
+            : $"Only an Admin can set status '{status}'. Submit the article for review instead, "
+              + "then ask an Admin to publish it via POST /api/articles/{id}/publish.";
+
+    /// <summary>
     /// Public article list. Always published — the caller cannot widen this.
     ///
     /// The status filter used to come from the query string, which meant an
@@ -82,14 +108,20 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(ArticleInput), Required = true, Description = "Article payload.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(Article), Description = "Created article")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Forbidden, Description = "Non-Admin caller asked for a status only an Admin may set")]
     public async Task<HttpResponseData> Create(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles")] HttpRequestData req,
+        FunctionContext context,
         CancellationToken ct)
     {
         if (!repo.SupportsWrites) return await WritesDisabled(req);
         var (input, err) = await ReadValidatedAsync<ArticleInput>(req, ct);
         if (err is not null) return err;
-        input!.Body = sanitizer.Sanitize(input.Body);
+
+        if (StatusRefusal(context, input!.Status) is { } refusal)
+            return await Forbidden(req, refusal);
+
+        input.Body = sanitizer.Sanitize(input.Body);
         try
         {
             var article = await repo.CreateArticleAsync(input, ct);
@@ -105,16 +137,27 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Article id.")]
     [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(ArticleInput), Required = true, Description = "Article payload.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article), Description = "Updated article")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Forbidden, Description = "Non-Admin caller asked for an Admin-only status, or targeted a published article")]
     public async Task<HttpResponseData> Replace(
         [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "articles/{id}")] HttpRequestData req,
+        FunctionContext context,
         string id, CancellationToken ct)
     {
         if (!repo.SupportsWrites) return await WritesDisabled(req);
         var (input, err) = await ReadValidatedAsync<ArticleInput>(req, ct);
         if (err is not null) return err;
-        input!.Body = sanitizer.Sanitize(input.Body);
+
+        if (StatusRefusal(context, input!.Status) is { } refusal)
+            return await Forbidden(req, refusal);
+
+        input.Body = sanitizer.Sanitize(input.Body);
         try
         {
+            // Live content is Admin-only. Contributors revise a published article through
+            // POST /articles/{id}/edit, which drafts the change instead of overwriting it.
+            if (!context.IsAdmin() && await repo.GetArticleAsync(id, PublishedStatus, ct) is not null)
+                return await Forbidden(req, PublishedReplaceRefusal);
+
             var article = await repo.ReplaceArticleAsync(id, input, IfMatch(req), ct);
             return await Ok(req, article, article.Etag);
         }

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -18,7 +18,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
 {
     /// <summary>
     /// Statuses a non-Admin caller may set on an article. Publishing is deliberately
-    /// Admin-only — it goes through POST /articles/{id}/publish — and "rejected" is the
+    /// Admin-only — it goes through POST /api/articles/{id}/publish — and "rejected" is the
     /// other half of that same review decision. Without this, Contributors could set
     /// status=published straight from the create/replace body and skip review entirely.
     /// </summary>

--- a/src/web/e2e/support/data.ts
+++ b/src/web/e2e/support/data.ts
@@ -47,6 +47,10 @@ export function draftId(): string {
  * A published article with no authorId — the shape `POST /api/articles`
  * produces. Fine for public browsing; NOT visible to a contributor in
  * /admin/content, which filters on `authorId === auth.oid`.
+ *
+ * Pass an ADMIN api client: setting status=published on create is Admin-only,
+ * so a contributor persona gets 403 here. Use publishAuthoredArticle below for
+ * content that has to belong to a contributor.
  */
 export async function createPublishedArticle(
   api: ApiClient,


### PR DESCRIPTION
Fixes the second High finding from the August 2026 security review, tracked privately as
advisory `GHSA-jrg4-83c2-6jh6`.

## The problem

`POST /api/articles` and `PUT /api/articles/{id}` are open to Contributors, but both took
`Status` straight from the request body. `ArticleInput` validates it only against the enum:

```csharp
[Required, RegularExpression("^(draft|in-review|published|rejected)$")]
public string Status { get; set; } = "draft";
```

`published` is an accepted value and `ContentRepository` writes it through as the partition key,
so a Contributor could publish without review. `Replace` had no guard on the target either — a
Contributor could `PUT` over any published article, including one they didn't write.

Both bypass a boundary the code clearly intends: `PublishArticle` and `DeleteArticle` are
`[RequireRole("Admin")]`, and Contributors have `POST /articles/{id}/edit` for revising live work.

## The fix

- `Create` and `Replace` take `FunctionContext` — the parameter pattern `DraftsFunctions.Upsert`
  already uses — and check the existing `FunctionContextExtensions.IsAdmin()` helper.
- Non-Admins may set only `draft` or `in-review`; `published`/`rejected` returns **403** naming
  the publish endpoint.
- `Replace` also refuses a non-Admin whose target is already published, pointing at
  `POST /articles/{id}/edit`.

Refusing beats silently downgrading the status: an author who asked to publish is told the
request was denied rather than discovering a different status later.

## Blast radius

The Vue app never calls either endpoint — authoring runs draft → submit → publish throughout — so
this only tightens the direct API surface. In e2e, `publishAuthoredArticle` uses the proper flow
and is unaffected; `createPublishedArticle` sets `status: published` but has no callers, so it's
now documented as needing an Admin client.

## Tests

9 new cases in `ArticlesFunctionsTests.cs`: both refusals, both Admin paths, and the
Contributor-still-works paths. Two set `ThrowOnWrite` to a 500 so a passing 403 can't quietly be
the storage-error path instead of the authorisation check.

`FakeContentRepository.GetArticleAsync` returned an article unconditionally; it's now a settable
`ArticleByIdAndStatus` defaulting to null, which is what let the published-target case be tested
at all.

**Verified**: API 285/285, web 400/400, `npm run lint` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
