### PR TITLE
fix(ci): stop preview environments outliving their PRs

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -13,6 +13,10 @@ name: Azure Static Web Apps deploy
 on:
   push:
     branches: [main]
+  # Nightly safety net for the orphan reaper, so a quiet period on main cannot
+  # let dead preview environments sit on the Free-tier cap.
+  schedule:
+    - cron: '17 4 * * *'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches: [main]
@@ -27,7 +31,10 @@ concurrency:
   # PR, leaving the preview environment never torn down. Multiple pushes to
   # the same branch/PR still cancel the earlier in-progress run as intended.
   group: swa-${{ github.ref }}-${{ github.event_name }}-${{ github.event.action == 'closed' && 'close' || 'build' }}
-  cancel-in-progress: true
+  # Builds still supersede each other, but a teardown must never be cancelled:
+  # PR #166's close run was cancelled mid-flight and its preview environment
+  # then sat there consuming a Free-tier slot until it was deleted by hand.
+  cancel-in-progress: ${{ github.event.action != 'closed' }}
 
 jobs:
   build_and_deploy:
@@ -247,3 +254,104 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           action: close
+
+      # The close action reports success without checking that anything was
+      # actually removed, and it loses a race it cannot see: for PR #162 it ran
+      # at 23:12:57, found no environment, exited green — and an in-flight
+      # preview deploy created environment 162 ten seconds later, where it sat
+      # in a Failed state consuming a slot. Deliberately splitting close into
+      # its own concurrency group (so it cannot cancel a build) is what allows
+      # a build to outlive it, so watch for a late arrival rather than assuming
+      # the close won. Deleting is idempotent, so a slow first appearance and a
+      # close that genuinely worked both end in the same state.
+      - name: Verify the preview environment is really gone
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          env_present() {
+            local count
+            count=$(az staticwebapp environment list               --name swa-slypn-prod --resource-group rg-slypn-prod               --query "[?name=='$PR_NUMBER'] | length(@)" -o tsv)
+            [ "$count" != "0" ]
+          }
+
+          absent_streak=0
+          for attempt in $(seq 1 10); do
+            if env_present; then
+              echo "attempt $attempt/10: environment $PR_NUMBER present — deleting."
+              az staticwebapp environment delete                 --name swa-slypn-prod --resource-group rg-slypn-prod                 --environment-name "$PR_NUMBER" --yes
+              absent_streak=0
+            else
+              absent_streak=$((absent_streak + 1))
+              echo "attempt $attempt/10: no environment for PR #$PR_NUMBER (absent x$absent_streak)."
+              # Gone for three consecutive checks (~30s). A deploy still in
+              # flight when the PR closed would have surfaced by now, so stop
+              # rather than burn the full window on every well-behaved close.
+              if [ "$absent_streak" -ge 3 ]; then break; fi
+            fi
+            sleep 15
+          done
+
+          if env_present; then
+            echo "::error::Environment $PR_NUMBER survived every delete attempt — free the slot by hand."
+            exit 1
+          fi
+          echo "PR #$PR_NUMBER has no preview environment."
+
+  # Backstop for anything the per-PR teardown misses: a cancelled close run, a
+  # deploy that outlived it, a PR closed while Actions was down. Reconciles the
+  # whole list against the open PRs rather than trusting any single event, so
+  # the Free-tier cap cannot silently fill up again the way it did with 162 and
+  # 166 — both orphaned by closed PRs and only noticed when a new PR was blocked.
+  reap_orphan_previews:
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    name: Reap orphaned preview environments
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Delete preview environments with no open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # "default" is production and is never a preview environment.
+          ENVS=$(az staticwebapp environment list             --name swa-slypn-prod --resource-group rg-slypn-prod             --query "[?name!='default'].name" -o tsv)
+
+          if [ -z "$ENVS" ]; then
+            echo "No preview environments exist."
+            exit 0
+          fi
+
+          OPEN_PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open             --limit 200 --json number --jq '.[].number')
+          echo "Open PRs: ${OPEN_PRS:-none}"
+
+          REAPED=0
+          for env in $ENVS; do
+            # Only ever touch environments named after a PR number; anything
+            # else was created by hand and is not ours to delete.
+            if ! echo "$env" | grep -qE '^[0-9]+$'; then
+              echo "Skipping non-PR environment '$env'."
+              continue
+            fi
+            if echo "$OPEN_PRS" | grep -qx "$env"; then
+              echo "Keeping $env — PR #$env is still open."
+              continue
+            fi
+            echo "Reaping $env — PR #$env is not open."
+            az staticwebapp environment delete               --name swa-slypn-prod --resource-group rg-slypn-prod               --environment-name "$env" --yes
+            REAPED=$((REAPED + 1))
+          done
+
+          echo "Reaped $REAPED orphaned preview environment(s)."


### PR DESCRIPTION
Preview environments `162` and `166` sat on the Free-tier cap until they were deleted by hand, blocking #168's deploy. Two different faults produced them, and **neither was reported** — both close jobs looked fine.

### `#166` — the close run was cancelled

`cancel-in-progress: true` applied to the close concurrency group as well as the build one, so #166's teardown was cancelled mid-flight at 01:59:01 and its environment was never removed. A teardown isn't superseded by anything, so cancellation is now limited to builds:

```yaml
cancel-in-progress: ${{ github.event.action != 'closed' }}
```

### `#162` — the close won a race it didn't know it was in

| Time | Event |
|---|---|
| 23:12:15 | PR merged |
| 23:12:57 | close action runs, finds nothing, prints *"Looking for event info… Exiting"*, exits **green** |
| 23:13:07 | environment `162` is **created** by an in-flight deploy, then lands in `Failed` |

Splitting close into its own concurrency group — so a teardown can't cancel a build — is exactly what allows a build to outlive it. The close job now watches for a late arrival instead of trusting a single lookup, deleting whatever it finds until the environment stays gone. It breaks early once the environment has been absent for three consecutive checks (~30s), so a well-behaved close doesn't burn the full window, and it now **fails loudly** if an environment survives every attempt instead of reporting success.

### The reaper

Both faults share a shape: per-PR teardown driven by a single event, with nothing checking the result. A new `reap_orphan_previews` job reconciles the full environment list against open PRs on every push to `main` and nightly at 04:17 UTC, so an orphan from a cancelled run, a late deploy, or a PR closed while Actions was down gets collected without a blocked PR being the thing that surfaces it.

Safety properties, both tested:
- only touches environments whose name is a **PR number** — hand-made environments are skipped
- **aborts without deleting anything** if the open-PR lookup fails, rather than treating an empty list as "reap everything"

## Testing

Both new `run` blocks were extracted and exercised against stubbed `az`/`gh`:

| Scenario | Result |
|---|---|
| Reaper: mixed envs `162, 166, 167, manual-test`, PRs 167/169 open | reaps 162+166, keeps 167, skips `manual-test` |
| Reaper: `gh pr list` fails | exits 1, deletes nothing |
| Verify: clean close, env never appears | breaks after 3 checks, 0 deletes, exit 0 |
| Verify: #162 race, env appears at check 2 | deletes it, confirms gone, exit 0 |
| Verify: env cannot be deleted | 10 attempts, `::error::`, exit 1 |

YAML parses; all embedded `run` blocks pass `bash -n`.

Note the reaper only runs on `push`/`schedule`, so it won't execute on this PR — its first real run is the merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
