### PR TITLE
fix(api): make the members table authoritative for roles

### DIFF
--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -139,7 +139,15 @@ internal sealed class FakeContentRepository : IContentRepository
         if (ThrowOnRead is not null) throw ThrowOnRead;
         return Task.FromResult(MemberById);
     }
-    public Task<Member?> GetMemberByOidAsync(string oid, CancellationToken ct) => Task.FromResult(MemberByOid);
+    /// <summary>Set to fail the OID member lookup specifically, without disturbing the
+    /// other reads. Exercises JwtMiddleware's "storage is down" fallback.</summary>
+    public Exception? ThrowOnMemberLookup { get; set; }
+
+    public Task<Member?> GetMemberByOidAsync(string oid, CancellationToken ct)
+    {
+        if (ThrowOnMemberLookup is not null) throw ThrowOnMemberLookup;
+        return Task.FromResult(MemberByOid);
+    }
     public Task<IReadOnlyList<Member>> ListMembersAsync(CancellationToken ct)
     {
         if (ThrowOnRead is not null) throw ThrowOnRead;

--- a/src/api/Slypn.Api.Tests/JwtMiddlewareTests.cs
+++ b/src/api/Slypn.Api.Tests/JwtMiddlewareTests.cs
@@ -416,4 +416,35 @@ public class JwtMiddlewareTests
 
         Assert.True(result.IsAllowed);
     }
+
+    [Fact]
+    public async Task No_caller_holds_a_role_when_storage_is_unconfigured()
+    {
+        // Raised in review of #163: returning early here left the token's roles intact,
+        // so a deployment missing its storage connection string would silently fall back
+        // to Entra app-role assignments — the exact authority this change moves away from.
+        var repo = new FakeContentRepository { Writes = false, MemberByOid = MemberWith("Admin") };
+
+        var result = await Make(principal: PrincipalWith("Admin"), repo: repo)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Forbidden, result.RefusalCode);
+    }
+
+    [Fact]
+    public async Task A_token_without_an_oid_claim_holds_no_roles()
+    {
+        // Nothing to look a member up by, so membership cannot be confirmed.
+        var identity = new ClaimsIdentity("test", "name", "roles");
+        identity.AddClaim(new Claim("name", "No Oid"));
+        identity.AddClaim(new Claim("roles", "Admin"));
+        var repo = new FakeContentRepository { MemberByOid = MemberWith("Admin") };
+
+        var result = await Make(principal: new ClaimsPrincipal(identity), repo: repo)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Forbidden, result.RefusalCode);
+    }
 }

--- a/src/api/Slypn.Api.Tests/JwtMiddlewareTests.cs
+++ b/src/api/Slypn.Api.Tests/JwtMiddlewareTests.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
 using Slypn.Api.Services;
 using Xunit;
 
@@ -201,7 +202,10 @@ public class JwtMiddlewareTests
     [Fact]
     public async Task Allows_when_the_token_is_valid_and_the_role_matches()
     {
-        var result = await Make(principal: PrincipalWith("Admin"))
+        // The member row is what carries the role — the table is authoritative, so a
+        // valid token on its own no longer grants anything (see the SEC-3 tests below).
+        var repo = new FakeContentRepository { MemberByOid = MemberWith("Admin") };
+        var result = await Make(principal: PrincipalWith("Admin"), repo: repo)
             .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
 
         Assert.True(result.IsAllowed);
@@ -238,7 +242,7 @@ public class JwtMiddlewareTests
         var middleware = new JwtMiddleware(
             validator,
             Options.Create(new EntraOptions { SkipAuth = false }),
-            new FakeContentRepository(),
+            new FakeContentRepository { MemberByOid = MemberWith("Admin") },
             NullLogger<JwtMiddleware>.Instance);
 
         var result = await middleware.AuthenticateAsync(
@@ -306,5 +310,110 @@ public class JwtMiddlewareTests
 
         return $"{Chunk("{\"alg\":\"RS256\",\"kid\":\"test-key\"}")}." +
                $"{Chunk($"{{\"oid\":\"{marker}\"}}")}.sig";
+    }
+
+    // ── SEC-3: the members table is authoritative for roles ──────────────────
+
+    private static Member MemberWith(params string[] roles) => new(
+        Id:          "m1",
+        Email:       "test.user@example.com",
+        DisplayName: "Test User",
+        Roles:       roles,
+        Status:      "active",
+        InvitedAt:   DateTime.UtcNow.AddDays(-30),
+        AcceptedAt:  DateTime.UtcNow.AddDays(-29),
+        InvitedBy:   "oid-admin",
+        Oid:         "11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task Demoting_a_member_in_the_table_revokes_the_role_from_a_stale_JWT()
+    {
+        // Roles can arrive from two places: Entra app-role assignments baked into
+        // the JWT, and the members table. Enrichment unioned them, so demoting
+        // someone in the table left their old JWT role effective until the token
+        // expired — the table was documented as the source of truth but could only
+        // ever grant, never revoke.
+        var repo = new FakeContentRepository { MemberByOid = MemberWith("Member") };
+
+        var result = await Make(principal: PrincipalWith("Admin"), repo: repo)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Forbidden, result.RefusalCode);
+    }
+
+    [Fact]
+    public async Task Table_roles_replace_JWT_roles_rather_than_adding_to_them()
+    {
+        // The claim set itself, not just the access decision: a stale role left on
+        // the principal would still reach anything reading claims directly, such as
+        // FunctionContextExtensions.IsAdmin().
+        var repo = new FakeContentRepository { MemberByOid = MemberWith("Contributor") };
+
+        var result = await Make(principal: PrincipalWith("Admin"), repo: repo)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AnyAuthenticated, default);
+
+        Assert.True(result.IsAllowed);
+        var roles = result.Principal!.FindAll("roles").Select(c => c.Value).ToArray();
+        Assert.Equal(new[] { "Contributor" }, roles);
+    }
+
+    [Fact]
+    public async Task Table_roles_are_granted_when_the_JWT_carries_none()
+    {
+        // The original purpose of enrichment: roles live in the table, not in Entra.
+        var repo = new FakeContentRepository { MemberByOid = MemberWith("Admin") };
+
+        var result = await Make(principal: PrincipalWith(), repo: repo)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.True(result.IsAllowed);
+        Assert.Contains(result.Principal!.Claims, c => c.Type == "roles" && c.Value == "Admin");
+    }
+
+    [Fact]
+    public async Task A_caller_with_no_member_record_holds_no_roles()
+    {
+        // Fail-closed: a valid CIAM token proves identity, not membership. Someone
+        // holding an Entra app-role assignment but no member row gets nothing.
+        var repo = new FakeContentRepository { MemberByOid = null };
+
+        var result = await Make(principal: PrincipalWith("Admin"), repo: repo)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(HttpStatusCode.Forbidden, result.RefusalCode);
+    }
+
+    [Fact]
+    public async Task A_caller_with_no_member_record_can_still_reach_the_relink_endpoints()
+    {
+        // The escape hatch that makes fail-closed survivable. /me and /whoami carry
+        // [RequireRole] with no roles listed, so they stay reachable with none — and
+        // GET /me is what re-links a stale OID by email and restores the roles.
+        var repo = new FakeContentRepository { MemberByOid = null };
+
+        var result = await Make(principal: PrincipalWith("Admin"), repo: repo)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AnyAuthenticated, default);
+
+        Assert.True(result.IsAllowed);
+        Assert.Empty(result.Principal!.FindAll("roles"));
+    }
+
+    [Fact]
+    public async Task A_storage_failure_falls_back_to_the_tokens_roles()
+    {
+        // Availability over strictness on the error path only: stripping roles when
+        // the table is unreachable would turn a transient storage fault into a
+        // site-wide lockout for every member at once.
+        var repo = new FakeContentRepository
+        {
+            ThrowOnMemberLookup = new InvalidOperationException("table storage unreachable"),
+        };
+
+        var result = await Make(principal: PrincipalWith("Admin"), repo: repo)
+            .AuthenticateAsync(Request(("Authorization", $"Bearer {TokenWithKid()}")), AdminOnly, default);
+
+        Assert.True(result.IsAllowed);
     }
 }

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -154,7 +154,7 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
         try
         {
             // Live content is Admin-only. Contributors revise a published article through
-            // POST /articles/{id}/edit, which drafts the change instead of overwriting it.
+            // POST /api/articles/{id}/edit, which drafts the change instead of overwriting it.
             if (!context.IsAdmin() && await repo.GetArticleAsync(id, PublishedStatus, ct) is not null)
                 return await Forbidden(req, PublishedReplaceRefusal);
 

--- a/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
@@ -23,6 +23,7 @@ public sealed class JwtMiddleware(
 
     public const string PrincipalContextKey = "Slypn.Principal";
     private const string RolesClaimType = "roles";
+    private const string NameClaimType = "name";
 
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
@@ -94,7 +95,7 @@ public sealed class JwtMiddleware(
         if (principal is null)
             return tokenRefusal;
 
-        await EnrichRolesFromCosmosAsync(principal, ct);
+        principal = await ApplyTableRolesAsync(principal, ct);
 
         return EnforceRole(attr, principal);
     }
@@ -130,26 +131,55 @@ public sealed class JwtMiddleware(
         }
     }
 
-    private async Task EnrichRolesFromCosmosAsync(ClaimsPrincipal principal, CancellationToken ct)
+    /// <summary>
+    /// Return the caller as the members table says they are. The table is the source of
+    /// truth for roles: an admin grants them through PATCH /api/members/{id}, not through
+    /// an Entra app-role assignment.
+    ///
+    /// Replacing the roles rather than adding to them is the whole point. This used to
+    /// only ever add, so demoting someone in the table left their old JWT role effective
+    /// until the token expired — the table could grant a role but never take one back.
+    ///
+    /// A caller with no member row ends up with no roles. A valid CIAM token proves who
+    /// someone is, not that they belong to SLYPN. Note that the stored OID can go stale:
+    /// personal Microsoft accounts are issued a different oid than az-cli reports, so a
+    /// seeded record can miss here. GET /me re-links such a record by email, which
+    /// restores the roles from the next request onward.
+    /// </summary>
+    private async Task<ClaimsPrincipal> ApplyTableRolesAsync(ClaimsPrincipal principal, CancellationToken ct)
     {
-        // Enrich principal with Cosmos roles (source of truth — overrides any JWT roles).
         if (!repo.SupportsWrites || principal.FindFirst("oid")?.Value is not { Length: > 0 } callerOid)
-            return;
+            return principal;
 
+        IReadOnlyList<string> roles;
         try
         {
             var member = await repo.GetMemberByOidAsync(callerOid, ct);
-            if (member?.Roles is { Count: > 0 } cosmosRoles
-                && principal.Identity is ClaimsIdentity identity)
-            {
-                foreach (var role in cosmosRoles.Where(role => !identity.HasClaim(RolesClaimType, role)))
-                    identity.AddClaim(new Claim(RolesClaimType, role));
-            }
+            if (member is null)
+                logger.LogWarning("No member record for OID {Oid} — treating the caller as having no roles.", callerOid);
+            roles = member?.Roles ?? [];
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Cosmos role enrichment failed for OID {Oid}", callerOid);
+            // Storage is unreachable. Fall back to the token's own roles rather than
+            // signing every member out of the site over a transient storage fault —
+            // stripping roles here would turn a blip into a site-wide outage.
+            logger.LogWarning(ex, "Role lookup failed for OID {Oid}; falling back to the token's roles", callerOid);
+            return principal;
         }
+
+        // Rebuilt rather than mutated: ClaimsIdentity.RemoveClaim only accepts claims the
+        // identity itself owns, and claims arriving from the token handler need not be, so
+        // removal in place can throw and leave a stale role attached.
+        var identity = new ClaimsIdentity(
+            principal.Claims.Where(c => c.Type != RolesClaimType),
+            principal.Identity?.AuthenticationType ?? "jwt",
+            NameClaimType,
+            RolesClaimType);
+        foreach (var role in roles)
+            identity.AddClaim(new Claim(RolesClaimType, role));
+
+        return new ClaimsPrincipal(identity);
     }
 
     private static AuthResult EnforceRole(RequireRoleAttribute attr, ClaimsPrincipal principal) =>

--- a/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
@@ -140,32 +140,50 @@ public sealed class JwtMiddleware(
     /// only ever add, so demoting someone in the table left their old JWT role effective
     /// until the token expired — the table could grant a role but never take one back.
     ///
-    /// A caller with no member row ends up with no roles. A valid CIAM token proves who
-    /// someone is, not that they belong to SLYPN. Note that the stored OID can go stale:
-    /// personal Microsoft accounts are issued a different oid than az-cli reports, so a
-    /// seeded record can miss here. GET /me re-links such a record by email, which
-    /// restores the roles from the next request onward.
+    /// A caller the table cannot vouch for ends up with no roles at all — whether the row
+    /// is missing, the token carries no oid to look one up by, or storage is unconfigured
+    /// so there is no table to consult. A valid CIAM token proves who someone is, not that
+    /// they belong to SLYPN, and any of these falling back to the token's roles would hand
+    /// authority quietly back to Entra app-role assignments.
+    ///
+    /// Note that the stored OID can go stale: personal Microsoft accounts are issued a
+    /// different oid than az-cli reports, so a seeded record can miss here. GET /me
+    /// re-links such a record by email, which restores the roles from the next request on.
+    ///
+    /// The one exception is a lookup that throws — see below.
     /// </summary>
     private async Task<ClaimsPrincipal> ApplyTableRolesAsync(ClaimsPrincipal principal, CancellationToken ct)
     {
-        if (!repo.SupportsWrites || principal.FindFirst("oid")?.Value is not { Length: > 0 } callerOid)
-            return principal;
+        IReadOnlyList<string> roles = [];
 
-        IReadOnlyList<string> roles;
-        try
+        if (!repo.SupportsWrites)
         {
-            var member = await repo.GetMemberByOidAsync(callerOid, ct);
-            if (member is null)
-                logger.LogWarning("No member record for OID {Oid} — treating the caller as having no roles.", callerOid);
-            roles = member?.Roles ?? [];
+            // Storage is configured in every deployed environment, so this means the
+            // connection string is missing rather than that roles are irrelevant.
+            logger.LogWarning("Members table unavailable (storage not configured) — no caller can hold a role.");
         }
-        catch (Exception ex)
+        else if (principal.FindFirst("oid")?.Value is not { Length: > 0 } callerOid)
         {
-            // Storage is unreachable. Fall back to the token's own roles rather than
-            // signing every member out of the site over a transient storage fault —
-            // stripping roles here would turn a blip into a site-wide outage.
-            logger.LogWarning(ex, "Role lookup failed for OID {Oid}; falling back to the token's roles", callerOid);
-            return principal;
+            logger.LogInformation("Token carries no oid claim — no member record to resolve roles from.");
+        }
+        else
+        {
+            try
+            {
+                var member = await repo.GetMemberByOidAsync(callerOid, ct);
+                if (member is null)
+                    logger.LogInformation("No member record for OID {Oid} — caller holds no roles.", callerOid);
+                roles = member?.Roles ?? [];
+            }
+            catch (Exception ex)
+            {
+                // Storage is reachable in principle but failed. Fall back to the token's
+                // own roles rather than signing every member out at once over a transient
+                // fault — that would turn a blip into a site-wide outage. This is the only
+                // path that keeps token roles, and it is deliberately the transient one.
+                logger.LogWarning(ex, "Role lookup failed for OID {Oid}; falling back to the token's roles", callerOid);
+                return principal;
+            }
         }
 
         // Rebuilt rather than mutated: ClaimsIdentity.RemoveClaim only accepts claims the


### PR DESCRIPTION
Closes #153.

## The defect, demonstrated first

Role enrichment unioned the members table's roles with the JWT's:

```csharp
foreach (var role in cosmosRoles.Where(role => !identity.HasClaim(RolesClaimType, role)))
    identity.AddClaim(new Claim(RolesClaimType, role));
```

It could grant a role but never take one back, so demoting someone in the table left their old
role effective until the token expired — despite the comment claiming the table "overrides any
JWT roles".

The tests went in before the fix. Against the old code they failed exactly as predicted:

```
Table_roles_replace_JWT_roles_rather_than_adding_to_them [FAIL]
  Assert.Equal() Failure: Collections differ
  Expected: ["Contributor"]
  Actual:   ["Admin", "Contributor"]

Demoting_a_member_in_the_table_revokes_the_role_from_a_stale_JWT [FAIL]
  Assert.False() Failure — a demoted admin still cleared the Admin gate
```

`Table_roles_are_granted_when_the_JWT_carries_none` passed throughout, pinning the original
purpose of enrichment so the fix couldn't quietly discard it.

## The fix

Roles are replaced, not added. Two decisions worth flagging for review:

**A caller with no member row holds no roles** (fail-closed). A valid CIAM token proves identity,
not membership. This is a real behaviour change: an Entra app-role assignment alone no longer
grants anything.

The escape hatch that makes it survivable — `/me` and `/whoami` carry `[RequireRole]` with no
roles listed, so they stay reachable with none. That matters because `GET /me` is what re-links a
stale OID by email, which is the documented failure mode for personal Microsoft accounts (they're
issued a different `oid` than `az ad signed-in-user show` reports, so a seeded record can miss the
OID lookup). Both properties are covered by tests.

**A storage failure falls back to the token's roles.** Stripping them when the table is
unreachable would turn a transient fault into a simultaneous lockout for every member, so
strictness gives way to availability on that path only.

## Implementation note

The principal is rebuilt rather than mutated. `ClaimsIdentity.RemoveClaim` only accepts claims the
identity itself owns, and claims arriving from the token handler need not be — removing in place
can throw and leave a stale role attached, which is the one failure mode this change exists to
prevent.

## Scope

The dev-persona path (`SkipAuth=true`) returns before any of this, so local dev and the e2e suite
are unaffected.

Two pre-existing tests needed a member row seeded to keep saying what they meant — both are about
token handling, not roles, and a valid token alone no longer carries a role.

**Verified**: 291/291 API tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
