### PR TITLE
fix(api): cap upload size before buffering multipart bodies (SEC-8)

### DIFF
--- a/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
@@ -1,6 +1,7 @@
 using Azure;
 using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Slypn.Api.Functions;
 using Slypn.Api.Infrastructure;
 using Slypn.Api.Models;
@@ -154,7 +155,7 @@ public class AdminFunctionsTests
     [Fact]
     public async Task Media_503_when_unconfigured()
     {
-        var fn = new MediaFunctions(new FakeBlobService { Configured = false });
+        var fn = new MediaFunctions(new FakeBlobService { Configured = false }, Options.Create(new StorageOptions()));
         var resp = (TestHttpResponseData)await fn.Upload(TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/media", ""));
         Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
     }
@@ -162,7 +163,7 @@ public class AdminFunctionsTests
     [Fact]
     public async Task Media_415_when_not_multipart()
     {
-        var fn = new MediaFunctions(new FakeBlobService());
+        var fn = new MediaFunctions(new FakeBlobService(), Options.Create(new StorageOptions()));
         var req = new TestHttpRequestData(new TestFunctionContext(), "POST", "http://localhost/api/media", "x",
             new Dictionary<string, string> { ["Content-Type"] = "application/json" });
         var resp = (TestHttpResponseData)await fn.Upload(req);
@@ -172,7 +173,7 @@ public class AdminFunctionsTests
     [Fact]
     public async Task Media_400_when_multipart_has_no_file_part()
     {
-        var fn = new MediaFunctions(new FakeBlobService());
+        var fn = new MediaFunctions(new FakeBlobService(), Options.Create(new StorageOptions()));
         // Body has only a text parameter (no filename → not a file part), so parsed.Files is empty.
         var resp = (TestHttpResponseData)await fn.Upload(MultipartParam("field"));
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
@@ -181,7 +182,7 @@ public class AdminFunctionsTests
     [Fact]
     public async Task Media_415_when_file_content_type_not_allowed()
     {
-        var fn = new MediaFunctions(new FakeBlobService());
+        var fn = new MediaFunctions(new FakeBlobService(), Options.Create(new StorageOptions()));
         var resp = (TestHttpResponseData)await fn.Upload(MultipartFile("file", "doc.pdf", "application/pdf"));
         Assert.Equal(HttpStatusCode.UnsupportedMediaType, resp.StatusCode);
     }
@@ -189,7 +190,7 @@ public class AdminFunctionsTests
     [Fact]
     public async Task Media_201_on_successful_upload()
     {
-        var fn = new MediaFunctions(new FakeBlobService());
+        var fn = new MediaFunctions(new FakeBlobService(), Options.Create(new StorageOptions()));
         var resp = (TestHttpResponseData)await fn.Upload(MultipartFile("file", "photo.png", "image/png"));
         Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
         Assert.Contains("url", resp.ReadBodyAsString());
@@ -201,7 +202,13 @@ public class AdminFunctionsTests
         var body = $"--{boundary}\r\nContent-Disposition: form-data; name=\"{partName}\"; filename=\"{fileName}\"\r\nContent-Type: {mimeType}\r\n\r\n{content}\r\n--{boundary}--\r\n";
         return TestHttp.Raw(
             new TestFunctionContext(), "POST", "http://localhost/api/media", body,
-            new Dictionary<string, string> { ["Content-Type"] = $"multipart/form-data; boundary={boundary}" });
+            new Dictionary<string, string>
+            {
+                ["Content-Type"] = $"multipart/form-data; boundary={boundary}",
+                // Real clients declare a length, and the upload endpoints now
+                // require one so an oversized body is refused before buffering.
+                ["Content-Length"] = System.Text.Encoding.UTF8.GetByteCount(body).ToString(),
+            });
     }
 
     private static TestHttpRequestData MultipartParam(string paramName)
@@ -210,7 +217,13 @@ public class AdminFunctionsTests
         var body = $"--{boundary}\r\nContent-Disposition: form-data; name=\"{paramName}\"\r\n\r\nvalue\r\n--{boundary}--\r\n";
         return TestHttp.Raw(
             new TestFunctionContext(), "POST", "http://localhost/api/media", body,
-            new Dictionary<string, string> { ["Content-Type"] = $"multipart/form-data; boundary={boundary}" });
+            new Dictionary<string, string>
+            {
+                ["Content-Type"] = $"multipart/form-data; boundary={boundary}",
+                // Real clients declare a length, and the upload endpoints now
+                // require one so an oversized body is refused before buffering.
+                ["Content-Length"] = System.Text.Encoding.UTF8.GetByteCount(body).ToString(),
+            });
     }
 
     [Fact]

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -1,6 +1,7 @@
 using Azure;
 using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Slypn.Api.Functions;
 using Slypn.Api.Infrastructure;
 using Slypn.Api.Models;
@@ -264,7 +265,7 @@ public class ContentFunctionsTests
 
     // ── Newsletters ──────────────────────────────────────────────────────────────
     private static NewslettersFunctions NewslettersFn(FakeContentRepository repo) =>
-        new(repo, NullLogger<NewslettersFunctions>.Instance);
+        new(repo, NullLogger<NewslettersFunctions>.Instance, Options.Create(new StorageOptions()));
 
     [Fact]
     public async Task Newsletters_create_412_when_storage_fails()
@@ -464,7 +465,13 @@ public class ContentFunctionsTests
         const string boundary = "testboundary";
         var body = $"--{boundary}\r\nContent-Disposition: form-data; name=\"field\"\r\n\r\nvalue\r\n--{boundary}--\r\n";
         var req = TestHttp.Raw(new TestFunctionContext(), "PUT", "http://localhost/api/newsletters/n1/file", body,
-            new Dictionary<string, string> { ["Content-Type"] = $"multipart/form-data; boundary={boundary}" });
+            new Dictionary<string, string>
+            {
+                ["Content-Type"] = $"multipart/form-data; boundary={boundary}",
+                // Real clients declare a length, and the upload endpoints now
+                // require one so an oversized body is refused before buffering.
+                ["Content-Length"] = System.Text.Encoding.UTF8.GetByteCount(body).ToString(),
+            });
         var resp = (TestHttpResponseData)await NewslettersFn(new FakeContentRepository()).UploadFile(req, "n1", Ct);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
@@ -516,7 +523,13 @@ public class ContentFunctionsTests
         var body = $"--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{fileName}\"\r\nContent-Type: {mimeType}\r\n\r\n{content}\r\n--{boundary}--\r\n";
         return TestHttp.Raw(
             new TestFunctionContext(), "PUT", $"http://localhost/api/newsletters/{id}/file", body,
-            new Dictionary<string, string> { ["Content-Type"] = $"multipart/form-data; boundary={boundary}" });
+            new Dictionary<string, string>
+            {
+                ["Content-Type"] = $"multipart/form-data; boundary={boundary}",
+                // Real clients declare a length, and the upload endpoints now
+                // require one so an oversized body is refused before buffering.
+                ["Content-Length"] = System.Text.Encoding.UTF8.GetByteCount(body).ToString(),
+            });
     }
 
     [Fact]

--- a/src/api/Slypn.Api.Tests/MediaFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/MediaFunctionsTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
+using Microsoft.Extensions.Options;
 using Slypn.Api.Functions;
+using Slypn.Api.Infrastructure;
 using Xunit;
 
 namespace Slypn.Api.Tests;
@@ -8,11 +10,23 @@ public class MediaFunctionsTests
 {
     private static readonly FakeBlobService Blob = new();
 
+    private const long MaxBytes = 5 * 1024 * 1024;
+
+    private static IOptions<StorageOptions> Limits(long max = MaxBytes) =>
+        Options.Create(new StorageOptions { MaxMediaUploadBytes = max });
+
+    /// <summary>Multipart headers with an explicit declared length.</summary>
+    private static Dictionary<string, string> Multipart(long contentLength) => new()
+    {
+        ["Content-Type"]   = "multipart/form-data; boundary=xbnd",
+        ["Content-Length"] = contentLength.ToString(),
+    };
+
     [Fact]
     public async Task Returns_service_unavailable_when_blob_not_configured()
     {
         var blob = new FakeBlobService { Configured = false };
-        var fn = new MediaFunctions(blob);
+        var fn = new MediaFunctions(blob, Limits());
         var req = TestHttp.Get(new TestFunctionContext(), "http://localhost/api/media");
         var resp = (TestHttpResponseData)await fn.Upload(req);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
@@ -21,7 +35,7 @@ public class MediaFunctionsTests
     [Fact]
     public async Task Returns_unsupported_media_type_when_content_type_missing()
     {
-        var fn = new MediaFunctions(Blob);
+        var fn = new MediaFunctions(Blob, Limits());
         var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/media", "data");
         var resp = (TestHttpResponseData)await fn.Upload(req);
         Assert.Equal(HttpStatusCode.UnsupportedMediaType, resp.StatusCode);
@@ -30,14 +44,79 @@ public class MediaFunctionsTests
     [Fact]
     public async Task Returns_bad_request_on_malformed_multipart_body()
     {
-        var fn = new MediaFunctions(Blob);
+        var fn = new MediaFunctions(Blob, Limits());
         var req = TestHttp.Raw(
             new TestFunctionContext(), "POST", "http://localhost/api/media",
             "this body has no multipart boundary markers at all",
-            new Dictionary<string, string> { ["Content-Type"] = "multipart/form-data; boundary=xbnd" });
+            Multipart(64));
         var resp = (TestHttpResponseData)await fn.Upload(req);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         Assert.Contains("Could not parse", resp.ReadBodyAsString());
+    }
+
+    // An oversized body used to be buffered in full before the content-type
+    // allowlist could reject it. The declared length is now checked first, so
+    // the parser is never reached.
+    [Fact]
+    public async Task Rejects_upload_larger_than_the_limit_before_parsing()
+    {
+        var fn = new MediaFunctions(Blob, Limits());
+        var req = TestHttp.Raw(
+            new TestFunctionContext(), "POST", "http://localhost/api/media",
+            // Deliberately tiny: if the body were what mattered this would pass,
+            // so reaching 413 proves the decision came from Content-Length alone.
+            "x",
+            Multipart(MaxBytes + 1));
+
+        var resp = (TestHttpResponseData)await fn.Upload(req);
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, resp.StatusCode);
+        // The parser would have reported a malformed body had it run.
+        Assert.DoesNotContain("Could not parse", resp.ReadBodyAsString());
+    }
+
+    [Fact]
+    public async Task Accepts_upload_at_the_limit()
+    {
+        var fn = new MediaFunctions(Blob, Limits());
+        var req = TestHttp.Raw(
+            new TestFunctionContext(), "POST", "http://localhost/api/media",
+            "still not valid multipart",
+            Multipart(MaxBytes));
+
+        var resp = (TestHttpResponseData)await fn.Upload(req);
+
+        // Exactly at the limit is allowed through: it fails later, in the
+        // parser, which is the pre-existing behaviour for a malformed body.
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("Could not parse", resp.ReadBodyAsString());
+    }
+
+    [Fact]
+    public async Task Rejects_upload_with_no_declared_length()
+    {
+        var fn = new MediaFunctions(Blob, Limits());
+        var req = TestHttp.Raw(
+            new TestFunctionContext(), "POST", "http://localhost/api/media", "x",
+            new Dictionary<string, string> { ["Content-Type"] = "multipart/form-data; boundary=xbnd" });
+
+        var resp = (TestHttpResponseData)await fn.Upload(req);
+
+        // Refused, not waved through — accepting it would leave open the very
+        // unbounded path the limit exists to close.
+        Assert.Equal(HttpStatusCode.LengthRequired, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Limit_comes_from_options_not_a_constant()
+    {
+        var fn = new MediaFunctions(Blob, Limits(max: 10));
+        var req = TestHttp.Raw(
+            new TestFunctionContext(), "POST", "http://localhost/api/media", "x", Multipart(11));
+
+        var resp = (TestHttpResponseData)await fn.Upload(req);
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, resp.StatusCode);
     }
 
     [Fact]

--- a/src/api/Slypn.Api/Functions/MediaFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MediaFunctions.cs
@@ -3,13 +3,14 @@ using HttpMultipartParser;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Slypn.Api.Services;
 using Slypn.Api.Infrastructure;
 
 namespace Slypn.Api.Functions;
 
-public sealed class MediaFunctions(IBlobService blob)
+public sealed class MediaFunctions(IBlobService blob, IOptions<StorageOptions> storage)
 {
     /// <summary>
     /// POST /api/media — multipart/form-data with a single "file" part.
@@ -40,6 +41,13 @@ public sealed class MediaFunctions(IBlobService blob)
         {
             return await Reject(req, HttpStatusCode.UnsupportedMediaType,
                 "Expected multipart/form-data with a 'file' part.");
+        }
+
+        // Before ParseAsync, which would otherwise buffer the whole body into
+        // memory and only then let the content-type allowlist reject it.
+        if (UploadLimits.Validate(req, storage.Value.MaxMediaUploadBytes) is { } refusal)
+        {
+            return await Reject(req, refusal.Code, refusal.Message);
         }
 
         MultipartFormDataParser parsed;

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
+using Microsoft.Extensions.Options;
 using Slypn.Api.Infrastructure;
 using Slypn.Api.Models;
 using Slypn.Api.Models.Inputs;
@@ -15,7 +16,10 @@ using static Slypn.Api.Functions.FunctionHelpers;
 
 namespace Slypn.Api.Functions;
 
-public sealed class NewslettersFunctions(IContentRepository repo, ILogger<NewslettersFunctions> log)
+public sealed class NewslettersFunctions(
+    IContentRepository repo,
+    ILogger<NewslettersFunctions> log,
+    IOptions<StorageOptions> storage)
 {
     [Function("GetNewsletters")]
     [OpenApiOperation(operationId: "newsletters.list", tags: new[] { "newsletters" }, Summary = "List newsletters", Description = "Returns all newsletters.")]
@@ -94,6 +98,13 @@ public sealed class NewslettersFunctions(IContentRepository repo, ILogger<Newsle
         {
             return await Reject(req, HttpStatusCode.UnsupportedMediaType,
                 "Expected multipart/form-data with a 'file' part.");
+        }
+
+        // Before ParseAsync, which would otherwise buffer the whole body into
+        // memory and only then let the content-type allowlist reject it.
+        if (UploadLimits.Validate(req, storage.Value.MaxNewsletterFileBytes) is { } refusal)
+        {
+            return await Reject(req, refusal.Code, refusal.Message);
         }
 
         MultipartFormDataParser parsed;

--- a/src/api/Slypn.Api/Infrastructure/StorageOptions.cs
+++ b/src/api/Slypn.Api/Infrastructure/StorageOptions.cs
@@ -15,4 +15,17 @@ public sealed class StorageOptions
 
     /// <summary>How long a generated read SAS URL is valid for.</summary>
     public TimeSpan ReadSasLifetime { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Largest media upload accepted, in bytes. Checked against Content-Length
+    /// before the multipart body is buffered, so an oversized request is refused
+    /// rather than read into memory first.
+    /// </summary>
+    public long MaxMediaUploadBytes { get; set; } = 5 * 1024 * 1024;
+
+    /// <summary>
+    /// Largest newsletter file accepted, in bytes. Higher than media because
+    /// these are PDFs and Word documents rather than images.
+    /// </summary>
+    public long MaxNewsletterFileBytes { get; set; } = 25 * 1024 * 1024;
 }

--- a/src/api/Slypn.Api/Infrastructure/UploadLimits.cs
+++ b/src/api/Slypn.Api/Infrastructure/UploadLimits.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace Slypn.Api.Infrastructure;
+
+/// <summary>
+/// Content-Length gate for multipart uploads.
+/// <para>
+/// The upload endpoints parse the whole body into memory, and the content-type
+/// allowlist only applies once parsing has finished — so without this an
+/// oversized body is fully buffered before anything can reject it. Both
+/// endpoints are role-gated, making this a cost and availability concern on a
+/// Free-tier plan rather than an external attack, but there was no upper bound
+/// at all.
+/// </para>
+/// </summary>
+internal static class UploadLimits
+{
+    /// <summary>
+    /// Validates the declared length before the body is read. Returns
+    /// <c>null</c> when the request is acceptable, otherwise the status and
+    /// message to reject it with.
+    /// </summary>
+    /// <remarks>
+    /// A missing or unparseable Content-Length is refused rather than waved
+    /// through: allowing it would leave exactly the unbounded path this exists
+    /// to close. Callers upload with a known length, so this costs them nothing.
+    /// </remarks>
+    internal static (HttpStatusCode Code, string Message)? Validate(HttpRequestData req, long maxBytes)
+    {
+        if (!req.Headers.TryGetValues("Content-Length", out var values)
+            || !long.TryParse(values.FirstOrDefault(), out var declared))
+        {
+            return (HttpStatusCode.LengthRequired,
+                "A Content-Length header is required so the upload can be size-checked before it is read.");
+        }
+
+        if (declared > maxBytes)
+        {
+            return (HttpStatusCode.RequestEntityTooLarge,
+                $"Upload is {declared} bytes; the limit is {maxBytes} bytes.");
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #158.

## Problem

`MediaFunctions` and `NewslettersFunctions` both parsed the entire multipart body into memory, and the content-type allowlist only applied *after* parsing — so an oversized body was fully buffered before anything could reject it. Both are role-gated, making this a cost/availability concern on Free-tier SWA rather than an external attack, but there was no upper bound at all.

## Fix

`Content-Length` is checked **before** `ParseAsync`, returning **413** when over the limit.

Limits live on `StorageOptions`, so they're configurable per environment rather than constants in the function:

| Setting | Default |
|---|---|
| `Storage:MaxMediaUploadBytes` | 5 MB |
| `Storage:MaxNewsletterFileBytes` | 25 MB (PDFs/DOCX, not images) |

The shared check lives in `UploadLimits` rather than being written twice — both call sites want the same decision and differ only in the limit.

## ⚠️ Behaviour change worth a look

A missing or unparseable `Content-Length` is **refused with 411**, per the issue's "treat as a rejection rather than a pass". Accepting it would leave open the very unbounded path the limit exists to close.

That is a real change for any client uploading with **chunked transfer encoding** and no declared length. Browsers sending `FormData` do set one, and both endpoints are only ever called from the editor, so I believe this is safe — but it's the one part of this change that could reject traffic that previously worked, so flagging it explicitly.

## Acceptance criteria

- [x] Oversized uploads are refused before the body is buffered — asserted by sending a *tiny* body with a large declared length and checking the parser was never reached.
- [x] Limits are configurable, not hard-coded — asserted with a 10-byte limit injected via options.
- [x] Existing valid uploads are unaffected — the at-limit case still reaches the parser and behaves exactly as before.

## Tests

| Case | Result |
|---|---|
| declared length over limit | 413, and no "Could not parse" in the body (parser never ran) |
| declared length exactly at limit | passes the gate, fails later in the parser as before |
| no `Content-Length` | 411 |
| limit injected as 10 bytes, 11 declared | 413 — proves the value comes from options |

Existing multipart tests across `AdminFunctionsTests` and `ContentFunctionsTests` now declare a `Content-Length` as a real client would. 326 API tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
