### PR TITLE
fix(api): require an actual invitation to pass the sign-up gate

### DIFF
--- a/src/api/Slypn.Api.Tests/AuthExtensionFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AuthExtensionFunctionsTests.cs
@@ -225,4 +225,61 @@ public class AuthExtensionFunctionsTests
         var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
         Assert.Contains("showBlockPage", Read(resp));
     }
+
+    // ── SEC-1: subscribing is not an invitation ─────────────────────────────
+    // The members table doubles as the newsletter subscriber list, and the gate
+    // used to allow any address with a row. Anyone could POST to the anonymous
+    // /api/newsletter/subscribe and then sign up through CIAM.
+
+    private static Member Subscriber(string email) =>
+        new("s1", email, email, Array.Empty<string>(), "subscribed", DateTime.UtcNow);
+
+    private static Member Invited(string email) =>
+        new("m9", email, "Invited Person", new[] { "Member" }, "invited", DateTime.UtcNow);
+
+    [Fact]
+    public async Task Blocks_a_newsletter_subscriber_who_was_never_invited()
+    {
+        var repo = new FakeContentRepository { MemberByEmail = Subscriber("subscriber@x.com") };
+        var fn = Make(repo);
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("subscriber@x.com"));
+
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+
+        Assert.Contains("showBlockPage", Read(resp));
+        Assert.DoesNotContain("continueWithDefaultBehavior", Read(resp));
+    }
+
+    [Fact]
+    public async Task A_subscriber_and_an_unknown_address_get_the_identical_block_page()
+    {
+        // No oracle: if the subscriber saw a different message, the gate would confirm
+        // which addresses hold a row in the members table to anyone who asked.
+        var subscriberResp = (TestHttpResponseData)await Make(
+                new FakeContentRepository { MemberByEmail = Subscriber("subscriber@x.com") })
+            .AllowSignup(
+                TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("subscriber@x.com")),
+                Ct);
+
+        var unknownResp = (TestHttpResponseData)await Make(new FakeContentRepository())
+            .AllowSignup(
+                TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("nobody@x.com")),
+                Ct);
+
+        Assert.Equal(Read(unknownResp), Read(subscriberResp));
+    }
+
+    [Fact]
+    public async Task Still_allows_an_invited_address_that_also_subscribed()
+    {
+        // Subscribe preserves the roles of an existing member, so an invitee who also
+        // signed up for the newsletter keeps their role and must still get through.
+        var repo = new FakeContentRepository { MemberByEmail = Invited("both@x.com") };
+        var fn = Make(repo);
+        var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("both@x.com"));
+
+        var resp = (TestHttpResponseData)await fn.AllowSignup(req, Ct);
+
+        Assert.Contains("continueWithDefaultBehavior", Read(resp));
+    }
 }

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -587,6 +587,54 @@ public class ContentFunctionsTests
         Assert.DoesNotContain("Admin", resp.ReadBodyAsString());
     }
 
+    // SEC-1: a newsletter subscriber has a row in the members table but is not a
+    // member. Claiming it would link their OID and flip the row to "active", so they
+    // would appear in Member Management as though an admin had invited them.
+    [Fact]
+    public async Task Me_does_not_claim_a_subscriber_row_for_the_caller()
+    {
+        var repo = new FakeContentRepository
+        {
+            MemberByOid   = null,
+            MemberByEmail = new Member("s1", "sub@x.com", "sub@x.com", Array.Empty<string>(), "subscribed", DateTime.UtcNow),
+        };
+        var fn = MeFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-attacker", "Mallory").WithEmail("sub@x.com");
+
+        var resp = (TestHttpResponseData)await fn.Get(TestHttp.Get(ctx, "http://localhost/api/me"), ctx, Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        // The re-link must not even be attempted. ThrowOnWrite would be swallowed by the
+        // catch inside TryRelinkByEmailAsync, so count the attempt instead.
+        Assert.Equal(0, repo.MemberUpserts);
+
+        // Status null, not "subscribed": the caller gets no profile at all rather than the
+        // subscriber's row echoed back, which is what distinguishes fixed from broken here.
+        var body = resp.ReadBodyAsString();
+        Assert.Contains("\"status\":null", body);
+        Assert.DoesNotContain("subscribed", body);
+    }
+
+    [Fact]
+    public async Task Me_still_relinks_an_invited_member_whose_stored_oid_is_stale()
+    {
+        // The case the re-link exists for: personal Microsoft accounts are issued a
+        // different oid than az-cli reports, so a seeded record misses the oid lookup.
+        var repo = new FakeContentRepository
+        {
+            MemberByOid   = null,
+            MemberByEmail = new Member("m1", "admin@x.com", "Placeholder", new[] { "Admin" }, "invited", DateTime.UtcNow, Oid: "stale-oid"),
+        };
+        var fn = MeFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-real", "Ada").WithEmail("admin@x.com");
+
+        var resp = (TestHttpResponseData)await fn.Get(TestHttp.Get(ctx, "http://localhost/api/me"), ctx, Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("Admin", resp.ReadBodyAsString());
+    }
+
     [Fact]
     public async Task Me_returns_empty_when_member_not_found_by_oid_or_email()
     {

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -153,7 +153,16 @@ internal sealed class FakeContentRepository : IContentRepository
         if (ThrowOnRead is not null) throw ThrowOnRead;
         return Task.FromResult<IReadOnlyList<Member>>(Members);
     }
-    public Task<Member> UpsertMemberAsync(Member member, string? ifMatch, CancellationToken ct) => Task.FromResult(Guard(member));
+    /// <summary>Count of attempted member upserts. ThrowOnWrite is no use for asserting
+    /// "nothing was written" on paths that catch their own exceptions, such as the
+    /// re-link in MeSelfFunctions — this records the attempt itself.</summary>
+    public int MemberUpserts { get; private set; }
+
+    public Task<Member> UpsertMemberAsync(Member member, string? ifMatch, CancellationToken ct)
+    {
+        MemberUpserts++;
+        return Task.FromResult(Guard(member));
+    }
     public Task DeleteMemberAsync(string id, string? ifMatch, CancellationToken ct) => Guard(Task.CompletedTask);
 
     public Task<Draft?> GetDraftAsync(string id, string authorId, CancellationToken ct)

--- a/src/api/Slypn.Api.Tests/TestHttp.cs
+++ b/src/api/Slypn.Api.Tests/TestHttp.cs
@@ -48,6 +48,16 @@ internal sealed class TestFunctionContext : FunctionContext
         Items[JwtMiddleware.PrincipalContextKey] = new ClaimsPrincipal(identity);
         return this;
     }
+
+    /// <summary>Add an email claim to the principal from <see cref="WithUser"/>. Separate
+    /// because it cannot be an optional parameter after that method's params array, and only
+    /// the re-link path in MeSelfFunctions reads it.</summary>
+    public TestFunctionContext WithEmail(string email)
+    {
+        if (Items[JwtMiddleware.PrincipalContextKey] is ClaimsPrincipal { Identity: ClaimsIdentity id })
+            id.AddClaim(new Claim("email", email));
+        return this;
+    }
 }
 
 internal sealed class TestHttpCookies : HttpCookies

--- a/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
+++ b/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
@@ -107,8 +107,11 @@ public sealed class AuthExtensionFunctions(
 
         try
         {
+            // Existence is not an invitation. The members table also holds newsletter
+            // subscribers, written by the anonymous POST /api/newsletter/subscribe, so
+            // gating on "a row exists" let anyone subscribe and then sign up.
             var member = await repo.GetMemberByEmailAsync(email.Trim().ToLowerInvariant(), ct);
-            if (member is not null)
+            if (member is { IsInvited: true })
             {
                 log.LogInformation("AllowSignup: allowing invited email {Email}", email);
                 return await Continue(req);

--- a/src/api/Slypn.Api/Functions/MeSelfFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MeSelfFunctions.cs
@@ -75,8 +75,11 @@ public sealed class MeSelfFunctions(
         if (string.IsNullOrEmpty(email))
             return null;
 
+        // A newsletter subscriber has a row here but is not a member, so their row must never
+        // be claimed by a signed-in caller: linking an OID would also flip it to "active" below
+        // and surface them in Member Management as though an admin had invited them.
         var byEmail = await repo.GetMemberByEmailAsync(email.Trim().ToLowerInvariant(), ct);
-        if (byEmail is null || byEmail.Oid == callerOid)
+        if (byEmail is null || !byEmail.IsInvited || byEmail.Oid == callerOid)
             return null;
 
         // Use the display name the user chose during CIAM sign-up; fall back

--- a/src/api/Slypn.Api/Models/Member.cs
+++ b/src/api/Slypn.Api/Models/Member.cs
@@ -16,4 +16,23 @@ public sealed record Member(
     [JsonPropertyName("_etag")]
     [Newtonsoft.Json.JsonProperty("_etag")]
     public string? Etag { get; init; }
+
+    /// <summary>
+    /// True when an admin actually invited this person, as opposed to their address merely
+    /// having a row here. The members table doubles as the newsletter subscriber list, so
+    /// existence alone says nothing about whether someone may sign in.
+    ///
+    /// Holding a role is the real test — every invite assigns exactly one
+    /// (<c>MemberInviteInput</c> requires it) and the dev-persona seed does too, while the
+    /// anonymous newsletter subscribe is the one write path that produces neither a role nor
+    /// any status but "subscribed". The status check guards against a future write path that
+    /// forgets to assign one.
+    ///
+    /// [JsonIgnore] is load-bearing: members persist as a JSON blob in the entity's Json
+    /// column, so without it this computed value would be written into storage.
+    /// </summary>
+    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public bool IsInvited =>
+        Roles.Count > 0 && !string.Equals(Status, "subscribed", StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
Fixes the last live High finding from the August 2026 security review, tracked privately as
advisory `GHSA-rcr3-vmhq-hvgp`. It was the only one an unauthenticated stranger could reach.

## The problem

`AllowSignup` authorised on bare row existence, and `Member.Status` was never consulted for
authorisation anywhere in the API:

```csharp
var member = await repo.GetMemberByEmailAsync(email.Trim().ToLowerInvariant(), ct);
if (member is not null) { return await Continue(req); }
```

The members table doubles as the newsletter subscriber list, written by the anonymous
`POST /api/newsletter/subscribe`. So: subscribe with any address → sign up through CIAM → the gate
passes. On the attacker's first `GET /me`, `TryRelinkByEmailAsync` then claimed that row, attaching
their OID and flipping it to `"active"`, so they surfaced in Member Management looking legitimate.

## The fix

Both sites test `Member.IsInvited` instead of existence. Holding a role is the real discriminator,
checked against every path that writes a member row:

- `MembersFunctions.Invite` — `MemberInviteInput` requires exactly one role
- `TableBootstrapper.SeedDevPersonasAsync` — seeds roles plus `Status: "active"`
- `NewslettersFunctions.Subscribe` — the only path producing an empty role list and `"subscribed"`

A subscriber falls through to the **existing** block page, wording unchanged, so the gate does not
become an oracle for which addresses hold a member record. There's a test asserting the two
responses are byte-identical.

`[JsonIgnore]` on `IsInvited` is load-bearing rather than cosmetic: members persist as a JSON blob
in the entity's `Json` column via `Serialize<T>`, so without it the computed value would be written
into storage.

## Tests fail without the fix

Verified by reverting the two guards with the tests in place:

```
Blocks_a_newsletter_subscriber_who_was_never_invited [FAIL]
A_subscriber_and_an_unknown_address_get_the_identical_block_page [FAIL]
Me_does_not_claim_a_subscriber_row_for_the_caller [FAIL]
Failed: 3, Passed: 295
```

The first draft of the third test passed in both states — `ThrowOnWrite` is swallowed by the catch
inside `TryRelinkByEmailAsync`, so it proved nothing. Replaced with a `MemberUpserts` counter on the
fake plus an assertion that `status` comes back null rather than the subscriber's row echoed back.

Two further tests — `Still_allows_an_invited_address_that_also_subscribed` and
`Me_still_relinks_an_invited_member_whose_stored_oid_is_stale` — pass in both states by design.
They guard the legitimate paths, including the personal-Microsoft-account case the re-link exists for.

**Verified**: 298/298.

## Follow-ups, not in this PR

- **#155** — moving subscribers to their own table is the structural fix that makes this class of
  bug unrepeatable. Deliberately separate so a ten-line security fix isn't held behind a migration.
- **Double opt-in** is filed separately. Worth doing for subscriber hygiene and consent evidence,
  but it is not a security control here: verifying an email proves address ownership, not
  invitation, so a *confirmed* subscriber would have passed the old gate exactly as an unconfirmed
  one did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
