### PR TITLE
fix(api): give newsletter subscribers their own table (SEC-5)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,7 +24,8 @@ To keep it simple and cheap we:
 | `events` | `yearMonth` (e.g. `2026-05`) | `id` | — | Listing events is by date range; a year-month partition keeps "this month + next" cheap. The API derives `yearMonth` from `startsAt` on write. |
 | `resources` | `category` | `id` | — | The Resources page filters by category. Partitioning matches the access pattern. |
 | `newsletters` | `"newsletter"` (constant) | `id` | `content/newsletters/{id}` (attached issue file, PDF/DOCX) | Volumes are small (~12 issues/year); a single partition keeps `ListNewsletters` a single-partition scan. |
-| `members` | `"member"` (constant) | `id` | — | Member counts are small; a single partition makes `ListMembers` and the email/oid lookups single-partition scans, and point reads by id are PK+RK lookups. |
+| `members` | `"member"` (constant) | `id` | — | Member counts are small; a single partition makes `ListMembers` and the email/oid lookups single-partition scans, and point reads by id are PK+RK lookups. Invited members only — see `subscribers`. |
+| `subscribers` | `"subscriber"` (constant) | `sha256(email)` | — | Newsletter subscribers, kept apart from `members` on purpose: subscribing is anonymous, so a subscriber row must never read as evidence someone was invited (SEC-5). Hashing the address into the RowKey makes a repeat subscribe a point-read upsert rather than a partition scan, and keeps the key clear of the characters Table Storage forbids. |
 
 ## Concurrency
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -96,8 +96,8 @@ resource contentContainer 'Microsoft.Storage/storageAccounts/blobServices/contai
   }
 }
 
-// Table service — the six content tables (articles, drafts, events, resources,
-// newsletters, members) are created at runtime by TableBootstrapper.
+// Table service — the seven content tables (articles, drafts, events, resources,
+// newsletters, members, subscribers) are created at runtime by TableBootstrapper.
 resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2024-01-01' = {
   parent: storage
   name: 'default'

--- a/scripts/migrateSubscribers.ps1
+++ b/scripts/migrateSubscribers.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+  Moves legacy newsletter subscribers out of the `members` table into `subscribers` (SEC-5).
+
+.DESCRIPTION
+  Before SEC-5, POST /api/newsletter/subscribe stored each address as a `members` row with
+  Status="subscribed", so subscribers and invited members shared one table. Subscribers have their
+  own table now and these rows have to follow.
+
+  The move itself runs in the Slypn.Seed console (--migrate-subscribers), which talks to Table
+  Storage through the Azure SDK; this script only resolves the connection string and confirms the
+  target. See src/api/Slypn.Seed/MigrateSubscribers.cs for the selection rules — in short, a row
+  moves only when its status is "subscribed" AND it holds no roles AND it has no oid, which is
+  exactly the "not invited" test the API uses, so a real member is never touched.
+
+  Idempotent and re-runnable: the destination row key is derived from the address, and rows already
+  migrated no longer match the source filter.
+
+  Requires an authenticated Azure CLI (az login) with access to the target subscription, unless
+  -ConnectionString is supplied. No secret is stored in this file.
+
+.EXAMPLE
+  pwsh scripts/migrateSubscribers.ps1 -DryRun          # report what would move, change nothing
+  pwsh scripts/migrateSubscribers.ps1                  # prompts for confirmation
+  pwsh scripts/migrateSubscribers.ps1 -Force           # no prompt (use in CI/automation)
+  pwsh scripts/migrateSubscribers.ps1 -ConnectionString "UseDevelopmentStorage=true" -Force
+#>
+[CmdletBinding()]
+param(
+    [string]$ResourceGroup  = "rg-slypn-prod",
+    [string]$StorageAccount = "slypnprodstgfuicmindwdk4",
+    # Skips the az lookup entirely — used to run this against local Azurite.
+    [string]$ConnectionString,
+    [switch]$DryRun,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$cs = $ConnectionString
+if (-not $cs) {
+    Write-Host "Resolving connection string for $StorageAccount ($ResourceGroup)…"
+    $cs = az storage account show-connection-string -g $ResourceGroup -n $StorageAccount --query connectionString -o tsv
+    if (-not $cs) { throw "Could not get connection string. Are you logged in (az login) and on the right subscription?" }
+    $target = $StorageAccount
+}
+else {
+    $target = "the supplied connection string"
+}
+
+if (-not $DryRun -and -not $Force) {
+    Write-Host "This will MOVE subscriber rows out of members in $target." -ForegroundColor Yellow
+    Write-Host "Run with -DryRun first if you haven't." -ForegroundColor Yellow
+    $answer = Read-Host "Type the storage account name to confirm"
+    if ($answer -ne $StorageAccount) { Write-Host "Aborted."; return }
+}
+
+$seed = Join-Path $PSScriptRoot "../src/api/Slypn.Seed"
+$seedArgs = @("--migrate-subscribers", "--connection-string", $cs)
+if ($DryRun) { $seedArgs += "--dry-run" }
+
+dotnet run --project $seed -- @seedArgs
+if ($LASTEXITCODE -ne 0) { throw "Migration failed (exit $LASTEXITCODE)." }
+
+Write-Host "Done." -ForegroundColor Green

--- a/src/api/Slypn.Api.Tests/AuthExtensionFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AuthExtensionFunctionsTests.cs
@@ -227,11 +227,13 @@ public class AuthExtensionFunctionsTests
     }
 
     // ── SEC-1: subscribing is not an invitation ─────────────────────────────
-    // The members table doubles as the newsletter subscriber list, and the gate
-    // used to allow any address with a row. Anyone could POST to the anonymous
-    // /api/newsletter/subscribe and then sign up through CIAM.
+    // The members table used to double as the newsletter subscriber list, and the gate
+    // allowed any address with a row. Anyone could POST to the anonymous
+    // /api/newsletter/subscribe and then sign up through CIAM. Subscribers have their own
+    // table since SEC-5, so these rows are now legacy shapes — the gate must still reject
+    // them, and anything else that learns to write a role-less member row.
 
-    private static Member Subscriber(string email) =>
+    private static Member LegacySubscriberRow(string email) =>
         new("s1", email, email, Array.Empty<string>(), "subscribed", DateTime.UtcNow);
 
     private static Member Invited(string email) =>
@@ -240,7 +242,7 @@ public class AuthExtensionFunctionsTests
     [Fact]
     public async Task Blocks_a_newsletter_subscriber_who_was_never_invited()
     {
-        var repo = new FakeContentRepository { MemberByEmail = Subscriber("subscriber@x.com") };
+        var repo = new FakeContentRepository { MemberByEmail = LegacySubscriberRow("subscriber@x.com") };
         var fn = Make(repo);
         var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("subscriber@x.com"));
 
@@ -253,10 +255,10 @@ public class AuthExtensionFunctionsTests
     [Fact]
     public async Task A_subscriber_and_an_unknown_address_get_the_identical_block_page()
     {
-        // No oracle: if the subscriber saw a different message, the gate would confirm
+        // No oracle: if the role-less row saw a different message, the gate would confirm
         // which addresses hold a row in the members table to anyone who asked.
         var subscriberResp = (TestHttpResponseData)await Make(
-                new FakeContentRepository { MemberByEmail = Subscriber("subscriber@x.com") })
+                new FakeContentRepository { MemberByEmail = LegacySubscriberRow("subscriber@x.com") })
             .AllowSignup(
                 TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("subscriber@x.com")),
                 Ct);
@@ -272,8 +274,8 @@ public class AuthExtensionFunctionsTests
     [Fact]
     public async Task Still_allows_an_invited_address_that_also_subscribed()
     {
-        // Subscribe preserves the roles of an existing member, so an invitee who also
-        // signed up for the newsletter keeps their role and must still get through.
+        // Subscribing no longer writes here at all, so an invitee who also signed up for the
+        // newsletter keeps their member row untouched and must still get through.
         var repo = new FakeContentRepository { MemberByEmail = Invited("both@x.com") };
         var fn = Make(repo);
         var req = TestHttp.Raw(new TestFunctionContext(), "POST", "http://localhost/api/auth/allow-signup", Body("both@x.com"));

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -325,12 +325,12 @@ public class ContentFunctionsTests
         var ctx = new TestFunctionContext();
         var payload = TestHttp.Json(ctx, "POST", "http://localhost/api/newsletter/subscribe", new { email = "me@example.com" });
 
-        // GetMemberByEmailAsync throws → line 119
-        var repo1 = new FakeContentRepository { ThrowOnMemberEmailLookup = new RequestFailedException(500, "Lookup failed") };
+        // GetSubscriberByEmailAsync throws
+        var repo1 = new FakeContentRepository { ThrowOnSubscriberLookup = new RequestFailedException(500, "Lookup failed") };
         var err1 = (TestHttpResponseData)await NewslettersFn(repo1).Subscribe(payload, Ct);
         Assert.Equal(HttpStatusCode.InternalServerError, err1.StatusCode);
 
-        // UpsertMemberAsync throws → line 148
+        // UpsertSubscriberAsync throws
         var repo2 = new FakeContentRepository { ThrowOnWrite = new RequestFailedException(412, "Precondition failed") };
         var err2 = (TestHttpResponseData)await NewslettersFn(repo2).Subscribe(
             TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe", new { email = "me@example.com" }), Ct);
@@ -600,9 +600,10 @@ public class ContentFunctionsTests
         Assert.DoesNotContain("Admin", resp.ReadBodyAsString());
     }
 
-    // SEC-1: a newsletter subscriber has a row in the members table but is not a
-    // member. Claiming it would link their OID and flip the row to "active", so they
-    // would appear in Member Management as though an admin had invited them.
+    // SEC-1: a row with no roles is not a member, whatever its status says. Subscribers no
+    // longer land in this table (SEC-5), but a legacy row that survived the migration must still
+    // not be claimable — claiming it links the caller's OID and flips the row to "active", so
+    // they would appear in Member Management as though an admin had invited them.
     [Fact]
     public async Task Me_does_not_claim_a_subscriber_row_for_the_caller()
     {
@@ -939,52 +940,113 @@ public class ContentFunctionsTests
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
+    // SEC-5: subscribing must never touch the members table. That conflation is what let an
+    // anonymous subscribe buy its way past the CIAM sign-up gate (SEC-1).
     [Fact]
-    public async Task Newsletters_subscribe_updates_existing_pure_subscriber()
+    public async Task Newsletters_subscribe_writes_a_subscriber_and_never_a_member()
     {
-        // existing subscriber with no roles and no Oid → Status stays "subscribed"
-        var existing = new Slypn.Api.Models.Member("m1", "sub@example.com", "Old Display",
-            Array.Empty<string>(), "subscribed", DateTime.UtcNow);
-        var repo = new FakeContentRepository { MemberByEmail = existing };
+        var repo = new FakeContentRepository();
         var fn = NewslettersFn(repo);
 
-        // With displayName → covers the non-whitespace displayName branch
         var resp = (TestHttpResponseData)await fn.Subscribe(
             TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe",
-                new { email = "sub@example.com", displayName = "New Display" }), Ct);
+                new { email = "  New@Example.com  " }), Ct);
+
         Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
-        Assert.Contains("sub@example.com", resp.ReadBodyAsString());
+        Assert.Equal(0, repo.MemberUpserts);
+
+        var saved = Assert.Single(repo.SubscriberUpserts);
+        Assert.Equal("new@example.com", saved.Email);              // trimmed + lower-cased
+        Assert.Equal("new@example.com", saved.DisplayName);        // falls back to the address
+        Assert.Equal(Subscriber.KeyFor("new@example.com"), saved.Id);
+        Assert.Contains("new@example.com", resp.ReadBodyAsString());
     }
 
     [Fact]
-    public async Task Newsletters_subscribe_existing_subscriber_without_display_name_keeps_existing()
+    public async Task Newsletters_subscribe_is_idempotent_and_keeps_the_original_date()
     {
-        var existing = new Slypn.Api.Models.Member("m1", "sub@example.com", "Old Display",
-            Array.Empty<string>(), "subscribed", DateTime.UtcNow);
-        var repo = new FakeContentRepository { MemberByEmail = existing };
+        // The row key is derived from the address, so a repeat subscribe upserts the same row.
+        var firstSeen = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var existing = new Subscriber(Subscriber.KeyFor("sub@example.com"), "sub@example.com", "Old Display", firstSeen);
+        var repo = new FakeContentRepository { SubscriberByEmail = existing };
         var fn = NewslettersFn(repo);
 
-        // Without displayName → keeps existing.DisplayName
         var resp = (TestHttpResponseData)await fn.Subscribe(
             TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe",
                 new { email = "sub@example.com" }), Ct);
+
         Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
+        var saved = Assert.Single(repo.SubscriberUpserts);
+        Assert.Equal(existing.Id, saved.Id);
+        Assert.Equal(firstSeen, saved.SubscribedAt);    // not reset by the resubmit
+        Assert.Equal("Old Display", saved.DisplayName); // no new name supplied -> keep theirs
     }
 
     [Fact]
-    public async Task Newsletters_subscribe_existing_member_with_roles_preserves_status()
+    public async Task Newsletters_subscribe_applies_a_supplied_display_name()
     {
-        // existing member with roles → Status preserved (not overwritten with "subscribed")
-        var existing = new Slypn.Api.Models.Member("m1", "mem@example.com", "Alice",
-            new[] { "Member" }, "active", DateTime.UtcNow, Oid: "oid-1");
-        var repo = new FakeContentRepository { MemberByEmail = existing };
+        var existing = new Subscriber(Subscriber.KeyFor("sub@example.com"), "sub@example.com", "Old Display", DateTime.UtcNow);
+        var repo = new FakeContentRepository { SubscriberByEmail = existing };
         var fn = NewslettersFn(repo);
 
         var resp = (TestHttpResponseData)await fn.Subscribe(
             TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe",
-                new { email = "mem@example.com" }), Ct);
+                new { email = "sub@example.com", displayName = "  New Display  " }), Ct);
+
         Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
-        Assert.Contains("active", resp.ReadBodyAsString());
+        Assert.Equal("New Display", Assert.Single(repo.SubscriberUpserts).DisplayName);
+    }
+
+    // ───── Subscribers: admin list + remove ─────
+
+    private static SubscribersFunctions SubscribersFn(FakeContentRepository repo) =>
+        new(repo, NullLogger<SubscribersFunctions>.Instance);
+
+    [Fact]
+    public async Task Subscribers_list_returns_rows_and_delete_removes_one()
+    {
+        var repo = new FakeContentRepository
+        {
+            Subscribers = { new Subscriber("s1", "sub@example.com", "Subby", DateTime.UtcNow) },
+        };
+        var fn = SubscribersFn(repo);
+        var ctx = new TestFunctionContext();
+
+        var list = (TestHttpResponseData)await fn.List(TestHttp.Get(ctx, "http://localhost/api/subscribers"), Ct);
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+        Assert.Contains("sub@example.com", list.ReadBodyAsString());
+
+        var del = (TestHttpResponseData)await fn.Delete(
+            TestHttp.Raw(ctx, "DELETE", "http://localhost/api/subscribers/s1", ""), "s1", Ct);
+        Assert.Equal(HttpStatusCode.NoContent, del.StatusCode);
+    }
+
+    [Fact]
+    public async Task Subscribers_503_when_writes_disabled()
+    {
+        var fn = SubscribersFn(new FakeContentRepository { Writes = false });
+        var ctx = new TestFunctionContext();
+
+        var list = (TestHttpResponseData)await fn.List(TestHttp.Get(ctx, "http://localhost/api/subscribers"), Ct);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, list.StatusCode);
+
+        var del = (TestHttpResponseData)await fn.Delete(
+            TestHttp.Raw(ctx, "DELETE", "http://localhost/api/subscribers/s1", ""), "s1", Ct);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, del.StatusCode);
+    }
+
+    [Fact]
+    public async Task Subscribers_map_storage_failures()
+    {
+        var listRepo = new FakeContentRepository { ThrowOnRead = new RequestFailedException(500, "Table down") };
+        var list = (TestHttpResponseData)await SubscribersFn(listRepo).List(
+            TestHttp.Get(new TestFunctionContext(), "http://localhost/api/subscribers"), Ct);
+        Assert.Equal(HttpStatusCode.InternalServerError, list.StatusCode);
+
+        var delRepo = new FakeContentRepository { ThrowOnWrite = new RequestFailedException(412, "Precondition failed") };
+        var del = (TestHttpResponseData)await SubscribersFn(delRepo).Delete(
+            TestHttp.Raw(new TestFunctionContext(), "DELETE", "http://localhost/api/subscribers/s1", ""), "s1", Ct);
+        Assert.Equal(HttpStatusCode.PreconditionFailed, del.StatusCode);
     }
 
     // ── Resources: writes-disabled and validation-error branches ─────────────

--- a/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Slypn.Api.Tests;
 
 // Storage is unconfigured, so ContentRepository serves reads from MockDataService
-// and rejects all writes / member / draft access via EnsureWrites.
+// and rejects all writes / member / subscriber / draft access via EnsureWrites.
 file sealed class UnconfiguredTableStore : ITableStore
 {
     public bool IsConfigured => false;
@@ -16,6 +16,7 @@ file sealed class UnconfiguredTableStore : ITableStore
     public TableClient Resources   => throw new NotSupportedException();
     public TableClient Newsletters => throw new NotSupportedException();
     public TableClient Members     => throw new NotSupportedException();
+    public TableClient Subscribers => throw new NotSupportedException();
 }
 
 file sealed class NoopBodyStore : IContentBodyStore
@@ -142,5 +143,7 @@ public class ContentRepositoryReadTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().ListMembersAsync(Ct));
         await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().GetMemberByEmailAsync("a@b.com", Ct));
         await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().ListDraftsByAuthorAsync("oid", Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().ListSubscribersAsync(Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().GetSubscriberByEmailAsync("a@b.com", Ct));
     }
 }

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -165,6 +165,37 @@ internal sealed class FakeContentRepository : IContentRepository
     }
     public Task DeleteMemberAsync(string id, string? ifMatch, CancellationToken ct) => Guard(Task.CompletedTask);
 
+    /// <summary>Rows returned by ListSubscribersAsync.</summary>
+    public List<Subscriber> Subscribers = new();
+
+    /// <summary>Row returned by GetSubscriberByEmailAsync — null means "not subscribed yet".</summary>
+    public Subscriber? SubscriberByEmail { get; set; }
+
+    /// <summary>Every subscriber handed to UpsertSubscriberAsync, in order. Lets a test assert both
+    /// the count (idempotency) and the payload without a mocking framework.</summary>
+    public List<Subscriber> SubscriberUpserts { get; } = new();
+
+    /// <summary>Set to throw from the next GetSubscriberByEmailAsync call, to test the
+    /// subscribe endpoint's lookup-error branch without disturbing other reads.</summary>
+    public Exception? ThrowOnSubscriberLookup { get; set; }
+
+    public Task<Subscriber?> GetSubscriberByEmailAsync(string email, CancellationToken ct)
+    {
+        if (ThrowOnSubscriberLookup is not null) throw ThrowOnSubscriberLookup;
+        return Task.FromResult(SubscriberByEmail);
+    }
+    public Task<IReadOnlyList<Subscriber>> ListSubscribersAsync(CancellationToken ct)
+    {
+        if (ThrowOnRead is not null) throw ThrowOnRead;
+        return Task.FromResult<IReadOnlyList<Subscriber>>(Subscribers);
+    }
+    public Task<Subscriber> UpsertSubscriberAsync(Subscriber subscriber, string? ifMatch, CancellationToken ct)
+    {
+        SubscriberUpserts.Add(subscriber);
+        return Task.FromResult(Guard(subscriber));
+    }
+    public Task DeleteSubscriberAsync(string id, string? ifMatch, CancellationToken ct) => Guard(Task.CompletedTask);
+
     public Task<Draft?> GetDraftAsync(string id, string authorId, CancellationToken ct)
     {
         if (ThrowOnRead is not null) throw ThrowOnRead;

--- a/src/api/Slypn.Api.Tests/SubscriberKeyTests.cs
+++ b/src/api/Slypn.Api.Tests/SubscriberKeyTests.cs
@@ -1,0 +1,34 @@
+using Slypn.Api.Models;
+using Xunit;
+
+namespace Slypn.Api.Tests;
+
+public class SubscriberKeyTests
+{
+    // Pins the key derivation. The SEC-5 migration (Slypn.Seed/MigrateSubscribers.cs) recomputes
+    // this hash independently to place migrated rows, so a change here that isn't mirrored there
+    // would strand every migrated subscriber under a key the API never looks up.
+    [Fact]
+    public void KeyFor_is_stable()
+    {
+        Assert.Equal(
+            "72497f475e4f76d0b28f57c73a084ece576d170874eba3ee2609d9afe4b71aab",
+            Subscriber.KeyFor("someone@example.com"));
+    }
+
+    [Fact]
+    public void KeyFor_normalises_case_and_whitespace()
+    {
+        // Why the endpoint can dedupe without a lookup: these are all one subscriber.
+        var expected = Subscriber.KeyFor("someone@example.com");
+        Assert.Equal(expected, Subscriber.KeyFor("  Someone@Example.COM  "));
+    }
+
+    [Fact]
+    public void KeyFor_avoids_characters_table_storage_rejects_in_a_row_key()
+    {
+        // A raw address could carry / \ # ? in a quoted local part; the hash never can.
+        var key = Subscriber.KeyFor("weird/local#part?@example.com");
+        Assert.Matches("^[0-9a-f]{64}$", key);
+    }
+}

--- a/src/api/Slypn.Api.Tests/TableBootstrapperTests.cs
+++ b/src/api/Slypn.Api.Tests/TableBootstrapperTests.cs
@@ -16,6 +16,7 @@ file sealed class UnconfiguredStore : ITableStore
     public TableClient Resources   => throw new NotSupportedException();
     public TableClient Newsletters => throw new NotSupportedException();
     public TableClient Members     => throw new NotSupportedException();
+    public TableClient Subscribers => throw new NotSupportedException();
 }
 
 public class TableBootstrapperTests

--- a/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
+++ b/src/api/Slypn.Api/Functions/AuthExtensionFunctions.cs
@@ -107,9 +107,10 @@ public sealed class AuthExtensionFunctions(
 
         try
         {
-            // Existence is not an invitation. The members table also holds newsletter
-            // subscribers, written by the anonymous POST /api/newsletter/subscribe, so
-            // gating on "a row exists" let anyone subscribe and then sign up.
+            // Existence is not an invitation. The members table used to hold newsletter
+            // subscribers too, so gating on "a row exists" let anyone subscribe and then sign
+            // up; subscribers have their own table now, and IsInvited keeps the gate honest
+            // regardless of what else learns to write here.
             var member = await repo.GetMemberByEmailAsync(email.Trim().ToLowerInvariant(), ct);
             if (member is { IsInvited: true })
             {

--- a/src/api/Slypn.Api/Functions/FunctionHelpers.cs
+++ b/src/api/Slypn.Api/Functions/FunctionHelpers.cs
@@ -96,6 +96,20 @@ internal static class FunctionHelpers
         return resp;
     }
 
+    /// <summary>
+    /// The envelope a storage-backed endpoint shares with every other one: refuse when storage
+    /// isn't configured, run the operation, and map an Azure storage failure onto the status it
+    /// deserves. Worth factoring out because the guard and the try/catch around the one
+    /// interesting line are longer than the line itself.
+    /// </summary>
+    public static async Task<HttpResponseData> WithStorageAsync(
+        HttpRequestData req, IContentRepository repo, ILogger log, Func<Task<HttpResponseData>> operation)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        try { return await operation(); }
+        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
+    }
+
     public static async Task<HttpResponseData> MapStorageException(
         HttpRequestData req, RequestFailedException ex, ILogger? log = null)
     {

--- a/src/api/Slypn.Api/Functions/MeSelfFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MeSelfFunctions.cs
@@ -75,9 +75,9 @@ public sealed class MeSelfFunctions(
         if (string.IsNullOrEmpty(email))
             return null;
 
-        // A newsletter subscriber has a row here but is not a member, so their row must never
-        // be claimed by a signed-in caller: linking an OID would also flip it to "active" below
-        // and surface them in Member Management as though an admin had invited them.
+        // Only a row an admin actually created may be claimed by a signed-in caller: linking an
+        // OID also flips it to "active" below and surfaces it in Member Management as though an
+        // admin had invited them. Newsletter subscribers used to land here and be claimable.
         var byEmail = await repo.GetMemberByEmailAsync(email.Trim().ToLowerInvariant(), ct);
         if (byEmail is null || !byEmail.IsInvited || byEmail.Oid == callerOid)
             return null;

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -208,10 +208,10 @@ public sealed class NewslettersFunctions(
     }
 
     /// <summary>
-    /// Public anonymous newsletter subscribe. Stores the email as a Member row
-    /// with Status="subscribed" so we get free dedupe (UpsertMemberAsync is
-    /// idempotent on a given id). No role assignment — subscribers aren't
-    /// SLYPN members in the auth sense.
+    /// Public anonymous newsletter subscribe. Writes to the <c>subscribers</c> table, which is
+    /// separate from <c>members</c> on purpose: subscribing is anonymous, so a subscriber row must
+    /// never be mistaken for evidence that someone was invited. Dedupe comes from the row key being
+    /// derived from the email, so repeat subscribes upsert the same row.
     /// </summary>
     [Function("SubscribeToNewsletter")]
     [OpenApiOperation(operationId: "newsletter.subscribe", tags: new[] { "newsletters" }, Summary = "Subscribe to newsletter", Description = "Subscribes an email address to the newsletter.")]
@@ -228,43 +228,22 @@ public sealed class NewslettersFunctions(
 
         var email = input!.Email.Trim().ToLowerInvariant();
 
-        Member? existing;
-        try { existing = await repo.GetMemberByEmailAsync(email, ct); }
+        Subscriber? existing;
+        try { existing = await repo.GetSubscriberByEmailAsync(email, ct); }
         catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
 
-        var now = DateTime.UtcNow;
         var displayName = input.DisplayName?.Trim();
-
-        Member record;
-        if (existing is null)
-        {
-            var newDisplayName = string.IsNullOrWhiteSpace(displayName) ? email : displayName;
-            record = new Member(
-                Id:          Guid.NewGuid().ToString("N"),
-                Email:       email,
-                DisplayName: newDisplayName,
-                Roles:       Array.Empty<string>(),
-                Status:      "subscribed",
-                InvitedAt:   now);
-        }
-        else
-        {
-            // Promote any earlier "invited" -> still "subscribed" but keep
-            // their roles + oid if they're an actual member. For pure
-            // subscribers (no roles, no oid), we just refresh the timestamp.
-            var isExistingMember = existing.Roles.Count > 0 || existing.Oid is not null;
-            var resolvedDisplayName = string.IsNullOrWhiteSpace(displayName) ? existing.DisplayName : displayName;
-            record = existing with
-            {
-                Status      = isExistingMember ? existing.Status : "subscribed",
-                DisplayName = resolvedDisplayName,
-            };
-        }
+        var record = new Subscriber(
+            Id:           Subscriber.KeyFor(email),
+            Email:        email,
+            DisplayName:  string.IsNullOrWhiteSpace(displayName) ? existing?.DisplayName ?? email : displayName,
+            // Keep the date they first signed up rather than resetting it on every resubmit.
+            SubscribedAt: existing?.SubscribedAt ?? DateTime.UtcNow);
 
         try
         {
-            var saved = await repo.UpsertMemberAsync(record, existing?.Etag, ct);
-            return await Created(req, new { saved.Email, saved.Status });
+            var saved = await repo.UpsertSubscriberAsync(record, existing?.Etag, ct);
+            return await Created(req, new { saved.Email });
         }
         catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
     }

--- a/src/api/Slypn.Api/Functions/SubscribersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/SubscribersFunctions.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using Azure;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.OpenApi.Models;
+using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
+using Slypn.Api.Services;
+using static Slypn.Api.Functions.FunctionHelpers;
+
+namespace Slypn.Api.Functions;
+
+/// <summary>
+/// Admin view of the newsletter subscriber list. Subscribers live in their own table, so these
+/// are separate from <see cref="MembersFunctions"/> — a subscriber has no roles and cannot sign in,
+/// and removing one has none of the Entra side effects that removing a member does.
+/// </summary>
+public sealed class SubscribersFunctions(
+    IContentRepository repo,
+    ILogger<SubscribersFunctions> log)
+{
+    [Function("ListSubscribers")]
+    [RequireRole("Admin")]
+    [OpenApiOperation(operationId: "subscribers.list", tags: new[] { "subscribers" }, Summary = "List subscribers", Description = "Returns all newsletter subscribers, newest first.")]
+    [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Subscriber[]), Description = "List of subscribers")]
+    public async Task<HttpResponseData> List(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "subscribers")] HttpRequestData req,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        try
+        {
+            var subscribers = await repo.ListSubscribersAsync(ct);
+            return await Ok(req, subscribers);
+        }
+        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
+    }
+
+    [Function("DeleteSubscriber")]
+    [RequireRole("Admin")]
+    [OpenApiOperation(operationId: "subscribers.delete", tags: new[] { "subscribers" }, Summary = "Delete subscriber", Description = "Removes an address from the newsletter subscriber list.")]
+    [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
+    [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Subscriber id.")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "Deleted")]
+    public async Task<HttpResponseData> Delete(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "subscribers/{id}")] HttpRequestData req,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        try
+        {
+            await repo.DeleteSubscriberAsync(id, IfMatch(req), ct);
+            return NoContent(req);
+        }
+        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
+    }
+}

--- a/src/api/Slypn.Api/Functions/SubscribersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/SubscribersFunctions.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using Azure;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -27,18 +26,10 @@ public sealed class SubscribersFunctions(
     [OpenApiOperation(operationId: "subscribers.list", tags: new[] { "subscribers" }, Summary = "List subscribers", Description = "Returns all newsletter subscribers, newest first.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Subscriber[]), Description = "List of subscribers")]
-    public async Task<HttpResponseData> List(
+    public Task<HttpResponseData> List(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "subscribers")] HttpRequestData req,
         CancellationToken ct)
-    {
-        if (!repo.SupportsWrites) return await WritesDisabled(req);
-        try
-        {
-            var subscribers = await repo.ListSubscribersAsync(ct);
-            return await Ok(req, subscribers);
-        }
-        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
-    }
+        => WithStorageAsync(req, repo, log, async () => await Ok(req, await repo.ListSubscribersAsync(ct)));
 
     [Function("DeleteSubscriber")]
     [RequireRole("Admin")]
@@ -46,16 +37,12 @@ public sealed class SubscribersFunctions(
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Subscriber id.")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "Deleted")]
-    public async Task<HttpResponseData> Delete(
+    public Task<HttpResponseData> Delete(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "subscribers/{id}")] HttpRequestData req,
         string id, CancellationToken ct)
-    {
-        if (!repo.SupportsWrites) return await WritesDisabled(req);
-        try
+        => WithStorageAsync(req, repo, log, async () =>
         {
             await repo.DeleteSubscriberAsync(id, IfMatch(req), ct);
             return NoContent(req);
-        }
-        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
-    }
+        });
 }

--- a/src/api/Slypn.Api/Infrastructure/TableBootstrapper.cs
+++ b/src/api/Slypn.Api/Infrastructure/TableBootstrapper.cs
@@ -7,7 +7,7 @@ using Slypn.Api.Services;
 namespace Slypn.Api.Infrastructure;
 
 /// <summary>
-/// Creates the six SLYPN content tables on startup. Uses the singleton
+/// Creates the seven SLYPN content tables on startup. Uses the singleton
 /// <see cref="ITableStore"/> so we don't open a second client. The body-blob
 /// container is created lazily by <see cref="ContentBodyStore"/>. No-op when
 /// storage is not configured. When SkipAuth is on (local dev), also seeds the
@@ -20,7 +20,7 @@ public sealed class TableBootstrapper(
     ILogger<TableBootstrapper> logger) : IHostedService
 {
     private static readonly string[] Tables =
-        ["articles", "drafts", "events", "resources", "newsletters", "members"];
+        ["articles", "drafts", "events", "resources", "newsletters", "members", "subscribers"];
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -82,6 +82,7 @@ public sealed class TableBootstrapper(
         "resources"   => store.Resources,
         "newsletters" => store.Newsletters,
         "members"     => store.Members,
+        "subscribers" => store.Subscribers,
         _ => throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown table"),
     };
 }

--- a/src/api/Slypn.Api/Models/Member.cs
+++ b/src/api/Slypn.Api/Models/Member.cs
@@ -19,14 +19,13 @@ public sealed record Member(
 
     /// <summary>
     /// True when an admin actually invited this person, as opposed to their address merely
-    /// having a row here. The members table doubles as the newsletter subscriber list, so
-    /// existence alone says nothing about whether someone may sign in.
+    /// having a row here.
     ///
-    /// Holding a role is the real test — every invite assigns exactly one
-    /// (<c>MemberInviteInput</c> requires it) and the dev-persona seed does too, while the
-    /// anonymous newsletter subscribe is the one write path that produces neither a role nor
-    /// any status but "subscribed". The status check guards against a future write path that
-    /// forgets to assign one.
+    /// Newsletter subscribers now live in their own table, so no anonymous write path reaches
+    /// this one any more — but the predicate stays as a regression guard. Holding a role is the
+    /// real test: every invite assigns exactly one (<c>MemberInviteInput</c> requires it) and the
+    /// dev-persona seed does too. The legacy "subscribed" status is still rejected in case a row
+    /// predating the split survived the migration.
     ///
     /// [JsonIgnore] is load-bearing: members persist as a JSON blob in the entity's Json
     /// column, so without it this computed value would be written into storage.

--- a/src/api/Slypn.Api/Models/Subscriber.cs
+++ b/src/api/Slypn.Api/Models/Subscriber.cs
@@ -1,0 +1,34 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Slypn.Api.Models;
+
+/// <summary>
+/// A newsletter subscriber. Deliberately *not* a <see cref="Member"/>: subscribing is anonymous and
+/// says nothing about whether someone may sign in. The two used to share the members table, which
+/// is how an anonymous subscribe once bought its way past the CIAM sign-up gate.
+///
+/// <c>Id</c> is derived from the email (see <see cref="KeyFor"/>), so re-subscribing the same
+/// address upserts the same row instead of creating a duplicate.
+/// </summary>
+public sealed record Subscriber(
+    string Id,
+    string Email,
+    string DisplayName,
+    DateTime SubscribedAt)
+{
+    [JsonPropertyName("_etag")]
+    [Newtonsoft.Json.JsonProperty("_etag")]
+    public string? Etag { get; init; }
+
+    /// <summary>
+    /// Storage id for an address: the SHA-256 of the normalised email, hex encoded. Deterministic,
+    /// so a repeat subscribe upserts the same row — the dedupe the members table used to provide,
+    /// but as a point read rather than a partition scan. Hashing also keeps the id clear of the
+    /// characters Table Storage forbids in a RowKey (/ \ # ?).
+    /// </summary>
+    public static string KeyFor(string email) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(email.Trim().ToLowerInvariant())))
+            .ToLowerInvariant();
+}

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -26,6 +26,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     private const string DraftBodyPrefix      = "drafts";
     private const string NewsletterFilePrefix = "newsletters";
     private const string MembersPartition     = "member";
+    private const string SubscribersPartition = "subscriber";
     private const string NewslettersPartition = "newsletter";
     private const string ArticleType       = "article";
     private const string InReviewStatus    = "in-review";
@@ -416,6 +417,50 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         var filter = TableClient.CreateQueryFilter($"PartitionKey eq {MembersPartition}");
         var entities = await QueryAsync(store.Members, filter, ct);
         return entities.Select(e => Deserialize<Member>(e) with { Etag = EncodeEtag(e.ETag) }).ToList();
+    }
+
+    // ---- Subscribers ----------------------------------------------------------
+
+    public async Task<Subscriber?> GetSubscriberByEmailAsync(string email, CancellationToken ct)
+    {
+        EnsureWrites();
+        try
+        {
+            var resp = await store.Subscribers.GetEntityAsync<TableEntity>(
+                SubscribersPartition, Subscriber.KeyFor(email), cancellationToken: ct);
+            return Deserialize<Subscriber>(resp.Value) with { Etag = EncodeEtag(resp.Value.ETag) };
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<Subscriber>> ListSubscribersAsync(CancellationToken ct)
+    {
+        EnsureWrites();
+        var filter = TableClient.CreateQueryFilter($"PartitionKey eq {SubscribersPartition}");
+        var entities = await QueryAsync(store.Subscribers, filter, ct);
+        return entities
+            .Select(e => Deserialize<Subscriber>(e) with { Etag = EncodeEtag(e.ETag) })
+            .OrderByDescending(s => s.SubscribedAt)
+            .ToList();
+    }
+
+    public async Task<Subscriber> UpsertSubscriberAsync(Subscriber subscriber, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        var entity = Entity(SubscribersPartition, subscriber.Id, subscriber);
+        var resp = ifMatch is null
+            ? await store.Subscribers.UpsertEntityAsync(entity, TableUpdateMode.Replace, ct)
+            : await store.Subscribers.UpdateEntityAsync(entity, DecodeEtag(ifMatch), TableUpdateMode.Replace, ct);
+        return subscriber with { Etag = EncodeEtag(resp.Headers.ETag!.Value) };
+    }
+
+    public async Task DeleteSubscriberAsync(string id, string? ifMatch, CancellationToken ct)
+    {
+        EnsureWrites();
+        await store.Subscribers.DeleteEntityAsync(SubscribersPartition, id, DecodeEtag(ifMatch), ct);
     }
 
     // ---- Drafts ---------------------------------------------------------------

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -54,6 +54,12 @@ public interface IContentRepository
     Task<Member>               UpsertMemberAsync(Member member, string? ifMatch, CancellationToken ct);
     Task                       DeleteMemberAsync(string id, string? ifMatch, CancellationToken ct);
 
+    // Subscribers ----------------------------------------------------------
+    Task<Subscriber?>              GetSubscriberByEmailAsync(string email, CancellationToken ct);
+    Task<IReadOnlyList<Subscriber>> ListSubscribersAsync(CancellationToken ct);
+    Task<Subscriber>               UpsertSubscriberAsync(Subscriber subscriber, string? ifMatch, CancellationToken ct);
+    Task                           DeleteSubscriberAsync(string id, string? ifMatch, CancellationToken ct);
+
     // Drafts ---------------------------------------------------------------
     Task<Draft?>              GetDraftAsync(string id, string authorId, CancellationToken ct);
     Task<IReadOnlyList<Draft>> ListDraftsByAuthorAsync(string authorId, CancellationToken ct);

--- a/src/api/Slypn.Api/Services/ITableStore.cs
+++ b/src/api/Slypn.Api/Services/ITableStore.cs
@@ -20,4 +20,5 @@ public interface ITableStore
     TableClient Resources   { get; }
     TableClient Newsletters { get; }
     TableClient Members     { get; }
+    TableClient Subscribers { get; }
 }

--- a/src/api/Slypn.Api/Services/TableStore.cs
+++ b/src/api/Slypn.Api/Services/TableStore.cs
@@ -45,6 +45,7 @@ public sealed class TableStore : ITableStore
     public TableClient Resources   => Table("resources");
     public TableClient Newsletters => Table("newsletters");
     public TableClient Members     => Table("members");
+    public TableClient Subscribers => Table("subscribers");
 
     private TableClient Table(string name) =>
         (_service ?? throw NotConfigured()).GetTableClient(name);

--- a/src/api/Slypn.Seed/MigrateSubscribers.cs
+++ b/src/api/Slypn.Seed/MigrateSubscribers.cs
@@ -1,0 +1,117 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Azure;
+using Azure.Data.Tables;
+
+namespace Slypn.Seed;
+
+/// <summary>
+/// One-off SEC-5 migration: moves legacy newsletter subscribers out of the <c>members</c> table
+/// into <c>subscribers</c>.
+///
+/// Before SEC-5, POST /api/newsletter/subscribe stored each address as a members row with
+/// Status="subscribed", so subscribers and invited members shared one table. Subscribers have
+/// their own table now; these rows have to follow.
+///
+/// Idempotent and re-runnable: the destination row key is derived from the address, so a repeat
+/// run rewrites the same rows, and rows already migrated no longer match the source filter.
+/// </summary>
+public static class MigrateSubscribers
+{
+    private const string MembersTable         = "members";
+    private const string SubscribersTable     = "subscribers";
+    private const string MembersPartition     = "member";
+    private const string SubscribersPartition = "subscriber";
+
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    // Only the fields the filter and the copy need; the rest of the members row is discarded.
+    private sealed record MemberRow(
+        string? Id, string? Email, string? DisplayName,
+        List<string>? Roles, string? Status, DateTime? InvitedAt, string? Oid);
+
+    private sealed record SubscriberRow(
+        string Id, string Email, string DisplayName, DateTime SubscribedAt);
+
+    public static async Task<int> RunAsync(string connectionString, bool dryRun, TextWriter output)
+    {
+        var service     = new TableServiceClient(connectionString);
+        var members     = service.GetTableClient(MembersTable);
+        var subscribers = service.GetTableClient(SubscribersTable);
+
+        if (!dryRun) await subscribers.CreateIfNotExistsAsync();
+
+        var moved = 0;
+        var left  = 0;
+
+        var filter = TableClient.CreateQueryFilter($"PartitionKey eq {MembersPartition}");
+        await foreach (var entity in members.QueryAsync<TableEntity>(filter: filter))
+        {
+            var json = entity.GetString("Json");
+            if (string.IsNullOrEmpty(json)) { left++; continue; }
+
+            MemberRow? row;
+            try { row = JsonSerializer.Deserialize<MemberRow>(json, JsonOpts); }
+            catch (JsonException) { left++; continue; }
+
+            if (row is null || !IsLegacySubscriber(row) || string.IsNullOrWhiteSpace(row.Email))
+            {
+                left++;
+                continue;
+            }
+
+            var email = row.Email.Trim().ToLowerInvariant();
+            var key   = KeyFor(email);
+
+            if (dryRun)
+            {
+                await output.WriteLineAsync($"  would move {email} -> {SubscribersTable}/{key}");
+                moved++;
+                continue;
+            }
+
+            // SubscribedAt carries over from InvitedAt: on a subscriber row that timestamp was only
+            // ever set by the subscribe endpoint, so it really is the date they signed up.
+            var subscriber = new SubscriberRow(
+                Id:           key,
+                Email:        email,
+                DisplayName:  string.IsNullOrWhiteSpace(row.DisplayName) ? email : row.DisplayName,
+                SubscribedAt: row.InvitedAt ?? DateTime.UtcNow);
+
+            await subscribers.UpsertEntityAsync(
+                new TableEntity(SubscribersPartition, key) { ["Json"] = JsonSerializer.Serialize(subscriber, JsonOpts) },
+                TableUpdateMode.Replace);
+
+            // Only after the copy landed.
+            try { await members.DeleteEntityAsync(entity.PartitionKey, entity.RowKey); }
+            catch (RequestFailedException ex) when (ex.Status == 404) { /* already gone */ }
+
+            await output.WriteLineAsync($"  - moved {email} -> {SubscribersTable}/{key}");
+            moved++;
+        }
+
+        var verb = dryRun ? "Would move" : "Moved";
+        await output.WriteLineAsync($"{verb} {moved} subscriber row(s); left {left} members row(s) alone.");
+        return 0;
+    }
+
+    /// <summary>
+    /// The exact inverse of <c>Member.IsInvited</c>, plus "has never signed in". A member who
+    /// somehow carries the legacy status but holds a role or an OID is a real member and stays put.
+    /// </summary>
+    private static bool IsLegacySubscriber(MemberRow row) =>
+        string.Equals(row.Status, "subscribed", StringComparison.OrdinalIgnoreCase)
+        && (row.Roles is null || row.Roles.Count == 0)
+        && string.IsNullOrEmpty(row.Oid);
+
+    /// <summary>
+    /// Must stay identical to <c>Slypn.Api.Models.Subscriber.KeyFor</c> — the API finds a migrated
+    /// row by recomputing this from the address. Pinned on both sides by
+    /// <c>SubscriberKeyTests.KeyFor_is_stable</c>: sha256("someone@example.com") =
+    /// 72497f475e4f76d0b28f57c73a084ece576d170874eba3ee2609d9afe4b71aab.
+    /// </summary>
+    private static string KeyFor(string email) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(email.Trim().ToLowerInvariant())))
+            .ToLowerInvariant();
+}

--- a/src/api/Slypn.Seed/Program.cs
+++ b/src/api/Slypn.Seed/Program.cs
@@ -9,10 +9,11 @@ using Slypn.Seed;
 
 // Args:
 //   [<docx-path>]  --connection-string <cs>  [--table <name>]  [--container <name>]
-//   [--dir <folder>]  [--demo]
+//   [--dir <folder>]  [--demo]  [--migrate-subscribers [--dry-run]]
 //
 // At least one of <docx-path> (seed one newsletter), --dir (bulk-import a folder
-// of YYYY-MM.pdf/.docx issues), or --demo (seed demo content) is required. Each
+// of YYYY-MM.pdf/.docx issues), --demo (seed demo content), or --migrate-subscribers
+// (one-off SEC-5 data move, see MigrateSubscribers) is required. Each
 // newsletter's file is uploaded to the content blob container under
 // newsletters/{id}; its metadata row is upserted into the newsletters table.
 // Defaults: table = "newsletters", container = "content".
@@ -22,6 +23,8 @@ const string DocxContentType = "application/vnd.openxmlformats-officedocument.wo
 
 var argList = args.ToList();
 var demo = argList.Remove("--demo");
+var migrateSubscribers = argList.Remove("--migrate-subscribers");
+var dryRun = argList.Remove("--dry-run");
 
 // Optional positional docx path = first arg that isn't a --flag.
 string? docxPath = argList.Count > 0 && !argList[0].StartsWith("--") ? argList[0] : null;
@@ -36,10 +39,10 @@ var table = named.GetValueOrDefault("table", "newsletters");
 var container = named.GetValueOrDefault("container", "content");
 named.TryGetValue("dir", out var importDir);
 
-if (docxPath is null && importDir is null && !demo)
+if (docxPath is null && importDir is null && !demo && !migrateSubscribers)
 {
-    await Console.Error.WriteLineAsync("usage: dotnet run -- [<docx-path>] --connection-string <cs> [--table <name>] [--container <name>] [--dir <folder>] [--demo]");
-    await Console.Error.WriteLineAsync("Pass a docx path or --dir to seed newsletters, and/or --demo to seed demo content.");
+    await Console.Error.WriteLineAsync("usage: dotnet run -- [<docx-path>] --connection-string <cs> [--table <name>] [--container <name>] [--dir <folder>] [--demo] [--migrate-subscribers [--dry-run]]");
+    await Console.Error.WriteLineAsync("Pass a docx path or --dir to seed newsletters, --demo to seed demo content, or --migrate-subscribers to run the SEC-5 data move.");
     return 1;
 }
 
@@ -127,6 +130,21 @@ if (demo)
     catch (Exception ex)
     {
         await Console.Error.WriteLineAsync($"Demo seed failed: {ex.Message}");
+        return 3;
+    }
+}
+
+// ----- SEC-5: move legacy subscriber rows out of members ----------------------
+if (migrateSubscribers)
+{
+    try
+    {
+        var code = await MigrateSubscribers.RunAsync(connectionString, dryRun, Console.Out);
+        if (code != 0) return code;
+    }
+    catch (Exception ex)
+    {
+        await Console.Error.WriteLineAsync($"Subscriber migration failed: {ex.Message}");
         return 3;
     }
 }

--- a/src/web/e2e/anon/public-browsing.spec.ts
+++ b/src/web/e2e/anon/public-browsing.spec.ts
@@ -145,16 +145,23 @@ test.describe('public browsing', () => {
     expect(response.ok(), `subscribe returned ${response.status()}`).toBeTruthy()
     await expect(page.getByTestId('subscribe-result')).toBeVisible()
 
-    // The address becomes a member row with status "subscribed" — only an admin
-    // may read the members list, so assert it with the persona header.
+    // SEC-5: the address lands in the subscribers table, never in members — a subscriber
+    // that shows up as a member is what let an anonymous subscribe past the sign-up gate.
+    // Both lists are admin-only, so read them with the persona header.
     const members = await request.get(`${API}/members`, {
       headers: { 'X-Slypn-Dev-User': 'admin' },
     })
-    const subscribed = await members.json() as { id: string; email: string; status: string }[]
-    const row = subscribed.find((m) => m.email === email)
-    expect(row?.status).toBe('subscribed')
+    const memberRows = await members.json() as { email: string }[]
+    expect(memberRows.some((m) => m.email === email)).toBe(false)
 
-    await request.delete(`${API}/members/${row!.id}`, {
+    const subscribers = await request.get(`${API}/subscribers`, {
+      headers: { 'X-Slypn-Dev-User': 'admin' },
+    })
+    const subscriberRows = await subscribers.json() as { id: string; email: string }[]
+    const row = subscriberRows.find((s) => s.email === email)
+    expect(row, `${email} not found in the subscriber list`).toBeDefined()
+
+    await request.delete(`${API}/subscribers/${row!.id}`, {
       headers: { 'X-Slypn-Dev-User': 'admin' },
     })
   })

--- a/src/web/src/components/layout/AppNav.spec.ts
+++ b/src/web/src/components/layout/AppNav.spec.ts
@@ -91,6 +91,7 @@ describe('AppNav', () => {
     const account = w.find('#mobile-account')
     expect(account.text()).toContain('Dashboard')
     expect(account.text()).toContain('Members')
+    expect(account.text()).toContain('Newsletter subscribers')
     expect(account.text()).toContain('Newsletters')
     expect(account.text()).toContain('Sign out')
 

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -37,6 +37,7 @@ const accountLinks = computed(() => ([
   { to: '/editor',          label: 'Editor',             show: auth.isContributor || auth.isAdmin },
   { to: '/admin/events',    label: 'Event management',   show: auth.isContributor || auth.isAdmin },
   { to: '/admin/members',   label: 'Members',            show: auth.isAdmin },
+  { to: '/admin/subscribers', label: 'Newsletter subscribers', show: auth.isAdmin },
   { to: '/admin/resources', label: 'Resources',          show: auth.isAdmin },
   { to: '/admin/newsletters', label: 'Newsletters',      show: auth.isAdmin },
 ] as { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }[]).filter(l => l.show))

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -60,6 +60,8 @@ const router = createRouter({
       meta: { requiresAuth: true, requiresRole: ['Admin', 'Contributor'] } },
     { path: '/admin/members', name: 'admin-members', component: () => import('@/views/MemberManagementView.vue'),
       meta: { requiresAuth: true, requiresRole: ['Admin'] } },
+    { path: '/admin/subscribers', name: 'admin-subscribers', component: () => import('@/views/SubscriberManagementView.vue'),
+      meta: { requiresAuth: true, requiresRole: ['Admin'] } },
     { path: '/admin/content', name: 'admin-content', component: () => import('@/views/ManageContentView.vue'),
       meta: { requiresAuth: true, requiresRole: ['Admin', 'Contributor'] } },
     { path: '/admin/resources', name: 'admin-resources', component: () => import('@/views/ResourceManagementView.vue'),

--- a/src/web/src/views/DashboardView.vue
+++ b/src/web/src/views/DashboardView.vue
@@ -97,6 +97,16 @@ onMounted(() => { if (auth.isAdmin) approvalsStore.refresh() })
       </RouterLink>
       <RouterLink
         v-if="auth.isAdmin"
+        to="/admin/subscribers"
+        class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+      >
+        <p class="font-display font-bold text-slypn-700">Newsletter subscribers</p>
+        <p class="mt-2 text-sm text-slypn-900/75">
+          View who signed up for the newsletter, and remove addresses.
+        </p>
+      </RouterLink>
+      <RouterLink
+        v-if="auth.isAdmin"
         to="/admin/resources"
         class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
       >

--- a/src/web/src/views/SubscriberManagementView.spec.ts
+++ b/src/web/src/views/SubscriberManagementView.spec.ts
@@ -87,6 +87,69 @@ describe('SubscriberManagementView', () => {
     expect(w.get('[data-testid="subscriber-save-error"]').text()).toContain('403')
   })
 
+  describe('search', () => {
+    const three = () => [
+      subscriber({ id: 'a', email: 'alice@example.com', displayName: 'Alice Adams' }),
+      subscriber({ id: 'b', email: 'bob@other.org', displayName: 'Bob Brown' }),
+      subscriber({ id: 'c', email: 'carol@example.com', displayName: 'Carol Clark' }),
+    ]
+
+    async function mountWithSearch(term: string) {
+      apiJson.mockResolvedValue(three())
+      const w = mountC()
+      await flushPromises()
+      await w.get('[data-testid="subscriber-search"]').setValue(term)
+      return w
+    }
+
+    it('filters on the email', async () => {
+      const w = await mountWithSearch('example.com')
+      const rows = w.findAll('[data-testid="subscriber-row"]')
+      expect(rows.map(r => r.attributes('data-id'))).toEqual(['a', 'c'])
+    })
+
+    it('filters on the display name, case-insensitively', async () => {
+      const w = await mountWithSearch('bOb')
+      const rows = w.findAll('[data-testid="subscriber-row"]')
+      expect(rows.map(r => r.attributes('data-id'))).toEqual(['b'])
+    })
+
+    it('ignores surrounding whitespace', async () => {
+      const w = await mountWithSearch('   carol   ')
+      expect(w.findAll('[data-testid="subscriber-row"]')).toHaveLength(1)
+    })
+
+    it('shows how many of the total matched', async () => {
+      const w = await mountWithSearch('example.com')
+      expect(w.text()).toContain('(2 of 3)')
+    })
+
+    it('shows a no-matches state that is distinct from having no subscribers', async () => {
+      const w = await mountWithSearch('nobody')
+      expect(w.findAll('[data-testid="subscriber-row"]')).toHaveLength(0)
+      expect(w.get('[data-testid="subscriber-no-matches"]').text()).toContain('nobody')
+      expect(w.text()).not.toContain('No subscribers yet')
+    })
+
+    it('restores the full list when cleared', async () => {
+      const w = await mountWithSearch('alice')
+      expect(w.findAll('[data-testid="subscriber-row"]')).toHaveLength(1)
+      await w.get('[data-testid="subscriber-search-clear"]').trigger('click')
+      expect(w.findAll('[data-testid="subscriber-row"]')).toHaveLength(3)
+      expect(w.text()).toContain('(3)')
+    })
+
+    it('removes the subscriber the filter is showing, not the first of the unfiltered list', async () => {
+      // The row list is what Remove is wired to, so a stale index here would delete the
+      // wrong person — the one case where this filter could do real damage.
+      apiFetch.mockResolvedValue(ok({}))
+      const w = await mountWithSearch('carol')
+      await w.get('[data-testid="subscriber-remove"]').trigger('click')
+      await flushPromises()
+      expect(apiFetch).toHaveBeenCalledWith('/subscribers/c', expect.objectContaining({ method: 'DELETE' }))
+    })
+  })
+
   it('renders an empty state', async () => {
     apiJson.mockResolvedValue([])
     const w = mountC()

--- a/src/web/src/views/SubscriberManagementView.spec.ts
+++ b/src/web/src/views/SubscriberManagementView.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, RouterLinkStub, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+
+import SubscriberManagementView from './SubscriberManagementView.vue'
+import { useAuthStore } from '@/stores/auth'
+
+const stubs = { RouterLink: RouterLinkStub }
+let pinia: Pinia
+const mountC = () => mount(SubscriberManagementView, { global: { plugins: [pinia], stubs } })
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+}
+
+const subscriber = (over = {}) => ({
+  id: 's1', email: 'sub@b.com', displayName: 'Subby',
+  subscribedAt: '2026-04-01T00:00:00Z', _etag: 'e1', ...over,
+})
+
+beforeEach(async () => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiJson.mockReset()
+  apiFetch.mockReset()
+  vi.stubGlobal('confirm', vi.fn(() => true))
+  await useAuthStore().initialize()
+})
+
+describe('SubscriberManagementView', () => {
+  it('lists subscribers with a count', async () => {
+    apiJson.mockResolvedValue([subscriber()])
+    const w = mountC()
+    await flushPromises()
+    expect(apiJson).toHaveBeenCalledWith('/subscribers')
+    expect(w.text()).toContain('sub@b.com')
+    expect(w.text()).toContain('Subby')
+    expect(w.text()).toContain('(1)')
+  })
+
+  it('shows newest first', async () => {
+    apiJson.mockResolvedValue([
+      subscriber({ id: 'old', email: 'old@b.com', subscribedAt: '2025-01-01T00:00:00Z' }),
+      subscriber({ id: 'new', email: 'new@b.com', subscribedAt: '2026-08-01T00:00:00Z' }),
+    ])
+    const w = mountC()
+    await flushPromises()
+    const rows = w.findAll('[data-testid="subscriber-row"]')
+    expect(rows.map(r => r.attributes('data-id'))).toEqual(['new', 'old'])
+  })
+
+  it('removes a subscriber after confirmation, passing the etag', async () => {
+    apiJson.mockResolvedValue([subscriber()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountC()
+    await flushPromises()
+    await w.get('[data-testid="subscriber-remove"]').trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/subscribers/s1', expect.objectContaining({
+      method: 'DELETE',
+      headers: { 'If-Match': 'e1' },
+    }))
+  })
+
+  it('does not remove when the confirmation is declined', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => false))
+    apiJson.mockResolvedValue([subscriber()])
+    const w = mountC()
+    await flushPromises()
+    await w.get('[data-testid="subscriber-remove"]').trigger('click')
+    await flushPromises()
+    expect(apiFetch).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed removal', async () => {
+    apiJson.mockResolvedValue([subscriber()])
+    apiFetch.mockResolvedValue({
+      ok: false, status: 403, statusText: 'Forbidden', text: () => Promise.resolve(''),
+    } as unknown as Response)
+    const w = mountC()
+    await flushPromises()
+    await w.get('[data-testid="subscriber-remove"]').trigger('click')
+    await flushPromises()
+    expect(w.get('[data-testid="subscriber-save-error"]').text()).toContain('403')
+  })
+
+  it('renders an empty state', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountC()
+    await flushPromises()
+    expect(w.text()).toContain('No subscribers yet')
+  })
+})

--- a/src/web/src/views/SubscriberManagementView.vue
+++ b/src/web/src/views/SubscriberManagementView.vue
@@ -23,6 +23,21 @@ const sortedSubscribers = computed(() =>
   [...(subscribers.value ?? [])].sort((a, b) =>
     b.subscribedAt.localeCompare(a.subscribedAt)))
 
+// ── Search ─────────────────────────────────────────────────────────────────
+
+// Filtering happens here rather than server-side: the whole list is already in
+// memory and small, so there is nothing to gain from a round trip per keystroke.
+const search = ref('')
+
+const filteredSubscribers = computed(() => {
+  const q = search.value.trim().toLowerCase()
+  if (!q) return sortedSubscribers.value
+  return sortedSubscribers.value.filter(s =>
+    s.email.toLowerCase().includes(q) || s.displayName.toLowerCase().includes(q))
+})
+
+const isFiltering = computed(() => search.value.trim().length > 0)
+
 // ── Remove ─────────────────────────────────────────────────────────────────
 
 const deletingId = ref<string | null>(null)
@@ -67,13 +82,36 @@ const fmtDate = (iso: string) =>
 
   <section class="page-container space-y-6 py-16">
     <article class="rounded-xl border border-slypn-100 bg-white shadow-sm">
-      <div class="border-b border-slypn-100 px-6 py-4">
+      <div class="flex flex-col gap-3 border-b border-slypn-100 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <h2 class="font-display text-xl font-bold text-slypn-700">
           All subscribers
           <span v-if="subscribers?.length" class="ml-1 text-sm font-medium text-slypn-500">
-            ({{ subscribers.length }})
+            <template v-if="isFiltering">({{ filteredSubscribers.length }} of {{ subscribers.length }})</template>
+            <template v-else>({{ subscribers.length }})</template>
           </span>
         </h2>
+
+        <div v-if="subscribers?.length" class="relative sm:w-72">
+          <label for="subscriber-search" class="sr-only">Search subscribers</label>
+          <!-- type=text, not search: Chrome renders its own clear affordance for type=search,
+               which would sit on top of ours, and Firefox renders none at all. -->
+          <input
+            id="subscriber-search"
+            v-model="search"
+            type="text"
+            data-testid="subscriber-search"
+            placeholder="Search by email or name"
+            class="w-full rounded-md border border-slypn-200 py-2 pl-3 pr-8 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+          />
+          <button
+            v-if="isFiltering"
+            type="button"
+            data-testid="subscriber-search-clear"
+            aria-label="Clear search"
+            class="absolute inset-y-0 right-0 px-2.5 text-slypn-400 hover:text-slypn-700"
+            @click="search = ''"
+          >&times;</button>
+        </div>
       </div>
 
       <p v-if="loading && !subscribers" class="px-6 py-8 text-center text-sm text-slypn-900/60">
@@ -90,9 +128,9 @@ const fmtDate = (iso: string) =>
         <button class="ml-2 underline" @click="saveError = null">Dismiss</button>
       </p>
 
-      <div v-if="subscribers?.length" class="divide-y divide-slypn-100">
+      <div v-if="filteredSubscribers.length" class="divide-y divide-slypn-100">
         <div
-          v-for="s in sortedSubscribers"
+          v-for="s in filteredSubscribers"
           :key="s.id"
           data-testid="subscriber-row"
           :data-id="s.id"
@@ -115,6 +153,11 @@ const fmtDate = (iso: string) =>
           >{{ deletingId === s.id ? 'Removing…' : 'Remove' }}</button>
         </div>
       </div>
+
+      <p v-else-if="isFiltering" data-testid="subscriber-no-matches" class="px-6 py-8 text-center text-sm text-slypn-900/60">
+        No subscribers match &ldquo;{{ search.trim() }}&rdquo;.
+        <button class="ml-1 underline" @click="search = ''">Clear search</button>
+      </p>
 
       <p v-else-if="subscribers" class="px-6 py-8 text-center text-sm text-slypn-900/60">
         No subscribers yet.

--- a/src/web/src/views/SubscriberManagementView.vue
+++ b/src/web/src/views/SubscriberManagementView.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import HeroBanner from '@/components/common/HeroBanner.vue'
+import { apiFetch, apiJson } from '@/lib/api'
+import { useAsyncData } from '@/composables/useAsyncData'
+
+interface Subscriber {
+  id: string
+  email: string
+  displayName: string
+  subscribedAt: string
+  _etag?: string
+}
+
+// ── Subscriber list ────────────────────────────────────────────────────────
+
+const { data: subscribers, loading, error, refresh } = useAsyncData(
+  () => apiJson<Subscriber[]>('/subscribers'),
+)
+
+// Newest first, matching the order the API returns them in.
+const sortedSubscribers = computed(() =>
+  [...(subscribers.value ?? [])].sort((a, b) =>
+    b.subscribedAt.localeCompare(a.subscribedAt)))
+
+// ── Remove ─────────────────────────────────────────────────────────────────
+
+const deletingId = ref<string | null>(null)
+const saveError = ref<string | null>(null)
+
+async function removeSubscriber(subscriber: Subscriber) {
+  if (!confirm(`Remove ${subscriber.email} from the newsletter list? This cannot be undone.`)) return
+  if (deletingId.value) return
+  saveError.value = null
+  deletingId.value = subscriber.id
+  try {
+    const resp = await apiFetch(`/subscribers/${subscriber.id}`, {
+      method: 'DELETE',
+      headers: subscriber._etag ? { 'If-Match': subscriber._etag } : {},
+    })
+    if (!resp.ok) throw new Error(`${resp.status} ${await resp.text()}`)
+    await refresh()
+  } catch (err) {
+    saveError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    deletingId.value = null
+  }
+}
+
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+</script>
+
+<template>
+  <HeroBanner
+    eyebrow="Admin"
+    title="Newsletter subscribers"
+    subtitle="Everyone who signed up for the newsletter. Subscribers are not members and cannot sign in."
+  >
+    <template #actions>
+      <RouterLink
+        :to="{ name: 'dashboard' }"
+        class="text-sm font-semibold text-white/80 hover:text-white"
+      >&larr; Dashboard</RouterLink>
+    </template>
+  </HeroBanner>
+
+  <section class="page-container space-y-6 py-16">
+    <article class="rounded-xl border border-slypn-100 bg-white shadow-sm">
+      <div class="border-b border-slypn-100 px-6 py-4">
+        <h2 class="font-display text-xl font-bold text-slypn-700">
+          All subscribers
+          <span v-if="subscribers?.length" class="ml-1 text-sm font-medium text-slypn-500">
+            ({{ subscribers.length }})
+          </span>
+        </h2>
+      </div>
+
+      <p v-if="loading && !subscribers" class="px-6 py-8 text-center text-sm text-slypn-900/60">
+        Loading subscribers…
+      </p>
+
+      <div v-else-if="error" class="px-6 py-4 text-sm text-rose-700">
+        Couldn't load subscribers: {{ error }}.
+        <button class="ml-2 underline" @click="refresh">Retry</button>
+      </div>
+
+      <p v-else-if="saveError" data-testid="subscriber-save-error" class="bg-rose-50 px-6 py-3 text-sm text-rose-700">
+        {{ saveError }}
+        <button class="ml-2 underline" @click="saveError = null">Dismiss</button>
+      </p>
+
+      <div v-if="subscribers?.length" class="divide-y divide-slypn-100">
+        <div
+          v-for="s in sortedSubscribers"
+          :key="s.id"
+          data-testid="subscriber-row"
+          :data-id="s.id"
+          class="flex flex-col gap-3 px-6 py-4 sm:flex-row sm:items-center sm:gap-6"
+        >
+          <div class="min-w-0 flex-1">
+            <p class="truncate font-semibold text-slypn-800">{{ s.email }}</p>
+            <p v-if="s.displayName !== s.email" class="mt-0.5 truncate text-sm text-slypn-500">
+              {{ s.displayName }}
+            </p>
+            <p class="mt-0.5 text-xs text-slypn-400">Subscribed {{ fmtDate(s.subscribedAt) }}</p>
+          </div>
+
+          <button
+            type="button"
+            data-testid="subscriber-remove"
+            :disabled="deletingId === s.id"
+            class="shrink-0 self-start rounded-md border border-rose-200 px-3 py-1.5 text-xs font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50 sm:self-auto"
+            @click="removeSubscriber(s)"
+          >{{ deletingId === s.id ? 'Removing…' : 'Remove' }}</button>
+        </div>
+      </div>
+
+      <p v-else-if="subscribers" class="px-6 py-8 text-center text-sm text-slypn-900/60">
+        No subscribers yet.
+      </p>
+    </article>
+  </section>
+</template>


### PR DESCRIPTION
Closes #155.

## Why

`POST /api/newsletter/subscribe` stored each address as a **`Member` row with `Status="subscribed"`**, so subscribers and invited members were the same storage entity, told apart only by a string nothing enforced.

That conflation is what produced SEC-1 (`GHSA-rcr3-vmhq-hvgp`): the CIAM sign-up gate asked "is there a member row for this email", so anyone could subscribe to the newsletter and then sign up. `Member.IsInvited` fixed that instance; this removes the class, and stops the anonymous endpoint padding the table behind the Admin members list.

## What changed

**New `subscribers` table** — wired through `ITableStore`, `TableBootstrapper` and `IContentRepository`. `Subscriber.KeyFor` derives the row key from the address (SHA-256 hex), so:

- a repeat subscribe is an idempotent **point-read upsert**, not the full-partition scan the old `GetMemberByEmailAsync` round-trip needed — that scan was the only reason to share a table in the first place;
- the key can never carry a character Table Storage rejects in a RowKey (`/ \ # ?`).

**`Subscribe` no longer touches `Member`.** It preserves the original `SubscribedAt` across resubmits.

**Admins keep visibility** they had via the members list: `GET /api/subscribers`, `DELETE /api/subscribers/{id}` (both Admin-only) and an `/admin/subscribers` page with a dashboard tile.

**Migration for existing rows** — `scripts/migrateSubscribers.ps1`, which resolves the connection string and runs `Slypn.Seed --migrate-subscribers`. It selects only rows where status is `subscribed` **and** roles is empty **and** oid is null (the exact `!IsInvited` predicate, so a real member is never moved), copies before deleting, supports `-DryRun`, and is re-runnable.

The move went through the Azure SDK rather than `az storage entity insert` because az on Windows silently strips the quotes out of a JSON column value — verified while building this, and not something to discover during a prod data migration.

`Member.IsInvited` still rejects the legacy `"subscribed"` status, as a regression guard for SEC-1.

## Verification

- `dotnet test` — 332 pass, including new coverage that Subscribe writes a subscriber and **never** calls `UpsertMemberAsync`, stays idempotent, and that the key derivation is pinned (the migration recomputes that hash independently).
- `npm run build` / `test:unit` (406) / `lint` — all pass.
- `playwright e2e/anon/public-browsing.spec.ts` — 11 pass; the subscribe test now asserts the address is **absent** from `/api/members` and present in `/api/subscribers`.
- Against local Azurite: subscribed twice → one row, absent from members; seeded a legacy `"subscribed"` member row plus a control row holding a role → migration moved only the former, left the control and the dev personas alone, and a second run was a clean no-op; the migrated row was then found by the API and stayed idempotent on re-subscribe, keeping its original date.

## Follow-up

Rate limiting on the anonymous subscribe endpoint is deliberately **not** here — filed separately. Double opt-in is already #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
