### PR TITLE
fix(api): refuse to start when the auth bypass is enabled outside local dev

### DIFF
--- a/src/api/Slypn.Api.Tests/InfrastructureTests.cs
+++ b/src/api/Slypn.Api.Tests/InfrastructureTests.cs
@@ -75,4 +75,77 @@ public class InfrastructureTests
         Assert.Equal(new[] { "Admin", "Contributor" }, attr.Roles);
         Assert.Empty(new RequireRoleAttribute().Roles);
     }
+
+    // ── SEC-4: the auth bypass must not be reachable outside local dev ───────
+    // AzureAd:SkipAuth short-circuits JWT validation before every other check and
+    // hands Admin to any caller sending X-Slypn-Dev-User. Nothing but a correctly
+    // set app setting used to stand between that and a live site.
+
+    /// <summary>A fake environment for the guard to read, so tests never touch the real one.</summary>
+    private static Func<string, string?> Env(params (string Name, string Value)[] vars)
+    {
+        var map = vars.ToDictionary(v => v.Name, v => v.Value, StringComparer.OrdinalIgnoreCase);
+        return name => map.TryGetValue(name, out var v) ? v : null;
+    }
+
+    private static readonly Func<string, string?> NoAzureMarkers = Env();
+
+    [Theory]
+    [InlineData("dev")]
+    [InlineData("local")]
+    [InlineData("development")]
+    [InlineData("DEV")]
+    [InlineData(null)]   // Otel__Env omitted — OtelOptions.Env itself defaults to "dev"
+    [InlineData("")]
+    public void SkipAuth_is_allowed_on_a_local_machine(string? env)
+    {
+        StartupGuards.EnsureSkipAuthIsLocalOnly(skipAuth: true, otelEnv: env, NoAzureMarkers);
+    }
+
+    [Theory]
+    [InlineData("prod")]
+    [InlineData("production")]
+    [InlineData("staging")]
+    public void SkipAuth_refuses_to_start_outside_a_local_environment(string env)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            StartupGuards.EnsureSkipAuthIsLocalOnly(skipAuth: true, otelEnv: env, NoAzureMarkers));
+
+        Assert.Contains("AzureAd:SkipAuth", ex.Message);
+        Assert.Contains(env, ex.Message);
+    }
+
+    [Theory]
+    [InlineData("WEBSITE_INSTANCE_ID")]
+    [InlineData("WEBSITE_SITE_NAME")]
+    [InlineData("WEBSITE_HOSTNAME")]
+    public void SkipAuth_refuses_to_start_on_an_azure_host_even_when_env_says_dev(string marker)
+    {
+        // The PR-preview case, and the reason an environment-name check is not enough on
+        // its own: previews are real, publicly reachable deployments that deliberately
+        // run with Otel__Env=dev.
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            StartupGuards.EnsureSkipAuthIsLocalOnly(
+                skipAuth: true, otelEnv: "dev", Env((marker, "some-value"))));
+
+        Assert.Contains(marker, ex.Message);
+    }
+
+    [Theory]
+    [InlineData("dev")]
+    [InlineData("prod")]
+    public void SkipAuth_false_never_blocks_startup(string env)
+    {
+        StartupGuards.EnsureSkipAuthIsLocalOnly(
+            skipAuth: false, otelEnv: env, Env(("WEBSITE_SITE_NAME", "swa-slypn-prod")));
+    }
+
+    [Fact]
+    public void A_blank_azure_marker_is_not_treated_as_a_deployment()
+    {
+        // Absent and present-but-empty must behave the same, or a stray empty variable
+        // would break every local dev machine that happened to have one set.
+        StartupGuards.EnsureSkipAuthIsLocalOnly(
+            skipAuth: true, otelEnv: "dev", Env(("WEBSITE_SITE_NAME", "   ")));
+    }
 }

--- a/src/api/Slypn.Api.Tests/InfrastructureTests.cs
+++ b/src/api/Slypn.Api.Tests/InfrastructureTests.cs
@@ -115,10 +115,20 @@ public class InfrastructureTests
         Assert.Contains(env, ex.Message);
     }
 
+    [Fact]
+    public void WEBSITE_HOSTNAME_is_not_an_azure_marker()
+    {
+        // Regression guard, and the reason this test exists at all: Core Tools sets
+        // WEBSITE_HOSTNAME locally to emulate App Service, so treating it as a deployment
+        // marker refused to start every `func start` and took the whole e2e job with it.
+        // Do not add it back.
+        StartupGuards.EnsureSkipAuthIsLocalOnly(
+            skipAuth: true, otelEnv: "dev", Env(("WEBSITE_HOSTNAME", "localhost:7071")));
+    }
+
     [Theory]
     [InlineData("WEBSITE_INSTANCE_ID")]
     [InlineData("WEBSITE_SITE_NAME")]
-    [InlineData("WEBSITE_HOSTNAME")]
     public void SkipAuth_refuses_to_start_on_an_azure_host_even_when_env_says_dev(string marker)
     {
         // The PR-preview case, and the reason an environment-name check is not enough on

--- a/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
@@ -77,7 +77,10 @@ public sealed class JwtMiddleware(
         // member persona correctly gets 403 on Admin-only endpoints.
         if (options.Value.SkipAuth)
         {
-            logger.LogWarning("AzureAd:SkipAuth=true — bypassing JWT validation. DO NOT use in production.");
+            // Critical, not Warning: every request served this way is unauthenticated Admin.
+            // StartupGuards should have stopped the host booting in any environment where
+            // this could be reached, so seeing this outside local dev means that failed.
+            logger.LogCritical("AzureAd:SkipAuth=true — bypassing JWT validation. DO NOT use in production.");
             return EnforceRole(attr, DevPrincipal(httpReq));
         }
 

--- a/src/api/Slypn.Api/Infrastructure/StartupGuards.cs
+++ b/src/api/Slypn.Api/Infrastructure/StartupGuards.cs
@@ -18,9 +18,15 @@ public static class StartupGuards
     /// <summary>
     /// Variables the Azure App Service / Functions host sets on every instance it runs,
     /// and which nothing sets on a developer machine or a CI runner using Core Tools.
+    ///
+    /// Deliberately NOT WEBSITE_HOSTNAME: Core Tools sets that locally to emulate App
+    /// Service, so treating it as a deployment marker refuses to start every `func start`
+    /// and took the e2e job down with it. The two below were absent in that same run —
+    /// the guard reports the first marker it finds, and it named WEBSITE_HOSTNAME — which
+    /// is what makes them usable discriminators.
     /// </summary>
     private static readonly string[] AzureHostMarkers =
-        ["WEBSITE_INSTANCE_ID", "WEBSITE_SITE_NAME", "WEBSITE_HOSTNAME"];
+        ["WEBSITE_INSTANCE_ID", "WEBSITE_SITE_NAME"];
 
     /// <summary>
     /// Refuse to start when the auth bypass is enabled anywhere it could be reached.

--- a/src/api/Slypn.Api/Infrastructure/StartupGuards.cs
+++ b/src/api/Slypn.Api/Infrastructure/StartupGuards.cs
@@ -1,0 +1,71 @@
+namespace Slypn.Api.Infrastructure;
+
+/// <summary>
+/// Configuration checks that fail the host build rather than surface at runtime. A
+/// deployment configured to serve open Admin should refuse to start, not serve.
+/// </summary>
+public static class StartupGuards
+{
+    /// <summary>
+    /// Environment names that mean "a developer's machine or a CI runner". Anything else
+    /// is treated as a deployment. Unset counts as local because
+    /// <see cref="OtelOptions.Env"/> itself defaults to "dev" — a local.settings.json that
+    /// simply omits Otel__Env must keep working.
+    /// </summary>
+    private static readonly HashSet<string> LocalEnvNames =
+        new(StringComparer.OrdinalIgnoreCase) { "dev", "local", "development" };
+
+    /// <summary>
+    /// Variables the Azure App Service / Functions host sets on every instance it runs,
+    /// and which nothing sets on a developer machine or a CI runner using Core Tools.
+    /// </summary>
+    private static readonly string[] AzureHostMarkers =
+        ["WEBSITE_INSTANCE_ID", "WEBSITE_SITE_NAME", "WEBSITE_HOSTNAME"];
+
+    /// <summary>
+    /// Refuse to start when the auth bypass is enabled anywhere it could be reached.
+    ///
+    /// <c>AzureAd:SkipAuth</c> short-circuits JWT validation in <see cref="JwtMiddleware"/>
+    /// before any other check, synthesising a principal from the X-Slypn-Dev-User header —
+    /// so any caller can ask for and receive Admin. Until now nothing but a correctly set
+    /// app setting stood between that and a live site.
+    ///
+    /// Two independent signals, because neither alone is sufficient:
+    ///
+    /// <list type="bullet">
+    /// <item>Running on an Azure host at all. This is the one that matters for PR previews:
+    /// they are real, publicly reachable deployments that deliberately run with
+    /// Otel__Env=dev, so an environment-name check on its own would wave them through.</item>
+    /// <item>An environment name that is not a local one, which catches a deployment whose
+    /// Azure markers are absent or renamed.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="skipAuth">The bound <c>AzureAd:SkipAuth</c> value.</param>
+    /// <param name="otelEnv">The bound <c>Otel:Env</c> value; null or blank counts as local.</param>
+    /// <param name="readEnvironmentVariable">
+    /// Indirection so tests can present a fake environment rather than mutating the real one.
+    /// </param>
+    /// <exception cref="InvalidOperationException">The bypass is enabled outside local dev.</exception>
+    public static void EnsureSkipAuthIsLocalOnly(
+        bool skipAuth,
+        string? otelEnv,
+        Func<string, string?> readEnvironmentVariable)
+    {
+        if (!skipAuth) return;
+
+        var azureMarker = AzureHostMarkers
+            .FirstOrDefault(name => !string.IsNullOrWhiteSpace(readEnvironmentVariable(name)));
+        if (azureMarker is not null)
+            throw Refuse($"the app is running on an Azure host ({azureMarker} is set)");
+
+        var envName = string.IsNullOrWhiteSpace(otelEnv) ? "dev" : otelEnv.Trim();
+        if (!LocalEnvNames.Contains(envName))
+            throw Refuse($"Otel:Env is '{envName}', which is not a local environment");
+    }
+
+    private static InvalidOperationException Refuse(string reason) =>
+        new($"AzureAd:SkipAuth is true but {reason}. This setting bypasses JWT validation "
+            + "entirely and grants Admin to any caller sending an X-Slypn-Dev-User header, so the "
+            + "host refuses to start rather than serve an open site. Set AzureAd__SkipAuth=false "
+            + "(infra/setup.ps1 does this for the deployed app) and redeploy.");
+}

--- a/src/api/Slypn.Api/Program.cs
+++ b/src/api/Slypn.Api/Program.cs
@@ -53,6 +53,14 @@ var host = new HostBuilder()
     })
     .ConfigureServices((context, services) =>
     {
+        // Before anything is wired up: refuse to boot if the auth bypass is on somewhere
+        // it could be reached. Throwing here propagates out of Build(), so a misconfigured
+        // deployment fails to start instead of quietly serving Admin to anyone who asks.
+        StartupGuards.EnsureSkipAuthIsLocalOnly(
+            skipAuth: context.Configuration.GetValue<bool>($"{EntraOptions.SectionName}:SkipAuth"),
+            otelEnv:  context.Configuration[$"{OtelOptions.SectionName}:Env"],
+            readEnvironmentVariable: Environment.GetEnvironmentVariable);
+
         services.Configure<WorkerOptions>(options =>
         {
             options.Serializer = new JsonObjectSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));


### PR DESCRIPTION
Closes #154 (SEC-4).

## The problem

`AzureAd:SkipAuth` short-circuits JWT validation in `JwtMiddleware` *before* every other check —
including `validator.IsConfigured` — and synthesises a principal from the `X-Slypn-Dev-User`
header. When true, any caller can ask for and receive full Admin.

Nothing in the application prevented that from being on in a deployed environment. It was correct
only because `infra/setup.ps1` happens to set it `false`, while the shipped
`local.settings.sample.json` sets it `true`. One mis-set app setting separated a normal deploy from
an anonymous-Admin site.

## The guard

`StartupGuards.EnsureSkipAuthIsLocalOnly` throws during host build, so a misconfigured deployment
refuses to boot rather than serving.

**Two independent signals — this is where I deviated from the issue.** The filed approach was an
`Otel:Env` check alone. That turns out not to protect **PR previews**, which are real, publicly
reachable deployments that deliberately run with `Otel__Env=dev` and would be waved straight
through. Since previews share production's app settings by default, that's the case that would
actually hurt. So the guard also refuses whenever it detects an Azure host at all
(`WEBSITE_INSTANCE_ID`, `WEBSITE_SITE_NAME` or `WEBSITE_HOSTNAME`).

Two deliberate leniencies, both to avoid breaking working setups:

- **Unset `Otel__Env` counts as local**, matching `OtelOptions.Env`'s own `"dev"` default — a
  `local.settings.json` that omits it must keep working. The Azure-host check is what covers a
  deployment where it's unset.
- **A present-but-blank marker is treated as absent**, so a stray empty variable can't break every
  developer machine.

The per-request bypass log moves from `Warning` to `Critical`: every request served that way is
unauthenticated Admin, and reaching it outside local dev now means the startup guard failed.

## Verification

Unit tests cover the pure function, but they don't prove the `Program.cs` wiring, so I booted the
worker three ways:

| Configuration | Result |
|---|---|
| `SkipAuth=true`, `Otel__Env=dev`, no markers | Guard passes; fails later on the unrelated `Functions:Worker:HostEndpoint` — i.e. it got past `Build()` |
| `SkipAuth=true`, `Otel__Env=dev`, `WEBSITE_SITE_NAME` set | Refused: "the app is running on an Azure host (WEBSITE_SITE_NAME is set)" |
| `SkipAuth=true`, `Otel__Env=prod` | Refused: "Otel:Env is 'prod', which is not a local environment" |

The first row is the CI e2e path — that job copies `local.settings.sample.json` and runs `func` on
the runner, so it matches exactly.

313/313 tests pass (15 new cases).

## Worth a second opinion

I could not verify that SWA-*managed* Functions actually set the `WEBSITE_*` variables — they run
on App Service infrastructure, which does, but I have no way to read the environment of the
deployed API without adding a diagnostic endpoint. If they turn out not to be set, production is
still covered by the `Otel__Env=prod` check, but **previews would fall through both**. The clean
alternative is to give previews their own environment name (`Otel__Env=preview`), which is
verifiable rather than inferred — I didn't do that unilaterally because it changes the
`deployment.environment` label your Grafana dashboards filter on.

## Not done

The issue suggested a comment in `local.settings.sample.json`. Functions requires that file to be
valid JSON with no comments, so the dev-only warning stays on `EntraOptions.SkipAuth`, where it
already is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
