### PR TITLE
docs(web): make VITE_FARO_URL handling consistent (SEC-11)

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -194,8 +194,13 @@ jobs:
           VITE_MSAL_AUTHORITY: ${{ secrets.VITE_MSAL_AUTHORITY }}
           VITE_MSAL_CLIENT_ID: ${{ secrets.VITE_MSAL_CLIENT_ID }}
           VITE_API_SCOPE:      ${{ secrets.VITE_API_SCOPE }}
-          # Faro frontend observability — URL stored as secret (client-side but kept out of source).
-          # VITE_FARO_ENV: push to main → prod, PR preview builds → dev.
+          # Faro frontend observability. VITE_FARO_URL lives in repo secrets for
+          # config hygiene and easy rotation, not confidentiality: Vite bakes it
+          # into the bundle, so every visitor can read it. That is fine because
+          # it is a write-only ingest endpoint. .env.example therefore carries a
+          # placeholder rather than the live URL, so the two agree about what
+          # this value is.
+          # VITE_FARO_ENV: CI-gated deploy of main → prod, PR previews → dev.
           VITE_FARO_URL:             ${{ secrets.VITE_FARO_URL }}
           VITE_FARO_ENV:             ${{ github.event_name == 'workflow_run' && 'prod' || 'dev' }}
           # Faro source map uploads — build-time only, never exposed to the browser.

--- a/src/web/.env.example
+++ b/src/web/.env.example
@@ -18,7 +18,13 @@ VITE_DEV_SKIP_AUTH=true
 # --- Grafana Faro (see docs/observability-setup.md) ------------------------
 # Faro is gated on cookie consent: even with these set, the SDK only
 # initialises once the user has clicked Accept on the cookie banner.
-VITE_FARO_URL=https://faro-collector-prod-gb-south-1.grafana.net/collect/fa90c58fdb9ebd681482d94fc54a742f
+#
+# A placeholder, like the MSAL values above. The real collector URL is not a
+# secret in the confidentiality sense — Vite bakes it into the bundle and it is
+# a write-only ingest endpoint — but it is held as a repo secret so there is one
+# place to change it. Get yours from Grafana Cloud (see §3.6 of the doc above),
+# or leave it blank: an empty value simply disables the SDK.
+VITE_FARO_URL=https://faro-collector-<region>.grafana.net/collect/<app-key>
 VITE_FARO_APP_NAME=slypn-web
 VITE_FARO_ENV=local
 


### PR DESCRIPTION
Closes #161.

## Problem

The deploy workflow read `VITE_FARO_URL` from repo secrets while `.env.example` committed a real collector URL. The repo asserted two contradictory things about the same value, leaving the next person unsure whether it needed protecting.

**This was never an exposure.** Vite bakes the collector URL into the client bundle, so every visitor can read it by design, and it's a write-only ingest endpoint.

## Fix

Kept the secret-based flow (the issue's recommended option) and replaced the committed URL with a placeholder, matching how the file already handles the MSAL values:

```
VITE_FARO_URL=https://faro-collector-<region>.grafana.net/collect/<app-key>
```

The workflow comment now says **why** it's a secret — one place to change it, not confidentiality — rather than only stating that it is one.

## Two things this fixes in passing

- The committed URL carried a **different app key** (`fa90c58f…`) from the one actually in use (`6d09a73d…`), so it was stale as well as contradictory.
- `docs/observability-setup.md` line 75 already told readers *"Sample placeholder values land in `src/web/.env.example`"* — which wasn't true of this line. No doc change needed; the code now matches what the doc always claimed.

Also corrected the neighbouring `VITE_FARO_ENV` comment, which still described the old push-triggered deploy rather than the CI-gated one.

## Acceptance criteria

- [x] `.env.example` and the workflow tell the same story about this value.
- [x] The comment explains the reasoning, not just the mechanism.
- [x] Local dev setup still works from `.env.example` alone — the file's own header says empty values disable the SDK, and the placeholder is explicit that blank is fine, so a fresh clone runs without a Grafana account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
