### PR TITLE
fix(ci): tolerate unpollable deletes, and gate production deploy on CI

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -270,6 +270,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          # `az staticwebapp environment delete` issues the delete and then polls
+          # Microsoft.Web/locations/staticSitesOperationStatuses, which the CI
+          # service principal cannot read — so it exits non-zero with
+          # AuthorizationFailed *after* the delete has already been accepted.
+          # The environment listing is the real source of truth, and this loop
+          # re-checks it anyway, so ignore the exit code rather than failing a
+          # teardown that actually worked.
+          delete_env() {
+            az staticwebapp environment delete               --name swa-slypn-prod --resource-group rg-slypn-prod               --environment-name "$1" --yes >/dev/null 2>&1 || true
+          }
+
           env_present() {
             local count
             count=$(az staticwebapp environment list               --name swa-slypn-prod --resource-group rg-slypn-prod               --query "[?name=='$PR_NUMBER'] | length(@)" -o tsv)
@@ -280,7 +291,7 @@ jobs:
           for attempt in $(seq 1 10); do
             if env_present; then
               echo "attempt $attempt/10: environment $PR_NUMBER present — deleting."
-              az staticwebapp environment delete                 --name swa-slypn-prod --resource-group rg-slypn-prod                 --environment-name "$PR_NUMBER" --yes
+              delete_env "$PR_NUMBER"
               absent_streak=0
             else
               absent_streak=$((absent_streak + 1))
@@ -337,7 +348,14 @@ jobs:
           OPEN_PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open             --limit 200 --json number --jq '.[].number')
           echo "Open PRs: ${OPEN_PRS:-none}"
 
-          REAPED=0
+          # Same AuthorizationFailed caveat as the teardown step above: the
+          # delete lands, the status poll is refused. Verify by re-listing below
+          # rather than trusting the exit code.
+          delete_env() {
+            az staticwebapp environment delete               --name swa-slypn-prod --resource-group rg-slypn-prod               --environment-name "$1" --yes >/dev/null 2>&1 || true
+          }
+
+          REAPED=""
           for env in $ENVS; do
             # Only ever touch environments named after a PR number; anything
             # else was created by hand and is not ours to delete.
@@ -350,8 +368,26 @@ jobs:
               continue
             fi
             echo "Reaping $env — PR #$env is not open."
-            az staticwebapp environment delete               --name swa-slypn-prod --resource-group rg-slypn-prod               --environment-name "$env" --yes
-            REAPED=$((REAPED + 1))
+            delete_env "$env"
+            REAPED="$REAPED $env"
           done
 
-          echo "Reaped $REAPED orphaned preview environment(s)."
+          if [ -z "$REAPED" ]; then
+            echo "Nothing to reap."
+            exit 0
+          fi
+
+          # Confirm against a fresh listing, so a delete that was refused rather
+          # than merely unpollable still fails the job instead of passing quietly.
+          REMAINING=$(az staticwebapp environment list             --name swa-slypn-prod --resource-group rg-slypn-prod             --query "[?name!='default'].name" -o tsv)
+
+          STUCK=""
+          for env in $REAPED; do
+            if echo "$REMAINING" | grep -qx "$env"; then STUCK="$STUCK $env"; fi
+          done
+
+          if [ -n "$STUCK" ]; then
+            echo "::error::Preview environment(s) survived deletion:$STUCK"
+            exit 1
+          fi
+          echo "Reaped:$REAPED"


### PR DESCRIPTION
Two changes to the SWA workflow.

## 1. The reaper failed on its first live run

```
Reaping 169 — PR #169 is not open.
ERROR: (AuthorizationFailed) ... does not have authorization to perform action
'Microsoft.Web/locations/staticSitesOperationStatuses/read'
```

`az staticwebapp environment delete` issues the delete and then polls a location-scoped operation-status endpoint the CI service principal can't read, so it exits non-zero **after the delete has already been accepted**. Environment 169 was in fact removed — only the poll was refused. This didn't surface in testing because the orphans cleared by hand were deleted with a user account, not the workflow's principal.

Both delete sites now ignore the exit code and confirm against a fresh environment listing — the real source of truth, already being consulted. The teardown re-checks presence every iteration so needed nothing more; the reaper re-lists at the end and fails if anything it tried to reap survives, so a genuinely refused delete still breaks the build rather than passing quietly.

The alternative is granting that permission, a wider Azure role than the reaper needs for a call the listing already answers.

The close job passed on that same run only because the environment was already gone, so it never issued a delete. It had the same latent bug; this covers both paths.

## 2. Production deployed in parallel with CI

`ci.yml` and this workflow both triggered on `push: [main]`, with no `workflow_run` or cross-workflow `needs` between them — so on every merge, CI and the production deploy started **at the same time** and a commit whose tests failed shipped anyway.

That's reachable because `required_status_checks.strict` is `false`: a branch green when it was cut can merge into a `main` it was never tested against. Three merges landed today from branches cut at different points.

Production now hangs off `workflow_run` for CI on `main`, running only when `conclusion == 'success'` — a `workflow_run` fires on completion whatever the outcome, so the conclusion check does the gating. `push` still triggers the workflow, but only the reaper runs on it.

The deploy checks out `github.event.workflow_run.head_sha` rather than the default branch, which may have moved on by the time CI finishes, so what ships is the commit that passed. The four steps treating `push` as "production" — version string, `Otel__Env`, `VITE_FARO_ENV`, production appsettings — now key off `workflow_run`. **PR previews are untouched**, so the required "Build + deploy" check still reports on PRs.

Gating on E2E creates no circularity: that job installs Functions Core Tools and runs its own API, so it never depends on the deployment.

### Trade-offs

- Deploys land a few minutes later than the merge.
- A CI run cancelled by a rapid follow-up merge deploys nothing; the next merge's CI covers both commits.

## Testing

| Scenario | deploy | reap | close |
|---|---|---|---|
| merge: push half | no | **yes** | no |
| merge: CI green | **yes** | no | no |
| merge: CI **red** | **no** | no | no |
| merge: CI cancelled | **no** | no | no |
| PR opened/synced | **yes** | no | no |
| PR closed | no | no | **yes** |
| nightly schedule | no | **yes** | no |

Reaper/teardown scenarios, against stubbed `az`/`gh`:

| Scenario | Result |
|---|---|
| delete works, `az` exits 1 (the real failure) | exit 0, reaps 169, keeps 167 |
| delete genuinely refused, env survives | `::error::`, exit 1 |
| teardown: env present, delete unpollable but effective | deletes, confirms gone, exit 0 |

YAML parses; `bash -n` clean on both run blocks.

⚠️ **`workflow_run` only takes effect once this is on the default branch**, so the new gate cannot be exercised by this PR — its first real run is the merge itself, and the production deploy for that merge will come from the CI run rather than the push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
