### PR TITLE
fix(scripts): repair local dev setup/start scripts

### DIFF
--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -1148,12 +1148,24 @@ if (-not $SkipLocal -and $authority -and $spaClientId -and $apiScopeStr) {
         $envLines += 'VITE_FARO_ENV=local'
     }
 
-    # Preserve any non-VITE_ vars already in the file (e.g. VITE_FARO_*).
+    # Carry over any other vars already in the file (e.g. VITE_FARO_APP_NAME),
+    # keyed by name so a key written above is never appended a second time —
+    # matching on prefixes alone let VITE_FARO_URL/VITE_FARO_ENV pile up one
+    # extra copy per run. Later occurrences win, as they do for Vite.
     if (Test-Path $envLocalPath) {
-        $existing = Get-Content $envLocalPath |
-            Where-Object { $_ -notmatch '^#' -and $_ -match '=' } |
-            Where-Object { $_ -notmatch '^VITE_MSAL_|^VITE_API_SCOPE|^VITE_DEV_SKIP_AUTH' }
-        if ($existing) { $envLines += $existing }
+        $writtenKeys = [System.Collections.Generic.HashSet[string]]::new(
+            [string[]] @($envLines |
+                Where-Object { $_ -notmatch '^\s*#' -and $_ -match '=' } |
+                ForEach-Object { ($_ -split '=', 2)[0].Trim() }),
+            [StringComparer]::OrdinalIgnoreCase)
+        $carried = [ordered]@{}
+        foreach ($line in @(Get-Content $envLocalPath)) {
+            if ($line -match '^\s*#' -or $line -notmatch '=') { continue }
+            $key = ($line -split '=', 2)[0].Trim()
+            if ($writtenKeys.Contains($key)) { continue }
+            $carried[$key] = $line.Trim()
+        }
+        if ($carried.Count -gt 0) { $envLines += @($carried.Values) }
     }
 
     $envLines | Set-Content $envLocalPath -Encoding UTF8

--- a/scripts/_lib.ps1
+++ b/scripts/_lib.ps1
@@ -73,6 +73,36 @@ function Test-ContainerExists($name) {
     return [bool]($found -and $found.Trim() -eq $name)
 }
 
+# Docker fixes port publishing at create time, and a container can also come back
+# from `docker start` with its bindings silently unestablished (seen after Docker
+# Desktop upgrades): `docker inspect` then shows HostConfig.PortBindings set but
+# NetworkSettings.Ports empty, and `docker ps` lists the port with no host
+# mapping. Neither `docker start` nor `docker restart` can repair that — the
+# container has to be recreated — so check what is really published, not what was
+# requested.
+function Test-ContainerPublishesPort($name, $hostPort) {
+    $json = docker inspect $name --format '{{json .NetworkSettings.Ports}}' 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json) -or $json -eq 'null') { return $false }
+    try { $ports = $json | ConvertFrom-Json } catch { return $false }
+    foreach ($entry in $ports.PSObject.Properties) {
+        foreach ($binding in @($entry.Value)) {
+            if ($binding -and "$($binding.HostPort)" -eq "$hostPort") { return $true }
+        }
+    }
+    return $false
+}
+
+# Name of the volume a container has mounted at $destination, so a container can
+# be recreated without orphaning the data it was holding.
+function Get-ContainerVolumeName($name, $destination) {
+    $json = docker inspect $name --format '{{json .Mounts}}' 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json) -or $json -eq 'null') { return $null }
+    try { $mounts = $json | ConvertFrom-Json } catch { return $null }
+    return (@($mounts) |
+        Where-Object { $_.Type -eq 'volume' -and $_.Destination -eq $destination } |
+        Select-Object -First 1).Name
+}
+
 function Wait-Port($port, $timeoutSec) {
     $start = Get-Date
     while (((Get-Date) - $start).TotalSeconds -lt $timeoutSec) {

--- a/scripts/setupLocal.ps1
+++ b/scripts/setupLocal.ps1
@@ -10,6 +10,10 @@
   (npm) and API (dotnet) dependencies, and copies local.settings.sample.json
   to local.settings.json if not already present.
 
+  Web dependencies are stamped with a hash of package.json + package-lock.json,
+  so a re-run skips `npm ci` entirely when neither has changed. Pass -Reinstall
+  to force the clean reinstall.
+
   Local auth mode: infra/setup.ps1 configures the *capability* to sign in with
   Entra locally (it writes the MSAL credentials); this script owns the on/off
   toggle. Pass -EntraLogin to flip it:
@@ -28,12 +32,18 @@
 
 .EXAMPLE
   .\scripts\setupLocal.ps1 -EntraLogin on  # switch to real Entra sign-in
+
+.EXAMPLE
+  .\scripts\setupLocal.ps1 -Reinstall     # force a clean `npm ci` reinstall
 #>
 
 [CmdletBinding()]
 param(
     [ValidateSet('on', 'off')]
-    [string] $EntraLogin
+    [string] $EntraLogin,
+
+    # Force `npm ci` even when the dependency stamp says node_modules is current.
+    [switch] $Reinstall
 )
 
 $ErrorActionPreference = 'Stop'
@@ -111,13 +121,43 @@ if ($EntraLogin) {
     return
 }
 
-# Refuse to run while the dev stack is up — `npm ci` wipes node_modules and would
-# fail (EPERM) trying to delete files the running Vite/func processes have open.
-foreach ($p in @($WebPort, $ApiPort)) {
-    if (Test-Port $p) {
-        Show-Err "Port $p is in use — the dev stack looks like it's running."
-        Show-Err 'Stop it first:  .\scripts\stopLocal.ps1   (then re-run setupLocal.ps1)'
-        exit 1
+# --- are the web dependencies already current? ------------------------------
+# `npm ci` always deletes node_modules and reinstalls from the lockfile, which
+# costs minutes for a tree this size. Stamp each successful install with a hash
+# of package.json + package-lock.json and skip the reinstall while both are
+# unchanged. The stamp lives inside node_modules, so wiping that folder (or an
+# interrupted install) correctly forces a fresh one.
+$webPkgPath   = Join-Path $WebDir 'package.json'
+$webLockPath  = Join-Path $WebDir 'package-lock.json'
+$webModules   = Join-Path $WebDir 'node_modules'
+$webStampPath = Join-Path $webModules '.slypn-deps-stamp'
+
+function Get-WebDepsHash {
+    $parts = foreach ($file in @($webPkgPath, $webLockPath)) {
+        if (Test-Path $file) { (Get-FileHash $file -Algorithm SHA256).Hash } else { 'missing' }
+    }
+    return ($parts -join '-')
+}
+
+$webDepsHash = Get-WebDepsHash
+$needsNpmInstall =
+    $Reinstall -or
+    -not (Test-Path $webModules) -or
+    -not (Test-Path $webStampPath) -or
+    ((Get-Content $webStampPath -Raw).Trim() -ne $webDepsHash)
+
+# Refuse to run while the dev stack is up ONLY when we are about to reinstall —
+# `npm ci` wipes node_modules and would fail (EPERM) trying to delete files the
+# running Vite/func processes have open. When the stamp says the tree is already
+# current there is nothing to wipe, so the script is safe against a live stack.
+if ($needsNpmInstall) {
+    foreach ($p in @($WebPort, $ApiPort)) {
+        if (Test-Port $p) {
+            Show-Err "Port $p is in use — the dev stack looks like it's running."
+            Show-Err 'Web dependencies changed, so this run needs a clean npm ci.'
+            Show-Err 'Stop it first:  .\scripts\stopLocal.ps1   (then re-run setupLocal.ps1)'
+            exit 1
+        }
     }
 }
 
@@ -135,6 +175,12 @@ if ($major -lt 20) {
     exit 1
 }
 Show-Ok "Node $nodeVersion"
+# Some dependencies (undici, eslint-visitor-keys) declare engines newer than
+# this; npm only warns (EBADENGINE) and installs anyway, but CI runs latest 22.x.
+$nodeParts = ($nodeVersion.TrimStart('v') -split '\.')
+if ($major -eq 22 -and [int]$nodeParts[1] -lt 19) {
+    Show-Warn "Node $nodeVersion triggers npm EBADENGINE warnings — 22.19+ (or 24) matches CI and silences them."
+}
 
 # --- .NET 8 SDK -------------------------------------------------------------
 Show-Step 'Checking .NET SDK'
@@ -204,20 +250,34 @@ Show-Step 'Checking Docker (for Azurite)'
 if (Test-DockerRunning) {
     $dockerVersion = docker version --format '{{.Server.Version}}' 2>$null
     Show-Ok "Docker $dockerVersion"
+    # Flag the failure mode startLocal.ps1 now repairs, so it is visible here too.
+    if ((Test-ContainerExists $AzuriteContainer) -and
+        -not (Test-ContainerPublishesPort $AzuriteContainer $AzuriteBlobPort)) {
+        Show-Warn "$AzuriteContainer exists but publishes no host port $AzuriteBlobPort."
+        Show-Warn 'startLocal.ps1 will recreate it (keeping its data volume) on the next run.'
+    }
 } else {
     Show-Warn 'Docker daemon is not reachable. Start Docker Desktop before running scripts/startLocal.ps1.'
     Show-Warn 'Without Docker, startLocal.ps1 must be invoked with -NoEmulators (API will skip Table/Blob storage).'
 }
 
 # --- web deps ---------------------------------------------------------------
-Show-Step "npm ci in $WebDir"
-Push-Location $WebDir
-try {
-    npm ci --no-fund --no-audit
-    if ($LASTEXITCODE -ne 0) { throw 'npm ci failed' }
-    Show-Ok 'web dependencies installed'
+Show-Step "Web dependencies in $WebDir"
+if (-not $needsNpmInstall) {
+    Show-Ok 'Already current — package.json and package-lock.json are unchanged since the last install.'
+    Write-Host '    Force a clean reinstall with: .\scripts\setupLocal.ps1 -Reinstall' -ForegroundColor DarkGray
+} else {
+    Push-Location $WebDir
+    try {
+        npm ci --no-fund --no-audit
+        if ($LASTEXITCODE -ne 0) { throw 'npm ci failed' }
+        # Re-hash after the install so the stamp reflects what npm actually left
+        # on disk, then write it last — a failed install leaves no stamp.
+        Get-WebDepsHash | Set-Content $webStampPath -Encoding UTF8
+        Show-Ok 'web dependencies installed'
+    }
+    finally { Pop-Location }
 }
-finally { Pop-Location }
 
 # --- API deps ---------------------------------------------------------------
 Show-Step "dotnet restore in $ApiDir"
@@ -264,8 +324,26 @@ function Get-EnvLocalVar([string]$name) {
     return ''
 }
 
-$currentUrl     = Get-EnvLocalVar 'VITE_FARO_URL'
-$currentAppName = Get-EnvLocalVar 'VITE_FARO_APP_NAME'
+# infra/setup.ps1 collects the Faro settings into infra/secrets.json but only
+# mirrors VITE_FARO_URL/VITE_FARO_ENV into .env.local — the FARO_SOURCEMAP_*
+# set goes to GitHub secrets instead. Fall back to secrets.json so re-running
+# shows what is already configured rather than an empty prompt.
+$secretsPath = Join-Path $RepoRoot 'infra/secrets.json'
+$secrets = @{}
+if (Test-Path $secretsPath) {
+    try { $secrets = Get-Content $secretsPath -Raw | ConvertFrom-Json -AsHashtable }
+    catch { Show-Warn "Could not read $secretsPath — prompt defaults may be blank." }
+}
+
+function Get-FaroCurrent([string] $envName, [string] $secretName) {
+    $value = Get-EnvLocalVar $envName
+    if (-not [string]::IsNullOrWhiteSpace($value)) { return $value }
+    if ($secretName -and $secrets.Contains($secretName)) { return [string] $secrets[$secretName] }
+    return ''
+}
+
+$currentUrl     = Get-FaroCurrent 'VITE_FARO_URL'      'faroUrl'
+$currentAppName = Get-FaroCurrent 'VITE_FARO_APP_NAME' ''
 
 $hintUrl     = if ($currentUrl)     { " [$currentUrl]" }     else { '' }
 $hintAppName = if ($currentAppName) { " [$currentAppName]" } else { ' [slypn-web]' }
@@ -276,10 +354,10 @@ $inputAppName = Read-Host "  ? Faro app name$hintAppName"
 $faroUrl     = if (-not [string]::IsNullOrWhiteSpace($inputUrl))     { $inputUrl.Trim() }     else { $currentUrl }
 $faroAppName = if (-not [string]::IsNullOrWhiteSpace($inputAppName)) { $inputAppName.Trim() } else { if ($currentAppName) { $currentAppName } else { 'slypn-web' } }
 
-$currentSmEndpoint = Get-EnvLocalVar 'FARO_SOURCEMAP_ENDPOINT'
-$currentSmAppId    = Get-EnvLocalVar 'FARO_SOURCEMAP_APP_ID'
-$currentSmStackId  = Get-EnvLocalVar 'FARO_SOURCEMAP_STACK_ID'
-$currentSmApiKey   = Get-EnvLocalVar 'FARO_SOURCEMAP_API_KEY'
+$currentSmEndpoint = Get-FaroCurrent 'FARO_SOURCEMAP_ENDPOINT' 'faroSourcemapEndpoint'
+$currentSmAppId    = Get-FaroCurrent 'FARO_SOURCEMAP_APP_ID'   'faroSourcemapAppId'
+$currentSmStackId  = Get-FaroCurrent 'FARO_SOURCEMAP_STACK_ID' 'faroSourcemapStackId'
+$currentSmApiKey   = Get-FaroCurrent 'FARO_SOURCEMAP_API_KEY'  'faroSourcemapApiKey'
 
 $hintSmEndpoint = if ($currentSmEndpoint) { " [$currentSmEndpoint]" } else { '' }
 $hintSmAppId    = if ($currentSmAppId)    { " [$currentSmAppId]" }    else { '' }
@@ -311,8 +389,18 @@ if (-not [string]::IsNullOrWhiteSpace($faroSmApiKey))   { $faroKvPairs.Add([pscu
 if ($faroKvPairs.Count -gt 0) {
     $lines = if (Test-Path $envLocalPath) { @(Get-Content $envLocalPath) } else { @('# Created by scripts/setupLocal.ps1') }
     foreach ($kv in $faroKvPairs) {
-        if ($lines -match "^\s*$($kv.Key)\s*=") {
-            $lines = $lines -replace "^\s*$($kv.Key)\s*=.*", "$($kv.Key)=$($kv.Value)"
+        $pattern = "^\s*$([regex]::Escape($kv.Key))\s*="
+        if ($lines -match $pattern) {
+            # Rewrite the first occurrence and drop the rest, so a file that
+            # earlier runs left with duplicate keys is repaired rather than
+            # having every copy rewritten to the same value.
+            $written = $false
+            $lines = @(foreach ($line in $lines) {
+                if ($line -notmatch $pattern) { $line; continue }
+                if ($written) { continue }
+                $written = $true
+                "$($kv.Key)=$($kv.Value)"
+            })
         } else {
             $lines += "$($kv.Key)=$($kv.Value)"
         }

--- a/scripts/startLocal.ps1
+++ b/scripts/startLocal.ps1
@@ -59,6 +59,25 @@ if (-not $NoEmulators) {
         exit 1
     }
 
+    # Creates the container with the port publishing baked in. $DataVolume lets a
+    # recreate reuse the previous container's /data volume so seeded blobs and
+    # tables survive; omit it and Docker allocates a fresh anonymous volume.
+    function New-AzuriteContainer([string] $DataVolume) {
+        $runArgs = @(
+            'run', '-d', '--name', $AzuriteContainer,
+            '-p', "${AzuriteBlobPort}:10000",
+            '-p', "${AzuriteQueuePort}:10001",
+            '-p', "${AzuriteTablePort}:10002"
+        )
+        if ($DataVolume) { $runArgs += @('-v', "${DataVolume}:/data") }
+        $runArgs += $AzuriteImage
+        docker @runArgs | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Show-Err "Failed to create $AzuriteContainer. See the docker output above."
+            exit 1
+        }
+    }
+
     Show-Step 'Ensuring Azurite container'
     if (Test-ContainerRunning $AzuriteContainer) {
         Show-Ok "$AzuriteContainer already running"
@@ -66,19 +85,30 @@ if (-not $NoEmulators) {
         docker start $AzuriteContainer | Out-Null
         Show-Ok "$AzuriteContainer started"
     } else {
-        docker run -d --name $AzuriteContainer `
-            -p "${AzuriteBlobPort}:10000" `
-            -p "${AzuriteQueuePort}:10001" `
-            -p "${AzuriteTablePort}:10002" `
-            $AzuriteImage | Out-Null
+        New-AzuriteContainer
         Show-Ok "$AzuriteContainer created"
     }
-    if (-not (Wait-Port $AzuriteBlobPort 30)) {
-        Show-Err "Azurite blob port $AzuriteBlobPort did not come up in 30s. See: docker logs $AzuriteContainer"
-        exit 1
+
+    # A running container is not the same as a reachable one: an existing
+    # container can come back from `docker start` publishing nothing, which no
+    # amount of restarting fixes. Detect that and rebuild it around the same data
+    # volume, rather than waiting 30s to fail with a misleading message.
+    if (-not (Test-ContainerPublishesPort $AzuriteContainer $AzuriteBlobPort)) {
+        Show-Warn "$AzuriteContainer is not publishing host port $AzuriteBlobPort — Docker never established its bindings."
+        Show-Warn 'Port publishing is fixed at create time, so recreating the container is the only fix.'
+        $dataVolume = Get-ContainerVolumeName $AzuriteContainer '/data'
+        if ($dataVolume) { Show-Warn "Reusing data volume $dataVolume so seeded data survives." }
+        docker rm -f $AzuriteContainer | Out-Null
+        New-AzuriteContainer -DataVolume $dataVolume
+        Show-Ok "$AzuriteContainer recreated with ports $AzuriteBlobPort-$AzuriteTablePort published"
     }
-    if (-not (Wait-Port $AzuriteTablePort 30)) {
-        Show-Err "Azurite table port $AzuriteTablePort did not come up in 30s. See: docker logs $AzuriteContainer"
+
+    foreach ($svc in @(@{ Name = 'blob'; Port = $AzuriteBlobPort }, @{ Name = 'table'; Port = $AzuriteTablePort })) {
+        if (Wait-Port $svc.Port 30) { continue }
+        Show-Err "Azurite $($svc.Name) port $($svc.Port) did not come up in 30s."
+        Show-Err "Container status: $(docker ps -a --filter "name=^/$AzuriteContainer$" --format '{{.Status}} | ports: {{.Ports}}')"
+        Show-Err "Logs:  docker logs $AzuriteContainer"
+        Show-Err "Rebuild from scratch (loses seeded data):  .\scripts\cleanLocal.ps1"
         exit 1
     }
     Show-Ok "Azurite ready on http://127.0.0.1:$AzuriteBlobPort/ (blob) + :$AzuriteTablePort (table)"


### PR DESCRIPTION
Three unrelated faults found while running `setupLocal.ps1` and `startLocal.ps1`.

### `.env.local` grew a duplicate Faro pair on every `infra/setup.ps1` run

The script wrote `VITE_FARO_URL`/`VITE_FARO_ENV`, then "preserved" existing lines by excluding only `VITE_MSAL_*`/`VITE_API_SCOPE`/`VITE_DEV_SKIP_AUTH` — so it carried forward the very keys it had just written, one extra pair per run. The carry-over is now keyed by variable name.

`setupLocal.ps1` couldn't clean it up either: `$lines -replace` rewrites *every* matching line, so all copies just got set to the same value. It now rewrites the first occurrence and drops the rest, so an already-polluted file self-heals.

### Blank defaults for the `FARO_SOURCEMAP_*` prompts

Those four values only ever lived in `infra/secrets.json` and GitHub secrets, never in `.env.local` — which was the only place the prompts looked. They now fall back to `secrets.json`, so a re-run offers what is already configured (API key masked).

### `npm ci` ran unconditionally

`npm ci` always deletes `node_modules` and reinstalls, which is slow for a 340MB tree and cannot run while Vite holds files open. Each successful install is now stamped with a hash of `package.json` + `package-lock.json` and skipped while both are unchanged; `-Reinstall` forces it. The port guard now only blocks when an install is genuinely needed, so a routine re-run works against a live stack.

Also adds a non-fatal warning when Node is older than 22.19 — `undici@8.5.0` and `eslint-visitor-keys@5.0.1` declare newer engines and emit `EBADENGINE`. CI pins `node-version: '22'` (latest 22.x) and is unaffected; the hard floor stays at Node 20.

### `startLocal.ps1` looped forever on an unpublished container

The Azurite container had `HostConfig.PortBindings` set but `NetworkSettings.Ports` empty — running and listening internally, but nothing reaching the host. `Test-ContainerRunning` returned true, so the script sailed past into a 30s wait on a port nothing could ever bind, then blamed the logs, where nothing was wrong.

Port publishing is fixed at create time, so neither `docker start` nor `docker restart` can repair it. `startLocal.ps1` now checks what is *actually* published and recreates the container around its existing `/data` volume, preserving seeded data. `setupLocal.ps1` reports the same condition; shared helpers live in `_lib.ps1`.

## Testing

- Web lint clean; 400 unit tests across 38 files pass.
- All four scripts parse clean via the PowerShell AST parser.
- `startLocal.ps1` exercised the repair path for real — detected the fault, reused volume `2205c605…`, and brought up Azurite + Vite + Functions.
- `setupLocal.ps1` run end to end against the live stack: skipped `npm ci`, did not trip the port guard, and wrote the source-map values into `.env.local`, which is now duplicate-free.
- Repeated simulated `infra/setup.ps1` runs are idempotent; five pre-existing duplicate pairs collapsed to one.

No application code changed — PowerShell dev scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
