### PR TITLE
ci: stop Dependabot PRs failing the two secret-dependent jobs

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -67,14 +67,16 @@ jobs:
     # no secrets: the deployment token and CIAM secrets should not be reachable from a
     # bot-authored PR. Without it the job runs with empty secrets and fails every week. The
     # exclusion sits on the pull_request arm only — a push to main is a real deploy whoever
-    # merged it, including Dependabot under auto-merge.
+    # merged it, including Dependabot under auto-merge. It reads the PR author rather than
+    # github.actor, which is the triggering entity and not a trustworthy identity claim
+    # (sonar githubactions:S8232).
     if: >-
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_repository.full_name == github.repository) ||
       (github.event_name == 'pull_request' && github.event.action != 'closed' &&
-       github.actor != 'dependabot[bot]')
+       github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     name: Build + deploy
     permissions:

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -62,12 +62,19 @@ jobs:
     # the deployment token and CIAM secrets. Requiring the triggering run to be a
     # push closes that off, since fork PR runs of CI are `pull_request`; the
     # repository check is belt and braces.
+    #
+    # The preview deploy additionally excludes Dependabot, for the same reason Dependabot gets
+    # no secrets: the deployment token and CIAM secrets should not be reachable from a
+    # bot-authored PR. Without it the job runs with empty secrets and fails every week. The
+    # exclusion sits on the pull_request arm only — a push to main is a real deploy whoever
+    # merged it, including Dependabot under auto-merge.
     if: >-
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_repository.full_name == github.repository) ||
-      (github.event_name == 'pull_request' && github.event.action != 'closed')
+      (github.event_name == 'pull_request' && github.event.action != 'closed' &&
+       github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     name: Build + deploy
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,12 @@ jobs:
     # would buy nothing: Dependabot is configured for github-actions only, so its PRs change
     # workflow YAML and no analysed source. Skip instead — a skipped job still satisfies a
     # required check, and web/api/e2e need no secrets, so the bumped SHAs are still tested.
-    # Scoped to pull_request: on a push the actor is whoever merged, and main must stay analysed.
-    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
+    #
+    # Keyed on the PR author rather than github.actor: the actor is whoever triggered the run,
+    # which is forgeable as a trust signal (sonar githubactions:S8232) and would also match a
+    # human merging a Dependabot PR. On a push there is no pull_request payload, so this is
+    # null and main stays analysed.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,14 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     needs: [web, api]
+    # Dependabot PRs run against Dependabot's own secret store, so secrets.SONAR_TOKEN
+    # arrives empty and the scan dies on "Not authorized or project not found". Mirroring
+    # the token over there would let a bot-authored PR spend our Sonar credentials, and it
+    # would buy nothing: Dependabot is configured for github-actions only, so its PRs change
+    # workflow YAML and no analysed source. Skip instead — a skipped job still satisfies a
+    # required check, and web/api/e2e need no secrets, so the bumped SHAs are still tested.
+    # Scoped to pull_request: on a push the actor is whoever merged, and main must stay analysed.
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
## Why

Every weekly Dependabot PR fails two checks, #176 included:

```
SONAR_TOKEN: 
ERROR: Not authorized or project not found. Please check the 'SONAR_TOKEN' environment variable...
```

GitHub deliberately runs Dependabot PRs against Dependabot's **own** secret store, so `secrets.SONAR_TOKEN` and the SWA deployment token both resolve to empty strings. SonarCloud fails on authentication and `Build + deploy` fails alongside it. Nothing in the PR's content is wrong — the jobs simply cannot succeed there.

## Why not just give Dependabot the secrets

Mirroring them into the Dependabot store would hand a bot-authored PR our deployment credentials and CIAM secrets — the exposure the SHA pinning and least-privilege tokens in SEC-9 were closing, and the same reasoning already written into the `build_and_deploy` gate about fork PRs.

It would also buy nothing for Sonar. `.github/dependabot.yml` is configured for `github-actions` only, so these PRs change workflow YAML and no analysed source. #176's whole diff is three `.yml` files.

## What changed

Skip the two jobs on Dependabot pull requests.

- A skipped job still satisfies a required status check, so branch protection is unaffected.
- `web`, `api` and `e2e` use no secrets and keep running, so the bumped action SHAs are still genuinely exercised — the part of the PR that could actually break something is still tested.
- Both conditions are scoped to `pull_request` on purpose: on a push to `main` the actor is whoever merged, which would be `dependabot[bot]` under auto-merge, and neither the production deploy nor the main-branch analysis should ever be skipped for that.

## Verification

Both workflows re-parse as valid YAML with the intended job conditions:

```
ci.yml sonarcloud          -> github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
azure-static-web-apps.yml build_and_deploy
  -> (workflow_run && success && push && same repo)
  || (pull_request && action != 'closed' && github.actor != 'dependabot[bot]')
```

The real proof is the next Dependabot PR (or a rebase of #176) showing those two as skipped rather than red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
