### PR TITLE
fix(ci): make PR preview sign-in work on first click, and stop setup.ps1 wiping previews

### DIFF
--- a/.github/scripts/spa-redirect-uri.sh
+++ b/.github/scripts/spa-redirect-uri.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Add or remove a SWA preview environment's redirect URIs on the SPA app registration.
+#
+# MSAL redeems its authorization code cross-origin, and Entra only permits that for URIs
+# registered under an application's "spa" platform — registering under "web" yields
+# AADSTS9002326 at the token endpoint even though /authorize succeeds. There is no az CLI
+# command for the spa platform, hence the raw Graph PATCH.
+#
+# Usage:
+#   spa-redirect-uri.sh add    <pr-number|base-url>
+#   spa-redirect-uri.sh remove <pr-number>
+#
+# "add" takes either a PR number (the preview hostname is derived, so this can run before
+# the deploy exists) or the exact base URL the deploy reported. "remove" takes a PR number
+# and strips every registered URI belonging to that PR's preview host, so it does not
+# depend on the environment still existing or on the derivation matching.
+#
+# Required env: CIAM_TENANT_ID, CIAM_CLIENT_ID, CIAM_CLIENT_SECRET, SPA_OBJECT_ID
+# Optional env: SWA_NAME (default swa-slypn-prod), SWA_RG (default rg-slypn-prod)
+
+set -euo pipefail
+
+MODE="${1:-}"
+TARGET="${2:-}"
+if [ -z "$MODE" ] || [ -z "$TARGET" ]; then
+  echo "usage: $(basename "$0") <add|remove> <pr-number|base-url>" >&2
+  exit 2
+fi
+
+: "${CIAM_TENANT_ID:?CIAM_TENANT_ID is required}"
+: "${CIAM_CLIENT_ID:?CIAM_CLIENT_ID is required}"
+: "${CIAM_CLIENT_SECRET:?CIAM_CLIENT_SECRET is required}"
+: "${SPA_OBJECT_ID:?SPA_OBJECT_ID is required}"
+SWA_NAME="${SWA_NAME:-swa-slypn-prod}"
+SWA_RG="${SWA_RG:-rg-slypn-prod}"
+
+# Derive a preview base URL from the production hostname. SWA names previews
+# <prefix>-<env>.<region>.<suffix> where production is <prefix>.<suffix>, e.g.
+# example-abc123.7.azurestaticapps.net -> example-abc123-42.westeurope.7.azurestaticapps.net
+derive_preview_url() {
+  local pr="$1" host region
+  host=$(az staticwebapp show -n "$SWA_NAME" -g "$SWA_RG" --query defaultHostname -o tsv)
+  region=$(az staticwebapp show -n "$SWA_NAME" -g "$SWA_RG" --query location -o tsv \
+    | tr '[:upper:]' '[:lower:]' | tr -d ' ')
+  echo "https://${host%%.*}-${pr}.${region}.${host#*.}"
+}
+
+graph_token() {
+  curl -sf "https://login.microsoftonline.com/${CIAM_TENANT_ID}/oauth2/v2.0/token" \
+    --data-urlencode "grant_type=client_credentials" \
+    --data-urlencode "client_id=${CIAM_CLIENT_ID}" \
+    --data-urlencode "client_secret=${CIAM_CLIENT_SECRET}" \
+    --data-urlencode "scope=https://graph.microsoft.com/.default" \
+    | jq -r .access_token
+}
+
+TOKEN=$(graph_token)
+CURRENT=$(curl -sf "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
+  -H "Authorization: Bearer $TOKEN" | jq -c '.spa.redirectUris // []')
+
+case "$MODE" in
+  add)
+    if [[ "$TARGET" =~ ^[0-9]+$ ]]; then
+      BASE_URL=$(derive_preview_url "$TARGET")
+      echo "Derived preview URL for PR #${TARGET}: $BASE_URL"
+    else
+      BASE_URL="$TARGET"
+    fi
+    CALLBACK="${BASE_URL%/}/auth/callback"
+    OAUTH_REDIRECT="${BASE_URL%/}/oauth2-redirect.html"
+    UPDATED=$(jq -cn --argjson c "$CURRENT" --arg a "$CALLBACK" --arg b "$OAUTH_REDIRECT" \
+      '$c + [$a, $b] | unique')
+    DESCRIPTION="$CALLBACK  $OAUTH_REDIRECT"
+    ;;
+  remove)
+    if [[ ! "$TARGET" =~ ^[0-9]+$ ]]; then
+      echo "::error::remove expects a PR number, got '$TARGET'" >&2
+      exit 2
+    fi
+    # Match on the PR's preview host rather than an exact URL, so cleanup does not
+    # depend on the environment still existing or on the derivation above.
+    #
+    # String operations, not a regex: the obvious pattern ("-<pr>\\.") is one lost
+    # backslash away from an unescaped dot, which would silently also match PR 1640
+    # when closing PR 164 and break that PR's sign-in. endswith cannot do that —
+    # "…-1640" does not end with "-164".
+    #
+    # Host is split("/")[2]; production is <prefix>.<suffix> with no "-<pr>" label
+    # suffix, and localhost has no azurestaticapps.net host, so neither can match.
+    UPDATED=$(jq -cn --argjson c "$CURRENT" --arg pr "$TARGET" '
+      [ $c[]
+        | select(
+            ((split("/") | .[2]) // "") as $host
+            | ((($host | split(".") | .[0]) // "") | endswith("-" + $pr))
+              and ($host | endswith("azurestaticapps.net"))
+            | not
+          )
+      ]')
+    DESCRIPTION="every redirect URI for PR #${TARGET}"
+    ;;
+  *)
+    echo "::error::unknown mode '$MODE' (expected add or remove)" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$UPDATED" = "$CURRENT" ]; then
+  echo "No change needed ($MODE): $DESCRIPTION"
+  exit 0
+fi
+
+curl -sf -X PATCH "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"spa\":{\"redirectUris\":${UPDATED}}}" > /dev/null
+
+echo "${MODE}d: $DESCRIPTION"

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -85,6 +85,26 @@ jobs:
           echo "$EXISTING_COUNT/$FREE_TIER_CAP preview environments in use — room for a new one."
         shell: bash
 
+      # Entra takes a few minutes to propagate a new SPA redirect URI to the token
+      # endpoint. Registering only after the deploy meant the preview link was live —
+      # and already posted to the PR — before sign-in worked, so anyone clicking
+      # straight away got AADSTS9002326 ("cross-origin token redemption is permitted
+      # only for the Single-Page Application client-type"): /authorize knew the URI,
+      # the token endpoint did not yet know it was an SPA one.
+      #
+      # The preview hostname is derivable from production's, so claim it up front and
+      # let the build and deploy absorb the propagation delay. The post-deploy step
+      # below still runs and is authoritative.
+      - name: Pre-register PR preview redirect URI
+        if: github.event_name == 'pull_request'
+        env:
+          CIAM_TENANT_ID:     ${{ secrets.CIAM_TENANT_ID }}
+          CIAM_CLIENT_ID:     ${{ secrets.CIAM_CLIENT_ID }}
+          CIAM_CLIENT_SECRET: ${{ secrets.CIAM_CLIENT_SECRET }}
+          SPA_OBJECT_ID:      ${{ secrets.SPA_OBJECT_ID }}
+        run: .github/scripts/spa-redirect-uri.sh add "${{ github.event.pull_request.number }}"
+        shell: bash
+
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -177,29 +197,10 @@ jobs:
           CIAM_CLIENT_ID:     ${{ secrets.CIAM_CLIENT_ID }}
           CIAM_CLIENT_SECRET: ${{ secrets.CIAM_CLIENT_SECRET }}
           SPA_OBJECT_ID:      ${{ secrets.SPA_OBJECT_ID }}
-          SWA_URL:            ${{ steps.builddeploy.outputs.static_web_app_url }}
-        run: |
-          set -euo pipefail
-          CALLBACK="${SWA_URL%/}/auth/callback"
-          TOKEN=$(curl -sf \
-            "https://login.microsoftonline.com/${CIAM_TENANT_ID}/oauth2/v2.0/token" \
-            --data-urlencode "grant_type=client_credentials" \
-            --data-urlencode "client_id=${CIAM_CLIENT_ID}" \
-            --data-urlencode "client_secret=${CIAM_CLIENT_SECRET}" \
-            --data-urlencode "scope=https://graph.microsoft.com/.default" \
-            | jq -r .access_token)
-          CURRENT=$(curl -sf \
-            "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
-            -H "Authorization: Bearer $TOKEN" \
-            | jq -c '.spa.redirectUris')
-          OAUTH_REDIRECT="${SWA_URL%/}/oauth2-redirect.html"
-          UPDATED=$(echo "$CURRENT" | jq -c --arg a "$CALLBACK" --arg b "$OAUTH_REDIRECT" '. + [$a,$b] | unique')
-          curl -sf -X PATCH \
-            "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"spa\":{\"redirectUris\":${UPDATED}}}"
-          echo "Registered: $CALLBACK  $OAUTH_REDIRECT"
+        # Authoritative: uses the URL the deploy actually produced. Normally a no-op,
+        # because the pre-register step above derived the same host — but it corrects
+        # the derivation if Azure's preview naming ever changes.
+        run: .github/scripts/spa-redirect-uri.sh add "${{ steps.builddeploy.outputs.static_web_app_url }}"
         shell: bash
 
   close_pr_environment:
@@ -207,8 +208,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Close PR environment
     permissions:
+      contents: read
       id-token: write
     steps:
+      # This job did not check out before — it does now because the redirect-URI
+      # cleanup below runs a script from the repo.
+      #
+      # The base branch, not the default refs/pull/N/merge: that ref can be gone by
+      # the time a closed PR is processed, and the cleanup script only ever needs the
+      # version already on main.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          submodules: false
+          lfs: false
+
       - name: Azure login (OIDC)
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
@@ -222,32 +236,10 @@ jobs:
           CIAM_CLIENT_ID:     ${{ secrets.CIAM_CLIENT_ID }}
           CIAM_CLIENT_SECRET: ${{ secrets.CIAM_CLIENT_SECRET }}
           SPA_OBJECT_ID:      ${{ secrets.SPA_OBJECT_ID }}
-        run: |
-          set -euo pipefail
-          PR_HOST=$(az staticwebapp environment list \
-            --name swa-slypn-prod --resource-group rg-slypn-prod \
-            --query "[?contains(hostname, '-${{ github.event.pull_request.number }}.')]|[0].hostname" \
-            -o tsv)
-          CALLBACK="https://${PR_HOST}/auth/callback"
-          OAUTH_REDIRECT="https://${PR_HOST}/oauth2-redirect.html"
-          TOKEN=$(curl -sf \
-            "https://login.microsoftonline.com/${CIAM_TENANT_ID}/oauth2/v2.0/token" \
-            --data-urlencode "grant_type=client_credentials" \
-            --data-urlencode "client_id=${CIAM_CLIENT_ID}" \
-            --data-urlencode "client_secret=${CIAM_CLIENT_SECRET}" \
-            --data-urlencode "scope=https://graph.microsoft.com/.default" \
-            | jq -r .access_token)
-          CURRENT=$(curl -sf \
-            "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
-            -H "Authorization: Bearer $TOKEN" \
-            | jq -c '.spa.redirectUris')
-          UPDATED=$(echo "$CURRENT" | jq -c --arg a "$CALLBACK" --arg b "$OAUTH_REDIRECT" '[.[] | select(. != $a and . != $b)]')
-          curl -sf -X PATCH \
-            "https://graph.microsoft.com/v1.0/applications/${SPA_OBJECT_ID}" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"spa\":{\"redirectUris\":${UPDATED}}}"
-          echo "Removed: $CALLBACK"
+        # By PR number, not by querying the environment's hostname: that query returned
+        # empty once the environment had already gone, which silently removed nothing
+        # and leaked the redirect URI permanently.
+        run: .github/scripts/spa-redirect-uri.sh remove "${{ github.event.pull_request.number }}"
         shell: bash
 
       - name: Close PR environment

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -595,6 +595,24 @@ if (-not $SkipEntra) {
 
     $spaApp           = Invoke-Graph GET "/applications/$spaObjectId"
     $currentRedirects = @($spaApp.spa.redirectUris)
+
+    # Carry over PR-preview callbacks. The deploy workflow registers one per open PR
+    # and the close-PR job removes it again, so they are legitimately present here and
+    # not ours to prune. Replacing the list wholesale used to strip them out from under
+    # every open PR, breaking preview sign-in until each was redeployed.
+    #
+    # A preview host is <prefix>-<pr>.<region>.<suffix> against production's
+    # <prefix>.<suffix>, so the first label ending in -<digits> is what marks one.
+    # $uriHost, not $host — the latter is a read-only PowerShell automatic variable.
+    $previewUris = @($currentRedirects | Where-Object {
+        $uriHost = ([uri]$_).Host
+        $uriHost.EndsWith('azurestaticapps.net') -and ($uriHost.Split('.')[0] -match '-\d+$')
+    })
+    if ($previewUris.Count -gt 0) {
+        Info "Preserving $($previewUris.Count) PR-preview redirect URI(s)"
+        $redirectUris = @($redirectUris + $previewUris | Select-Object -Unique)
+    }
+
     if (Compare-StringSets $redirectUris $currentRedirects) {
         Info "Redirect URIs already correct"
     } else {


### PR DESCRIPTION
Two independent faults in how the SPA app registration's redirect URIs are managed, both
surfaced by hitting `AADSTS9002326` on the PR #164 preview.

## 1. Preview sign-in raced Entra propagation

The redirect URI was registered *after* the deploy — by which point the preview link was live and
already posted to the PR. Entra takes a few minutes to propagate a new SPA redirect URI to the
token endpoint, so clicking straight away gave:

> AADSTS9002326: Cross-origin token redemption is permitted only for the 'Single-Page Application'
> client-type.

`/authorize` accepted the URI; the token endpoint hadn't yet learnt it was an *SPA* one. Confirmed
by inspecting the live app registration afterwards — the URI was correctly under `spa`, with `web`
and `publicClient` both empty. Registration at `00:05:11Z`, failure at `00:08:28Z`.

The preview hostname is derivable from production's (`<prefix>-<pr>.<region>.<suffix>` against
`<prefix>.<suffix>`), so it's now claimed **before** the toolchain setup and build, which absorb
the propagation delay. The post-deploy step still runs and remains authoritative — normally a
no-op, but it corrects the derivation if Azure's preview naming ever changes.

## 2. `setup.ps1` wiped every open PR's preview callback

`infra/setup.ps1` PATCHed `spa.redirectUris` with a fixed list of prod + localhost, *replacing*
rather than merging. Any run would have stripped the callbacks of every open preview and broken
their sign-in until each was redeployed. It now carries over hosts whose first label ends in
`-<digits>` — the deploy workflow registers those and the close-PR job removes them again, so
they're not `setup.ps1`'s to prune.

## Consolidation

The three near-identical Graph dances are now one script, `.github/scripts/spa-redirect-uri.sh`.

Teardown keys off the **PR number** instead of querying the environment's hostname. That query
returned empty once the environment had already gone, so the removal silently matched nothing and
leaked the redirect URI permanently.

The matching there deliberately uses string operations rather than a regex. The obvious pattern
(`-<pr>\.`) is one lost backslash away from an unescaped dot — which would also match PR **1640**
while closing PR **164**, breaking that PR's sign-in. A local harness reproduced exactly that
collision before the logic changed; `endswith("-164")` cannot express it, since `…-1640` doesn't
end with `-164`.

`close_pr_environment` now checks out the repo, since it runs a script from it. It takes the base
branch rather than the default `refs/pull/N/merge`, which can be gone by the time a closed PR is
processed.

## Verification

- `.github/scripts/spa-redirect-uri.sh` passes `bash -n`; committed mode `100755`.
- All three workflows parse with a real YAML parser; step ordering asserted (checkout → login →
  quota guard → pre-register → build → deploy → post-register).
- `infra/setup.ps1` parses clean via `Parser::ParseFile`, and the preview-detection predicate was
  run against a fixture: keeps 2 preview URIs, leaves prod and localhost untouched.
- The teardown matcher was tested on both collision directions (PR 1640 and PR 64 survive closing
  PR 164), plus prod, localhost, and a no-op close.

Note `$uriHost` rather than `$host` in the PowerShell — `$host` is a read-only automatic variable
and assigning to it throws.

## Not changed

`close_pr_environment` still runs `azure/login`, which is now unused there — the teardown no longer
shells out to `az`. Left in place rather than cleaned up in the same PR, since that job's failure
is what leaks preview environments. Easy follow-up if you want it gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
