### PR TITLE
fix(api): force rel=noopener on target=_blank links (SEC-7)

### DIFF
--- a/src/api/Slypn.Api.Tests/HtmlSanitizerTests.cs
+++ b/src/api/Slypn.Api.Tests/HtmlSanitizerTests.cs
@@ -90,4 +90,58 @@ public class HtmlSanitizerTests
         Assert.Equal(string.Empty, _sut.Sanitize(""));
         Assert.Equal(string.Empty, _sut.Sanitize("   "));
     }
+
+    // A target="_blank" link hands the opened page a window.opener handle back to
+    // this tab unless rel says otherwise, so the sanitiser forces it rather than
+    // trusting the author to have written it.
+    [Theory]
+    [InlineData("<a href=\"https://x.example\" target=\"_blank\">x</a>")]
+    [InlineData("<a target=\"_blank\" href=\"https://x.example\">x</a>")]
+    [InlineData("<a href=\"https://x.example\" target=\"_BLANK\">x</a>")]
+    public void Sanitize_ForcesNoopenerOnBlankTargets(string html)
+    {
+        var output = _sut.Sanitize(html);
+
+        var rel = RelOf(output);
+        Assert.Contains("noopener", rel, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("noreferrer", rel, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    // Already correct — must not gain a second copy of either token.
+    [InlineData("<a href=\"https://x.example\" target=\"_blank\" rel=\"noopener noreferrer\">x</a>", new[] { "noopener", "noreferrer" })]
+    [InlineData("<a href=\"https://x.example\" target=\"_blank\" rel=\"noopener\">x</a>", new[] { "noopener", "noreferrer" })]
+    // An author's own rel is meaningful and must survive alongside ours.
+    [InlineData("<a href=\"https://x.example\" target=\"_blank\" rel=\"nofollow\">x</a>", new[] { "nofollow", "noopener", "noreferrer" })]
+    public void Sanitize_MergesExistingRelWithoutDuplicating(string html, string[] expected)
+    {
+        var output = _sut.Sanitize(html);
+
+        var tokens = RelOf(output).Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(expected.Length, tokens.Length);
+        foreach (var token in expected)
+        {
+            Assert.Single(tokens, t => t.Equals(token, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    [Theory]
+    // No target, or a target we are not worried about: leave rel alone entirely.
+    [InlineData("<a href=\"https://x.example\">x</a>")]
+    [InlineData("<a href=\"https://x.example\" target=\"_self\">x</a>")]
+    [InlineData("<a href=\"mailto:hello@example.com\">mail</a>")]
+    public void Sanitize_LeavesNonBlankLinksAlone(string html)
+    {
+        var output = _sut.Sanitize(html);
+
+        Assert.DoesNotContain("rel=", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Value of the first rel attribute, or empty if there isn't one.</summary>
+    private static string RelOf(string html)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(
+            html, "rel=\"(?<rel>[^\"]*)\"", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups["rel"].Value : string.Empty;
+    }
 }

--- a/src/api/Slypn.Api/Services/HtmlSanitizer.cs
+++ b/src/api/Slypn.Api/Services/HtmlSanitizer.cs
@@ -1,3 +1,4 @@
+using AngleSharp.Dom;
 using Ganss.Xss;
 
 namespace Slypn.Api.Services;
@@ -33,6 +34,13 @@ public sealed class HtmlSanitizer : IHtmlSanitizer
         "http", "https", "mailto",
     };
 
+    /// <summary>
+    /// Forced onto every <c>target="_blank"</c> link. Without <c>noopener</c> the
+    /// opened page gets a <c>window.opener</c> handle back to this tab and can
+    /// navigate it elsewhere (reverse tabnabbing).
+    /// </summary>
+    private static readonly string[] RequiredBlankRel = { "noopener", "noreferrer" };
+
     private readonly Ganss.Xss.HtmlSanitizer _inner;
 
     public HtmlSanitizer()
@@ -46,8 +54,33 @@ public sealed class HtmlSanitizer : IHtmlSanitizer
         foreach (var s in AllowedSchemes) _inner.AllowedSchemes.Add(s);
         // Defence in depth — no CSS even if a span sneaks one in.
         _inner.AllowedCssProperties.Clear();
-        // Refuse data: URIs everywhere (we upload images to Blob and link by URL).
+        // No CSS at-rules either (@import, @media and friends). data: URIs are
+        // already refused by the AllowedSchemes allowlist above, not by this.
         _inner.AllowedAtRules.Clear();
+
+        // Enforced after the allowlist has run, so it applies to whatever
+        // survives. Forcing rel is preferred over dropping target from the
+        // allowlist, which would change how already-published links behave.
+        _inner.PostProcessNode += (_, e) =>
+        {
+            if (e.Node is not IElement element) return;
+            if (!element.TagName.Equals("a", StringComparison.OrdinalIgnoreCase)) return;
+            if (!string.Equals(element.GetAttribute("target"), "_blank", StringComparison.OrdinalIgnoreCase)) return;
+
+            // Merge rather than overwrite: an author's existing rel may carry
+            // something meaningful like nofollow, and a token already present
+            // must not be added twice.
+            var tokens = (element.GetAttribute("rel") ?? string.Empty)
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+
+            foreach (var required in RequiredBlankRel)
+            {
+                if (!tokens.Contains(required, StringComparer.OrdinalIgnoreCase)) tokens.Add(required);
+            }
+
+            element.SetAttribute("rel", string.Join(' ', tokens));
+        };
     }
 
     public string Sanitize(string? html)


### PR DESCRIPTION
Closes #157.

## Problem

The allowlist permitted `target` and `rel` on `<a>` but never *required* one, so an article body could publish `<a target="_blank">` and hand the opened page a `window.opener` handle back to the SLYPN tab — reverse tabnabbing. Article bodies are Contributor-authored, so it's low-privilege-to-low-impact.

## Fix

A `PostProcessNode` handler forces `noopener noreferrer` onto any link carrying `target="_blank"`, running *after* the allowlist so it applies to whatever survives. Forcing `rel` is preferred over dropping `target` from the allowlist, which would change how already-published links behave.

An existing `rel` is **merged, not overwritten** — `nofollow` survives alongside, and a token already present isn't added twice.

Also corrects the misleading comment the issue flagged: `AllowedAtRules` governs CSS at-rules, not URI schemes. `data:` was already refused by `AllowedSchemes` just above, so only the comment was wrong.

## Acceptance criteria

- [x] Every `target="_blank"` link emitted by the sanitizer carries `rel="noopener noreferrer"` — asserted for attribute order variations and `target="_BLANK"` casing.
- [x] Comment matches actual behaviour.

## Tests

All three cases the issue asked for, plus casing/ordering:

| Case | Assertion |
|---|---|
| `target="_blank"`, no `rel` | gains `noopener` + `noreferrer` |
| `rel="noopener noreferrer"` already | exactly 2 tokens, no duplicates |
| `rel="noopener"` | exactly 2 tokens |
| `rel="nofollow"` | 3 tokens — author's `nofollow` preserved |
| no `target`, `target="_self"`, `mailto:` | no `rel` added at all |

322 API tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
