### PR TITLE
ci: least-privilege tokens and SHA-pinned actions (SEC-9)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # Actions are pinned to commit SHAs so a tag cannot be repointed under us.
+  # That trades a supply-chain risk for a staleness one — a pinned SHA never
+  # picks up a security fix on its own — so Dependabot keeps the pins moving
+  # and rewrites the trailing version comment along with them.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      # One PR a week rather than one per action.
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -78,7 +78,7 @@ jobs:
       # workflow_run runs against the default branch, which may already have
       # moved on. Check out the commit CI actually tested so what ships is what
       # passed. For pull_request this is the usual refs/pull/N/merge.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           submodules: true
@@ -146,14 +146,14 @@ jobs:
         shell: bash
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: src/web/package-lock.json
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege for every job here: nothing in this workflow writes to the
+# repository, so a compromised action or dependency gets a token that can only
+# read. Widen per job if one ever genuinely needs more.
+permissions:
+  contents: read
+
 jobs:
   web:
     name: Web (Vue + TS)
@@ -18,10 +24,10 @@ jobs:
       run:
         working-directory: src/web
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -40,7 +46,7 @@ jobs:
         run: npm run build
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: web-coverage
           path: src/web/coverage
@@ -50,15 +56,15 @@ jobs:
     name: API (.NET Functions)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '8.0.x'
 
       - name: NuGet cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('src/api/**/*.csproj') }}
@@ -84,7 +90,7 @@ jobs:
           --verbosity normal
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: api-coverage
           path: src/api/Slypn.Api.Tests/TestResults
@@ -94,23 +100,23 @@ jobs:
     name: E2E (Playwright + live API)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: src/web/package-lock.json
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '8.0.x'
 
       # Same key as the `api` job so the two share one cache entry.
       - name: NuGet cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('src/api/**/*.csproj') }}
@@ -125,7 +131,7 @@ jobs:
         run: npm ci --no-fund --no-audit --ignore-scripts
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('src/web/package-lock.json') }}
@@ -182,7 +188,7 @@ jobs:
       # from a green run that quietly did the wrong thing.
       - name: Upload backend logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-backend-logs
           path: .testresults/e2e-backend
@@ -191,7 +197,7 @@ jobs:
       # Traces, videos and screenshots are large, so only when something failed.
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-report
           path: |
@@ -204,17 +210,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [web, api]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '8.0.x'
 
       - name: NuGet cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('src/api/**/*.csproj') }}
@@ -222,20 +228,20 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: src/web/package-lock.json
 
       - name: Set up JDK 17 (required by SonarScanner)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -252,13 +258,13 @@ jobs:
         run: npm ci --no-fund --no-audit --ignore-scripts
 
       - name: Download web coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: web-coverage
           path: src/web/coverage
 
       - name: Download API coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: api-coverage
           path: src/api/Slypn.Api.Tests/TestResults

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -19,12 +19,18 @@ concurrency:
   group: infra-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege for every job here: nothing in this workflow writes to the
+# repository, so a compromised action or dependency gets a token that can only
+# read. Widen per job if one ever genuinely needs more.
+permissions:
+  contents: read
+
 jobs:
   bicep:
     name: Bicep build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Bicep CLI
         run: az bicep install

--- a/.github/workflows/swa-close-preview.yml
+++ b/.github/workflows/swa-close-preview.yml
@@ -42,7 +42,7 @@ jobs:
       # Either way this job never checks out the PR head, so fork code is never
       # what runs here; the literal just makes that obvious to a reader and a
       # scanner alike. Revisit if the trigger ever gains a second base branch.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           submodules: false


### PR DESCRIPTION
Closes #159.

## 1. No `permissions:` block

`ci.yml` and `infra.yml` declared no permissions at all, so every job inherited the repository default `GITHUB_TOKEN` scope. If that default is read-write, a compromised action or dependency in those jobs holds a token that can push to the repo.

Neither workflow writes anything — I checked before narrowing: no job uses `GITHUB_TOKEN` or the `gh` CLI, and `infra.yml` only runs `az bicep` with no OIDC login. Both now declare `contents: read` at workflow level.

`azure-static-web-apps.yml` and `swa-close-preview.yml` already scope permissions per job and are unchanged.

## 2. Inconsistent pinning

**All 27 `uses:` across the four workflows** are now SHA-pinned with a trailing version comment, matching the style `azure/login` and `static-web-apps-deploy` already used:

| Action | Pinned to | Uses |
|---|---|---|
| `actions/checkout` | `3d3c42e…` | 7 |
| `actions/cache` | `55cc834…` | 5 |
| `actions/setup-node` | `2499707…` | 4 |
| `actions/setup-dotnet` | `26b0ec1…` | 4 |
| `actions/upload-artifact` | `ea165f8…` | 4 |
| `actions/download-artifact` | `d3f86a1…` | 2 |
| `actions/setup-java` | `cf277c6…` | 1 |

`infra.yml` was the only place still on `checkout@v4`; it moves to v7 with everything else, as the issue suggested.

## 3. Dependabot

SHA pinning trades a supply-chain risk for a staleness one — a pinned SHA never picks up a security fix on its own. `.github/dependabot.yml` adds the `github-actions` ecosystem so the pins keep moving and the version comments are rewritten with them, grouped into **one PR a week** rather than one per action.

Only that ecosystem is configured. npm and NuGet would open a lot of unrelated PRs and aren't what this issue is about — easy to add separately if you want them.

## Acceptance criteria

- [x] `ci.yml` and `infra.yml` declare least-privilege permissions at workflow level.
- [x] Every `uses:` across all workflows is SHA-pinned with a version comment — verified by grep finding no remaining `@v<n>` refs.
- [ ] All workflows still pass on a test PR — this PR is that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
