### PR TITLE
ci: mirror SONAR_TOKEN to Dependabot instead of skipping the scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,18 +209,13 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     needs: [web, api]
-    # Dependabot PRs run against Dependabot's own secret store, so secrets.SONAR_TOKEN
-    # arrives empty and the scan dies on "Not authorized or project not found". Mirroring
-    # the token over there would let a bot-authored PR spend our Sonar credentials, and it
-    # would buy nothing: Dependabot is configured for github-actions only, so its PRs change
-    # workflow YAML and no analysed source. Skip instead — a skipped job still satisfies a
-    # required check, and web/api/e2e need no secrets, so the bumped SHAs are still tested.
-    #
-    # Keyed on the PR author rather than github.actor: the actor is whoever triggered the run,
-    # which is forgeable as a trust signal (sonar githubactions:S8232) and would also match a
-    # human merging a Dependabot PR. On a push there is no pull_request payload, so this is
-    # null and main stays analysed.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # This job deliberately has no Dependabot exclusion. "SonarCloud Code Analysis" is a
+    # required check posted by the SonarCloud app only when an analysis is actually
+    # submitted, so skipping the job leaves it permanently unreported rather than skipped,
+    # and the PR can never merge. SONAR_TOKEN is therefore mirrored into the Dependabot
+    # secret store by infra/setup.ps1. Only that token is — the deployment and CIAM
+    # credentials stay out of reach of bot-authored PRs, which is why Build + deploy in
+    # azure-static-web-apps.yml still skips for Dependabot.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -997,6 +997,15 @@ if (-not $SkipGitHub) {
             if ($LASTEXITCODE -eq 0) { Ok $name; $script:setSecretNames += $name } else { Warn "Failed to set $name" }
         }
 
+        # Dependabot PRs run against a separate secret store, so nothing set above is
+        # visible to them. Only tokens that a bot-authored PR may safely spend belong here.
+        $script:setDependabotSecretNames = @()
+        function Set-GhDependabotSecret([string]$name, [string]$value) {
+            if ([string]::IsNullOrWhiteSpace($value)) { Warn "Skipping $name (dependabot) — value not available"; return }
+            $value | gh secret set $name --repo $gitHubRepo --app dependabot
+            if ($LASTEXITCODE -eq 0) { Ok "$name (dependabot)"; $script:setDependabotSecretNames += $name } else { Warn "Failed to set $name (dependabot)" }
+        }
+
         # SWA deployment token — fetch fresh from Azure each run.
         if ($swaName -and $s['resourceGroup']) {
             if ($s.Contains('subscriptionId')) { Switch-ToSubscription $s['subscriptionId'] }
@@ -1100,6 +1109,14 @@ if (-not $SkipGitHub) {
         $sonarToken = Ask $s 'sonarToken' 'SonarCloud token (sonarcloud.io -> My Account -> Security, Enter to skip)'
         Set-GhSecret 'SONAR_TOKEN' $sonarToken
 
+        # ...and mirrored to Dependabot, which cannot see the secret above. Without it the
+        # scan fails to authenticate on every Dependabot PR, and because the required
+        # "SonarCloud Code Analysis" check is only posted when an analysis is submitted, the
+        # PR is left waiting on a status that never arrives. This is the only secret shared
+        # with Dependabot: it submits analyses and nothing else, unlike the deployment and
+        # CIAM credentials above.
+        Set-GhDependabotSecret 'SONAR_TOKEN' $sonarToken
+
         # ── Validate all expected secrets are present ────────────────────────
         Step 'Phase 4 · Validating GitHub secrets'
         $actualSecretNames   = @(gh secret list --repo $gitHubRepo --json name -q '.[].name' 2>$null)
@@ -1109,6 +1126,19 @@ if (-not $SkipGitHub) {
             Ok "All $($expectedSecretNames.Count) secret(s) confirmed present on $gitHubRepo"
         } else {
             Warn "Missing on $gitHubRepo`: $($missingSecretNames -join ', ')"
+        }
+
+        # The Dependabot store is listed separately — `gh secret list` without --app only
+        # ever shows Actions secrets, so a missing mirror would otherwise pass unnoticed.
+        $expectedDependabotNames = @($script:setDependabotSecretNames | Select-Object -Unique)
+        if ($expectedDependabotNames.Count -gt 0) {
+            $actualDependabotNames  = @(gh secret list --repo $gitHubRepo --app dependabot --json name -q '.[].name' 2>$null)
+            $missingDependabotNames = @($expectedDependabotNames | Where-Object { $_ -notin $actualDependabotNames })
+            if ($missingDependabotNames.Count -eq 0) {
+                Ok "All $($expectedDependabotNames.Count) Dependabot secret(s) confirmed present on $gitHubRepo"
+            } else {
+                Warn "Missing from the Dependabot store on $gitHubRepo`: $($missingDependabotNames -join ', ')"
+            }
         }
     }
 }


### PR DESCRIPTION
Follow-up to #180, which fixed the visible red check on Dependabot PRs but not the merge block.

## The gap

`SonarCloud Code Analysis` is a **required** status check, but it isn't a job in this repo's workflows — the SonarCloud app posts it when an analysis is submitted. Skipping the `sonarcloud` job means no analysis, so the check is never posted **at all**, and branch protection waits indefinitely on a status that never arrives.

The evidence is in the two PRs' check lists. #178 reports it; #176 has no such row:

```
#176   Build + deploy  fail | SonarCloud  fail | API pass | E2E pass | Web pass
#178   Build + deploy  pass | SonarCloud  pass | SonarCloud Code Analysis  pass | ...
```

A skipped *job* is fine — it reports a conclusion and satisfies its requirement. An app check that never fires is not the same thing, and that distinction is what #180 got wrong.

## What changed

The scan has to actually run on Dependabot PRs, so `infra/setup.ps1` mirrors `SONAR_TOKEN` into the Dependabot secret store (`gh secret set --app dependabot`), and the `sonarcloud` job loses its exclusion. The comment left in its place explains why it must not gain one again.

`SONAR_TOKEN` is the **only** secret shared with Dependabot. It submits analyses and nothing else. The SWA deployment token and the CIAM credentials stay out of reach of bot-authored PRs, so `Build + deploy` keeps its Dependabot skip from #180 — that one is a job, so skipping it reports cleanly.

Secret validation now lists the Dependabot store separately, because `gh secret list` without `--app` only ever shows Actions secrets and a missing mirror would otherwise pass unnoticed.

## Follow-up required — this does not take effect on its own

The workflow change is inert until the secret exists. After merging, run:

```
pwsh infra/setup.ps1
```

It will re-prompt for the SonarCloud token (or reuse the stored one) and set it in both stores. Until then, Dependabot PRs keep failing exactly as they do now.

## Verification

- Both workflows re-parse as valid YAML; `sonarcloud` now has no `if:`, and `build_and_deploy` keeps its PR-author exclusion.
- `infra/setup.ps1` parses clean via `System.Management.Automation.Language.Parser`.
- End-to-end proof is the next Dependabot PR going green, which needs the setup script run first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
