### PR TITLE
fix: resolve all open SonarCloud issues

### DIFF
--- a/.github/scripts/spa-redirect-uri.sh
+++ b/.github/scripts/spa-redirect-uri.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 MODE="${1:-}"
 TARGET="${2:-}"
-if [ -z "$MODE" ] || [ -z "$TARGET" ]; then
+if [[ -z "$MODE" || -z "$TARGET" ]]; then
   echo "usage: $(basename "$0") <add|remove> <pr-number|base-url>" >&2
   exit 2
 fi
@@ -105,7 +105,7 @@ case "$MODE" in
     ;;
 esac
 
-if [ "$UPDATED" = "$CURRENT" ]; then
+if [[ "$UPDATED" == "$CURRENT" ]]; then
   echo "No change needed ($MODE): $DESCRIPTION"
   exit 0
 fi

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -733,10 +733,8 @@ public class ContentFunctionsTests
     [Fact]
     public async Task WhoAmI_returns_claims_for_current_principal()
     {
-        var repo = new FakeContentRepository();
-        var fn = MeFn(repo);
         var ctx = new TestFunctionContext().WithUser("oid-1", "Alice", "Admin");
-        var resp = (TestHttpResponseData)await fn.WhoAmI(TestHttp.Get(ctx, "http://localhost/api/whoami"), ctx);
+        var resp = (TestHttpResponseData)await MeSelfFunctions.WhoAmI(TestHttp.Get(ctx, "http://localhost/api/whoami"), ctx);
         Assert.Equal(System.Net.HttpStatusCode.OK, resp.StatusCode);
         var body = resp.ReadBodyAsString();
         Assert.Contains("oid", body);
@@ -745,10 +743,8 @@ public class ContentFunctionsTests
     [Fact]
     public async Task WhoAmI_returns_empty_claims_when_no_principal()
     {
-        var repo = new FakeContentRepository();
-        var fn = MeFn(repo);
         var ctx = new TestFunctionContext(); // no principal
-        var resp = (TestHttpResponseData)await fn.WhoAmI(TestHttp.Get(ctx, "http://localhost/api/whoami"), ctx);
+        var resp = (TestHttpResponseData)await MeSelfFunctions.WhoAmI(TestHttp.Get(ctx, "http://localhost/api/whoami"), ctx);
         Assert.Equal(System.Net.HttpStatusCode.OK, resp.StatusCode);
     }
 

--- a/src/api/Slypn.Api.Tests/SwaggerTests.cs
+++ b/src/api/Slypn.Api.Tests/SwaggerTests.cs
@@ -18,10 +18,9 @@ public class SwaggerTests
     [Fact]
     public async Task SwaggerOAuth2Redirect_returns_200_html_page()
     {
-        var fn = new SwaggerOAuth2RedirectFunction();
         var ctx = new TestFunctionContext();
         var req = TestHttp.Get(ctx, "http://localhost/api/swagger/oauth2-redirect.html");
-        var resp = (TestHttpResponseData)await fn.Run(req);
+        var resp = (TestHttpResponseData)await SwaggerOAuth2RedirectFunction.Run(req);
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.True(resp.Headers.TryGetValues("Content-Type", out var ct));

--- a/src/api/Slypn.Api/Functions/MeSelfFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MeSelfFunctions.cs
@@ -22,7 +22,7 @@ public sealed class MeSelfFunctions(
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Unauthorized, Description = "Missing or invalid token")]
     [Function("WhoAmI")]
     [RequireRole]
-    public async Task<HttpResponseData> WhoAmI(
+    public static async Task<HttpResponseData> WhoAmI(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "whoami")] HttpRequestData req,
         FunctionContext context)
     {

--- a/src/api/Slypn.Api/Functions/MediaFunctions.cs
+++ b/src/api/Slypn.Api/Functions/MediaFunctions.cs
@@ -60,7 +60,8 @@ public sealed class MediaFunctions(IBlobService blob, IOptions<StorageOptions> s
             return await Reject(req, HttpStatusCode.BadRequest, $"Could not parse multipart body: {ex.Message}");
         }
 
-        var file = parsed.Files.FirstOrDefault(f => f.Name == "file") ?? parsed.Files.FirstOrDefault();
+        var file = parsed.Files.FirstOrDefault(f => f.Name == "file")
+                   ?? (parsed.Files.Count > 0 ? parsed.Files[0] : null);
         if (file is null)
         {
             return await Reject(req, HttpStatusCode.BadRequest, "No file part in the upload.");

--- a/src/api/Slypn.Api/Functions/SwaggerOAuth2RedirectFunction.cs
+++ b/src/api/Slypn.Api/Functions/SwaggerOAuth2RedirectFunction.cs
@@ -9,7 +9,7 @@ namespace Slypn.Api.Functions;
 /// extension does not register this endpoint automatically; Swagger UI derives
 /// the redirect URL from its own page path, so it must live here.
 /// </summary>
-public sealed class SwaggerOAuth2RedirectFunction
+public static class SwaggerOAuth2RedirectFunction
 {
     private const string Html = """
         <!doctype html>

--- a/src/api/Slypn.Api/Functions/SwaggerOAuth2RedirectFunction.cs
+++ b/src/api/Slypn.Api/Functions/SwaggerOAuth2RedirectFunction.cs
@@ -57,7 +57,7 @@ public sealed class SwaggerOAuth2RedirectFunction
         """;
 
     [Function("SwaggerOAuth2Redirect")]
-    public async Task<HttpResponseData> Run(
+    public static async Task<HttpResponseData> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/oauth2-redirect.html")] HttpRequestData req)
     {
         var response = req.CreateResponse(HttpStatusCode.OK);

--- a/src/api/Slypn.Api/Infrastructure/DevPersonas.cs
+++ b/src/api/Slypn.Api/Infrastructure/DevPersonas.cs
@@ -25,7 +25,7 @@ public static class DevPersonas
         new("member",       "33333333-3333-3333-3333-333333333333", "slypn.test.member@cookingcode.com",        "Test Member",        ["Member"]),
     ];
 
-    private static readonly IReadOnlyDictionary<string, DevPersona> ByKey =
+    private static readonly Dictionary<string, DevPersona> ByKey =
         All.ToDictionary(p => p.Key, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Resolve a persona by key, falling back to the default (admin) when unknown/null.</summary>

--- a/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
@@ -269,7 +269,7 @@ public sealed class JwtMiddleware(
     private static async Task ShortCircuit(FunctionContext context, HttpRequestData req, HttpStatusCode code, string message)
     {
         var resp = req.CreateResponse(code);
-        await resp.WriteStringAsync(message);
+        await resp.WriteStringAsync(message, context.CancellationToken);
         context.GetInvocationResult().Value = resp;
     }
 }

--- a/src/api/Slypn.Api/Infrastructure/OpenApiConfig.cs
+++ b/src/api/Slypn.Api/Infrastructure/OpenApiConfig.cs
@@ -21,5 +21,5 @@ public sealed class OpenApiConfig : IOpenApiConfigurationOptions
     public bool IncludeRequestingHostName { get; set; } = false;
     public bool ForceHttp { get; set; } = false;
     public bool ForceHttps { get; set; } = false;
-    public List<IDocumentFilter> DocumentFilters { get; set; } = [];
+    public List<IDocumentFilter> DocumentFilters { get; set; }
 }

--- a/src/api/Slypn.Api/Infrastructure/SwaggerOAuthFilter.cs
+++ b/src/api/Slypn.Api/Infrastructure/SwaggerOAuthFilter.cs
@@ -49,15 +49,18 @@ public sealed class SwaggerOAuthFilter(IConfiguration config) : IDocumentFilter
             Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }
         };
 
-        foreach (var path in document.Paths.Values)
-        foreach (var op in path.Operations.Values)
+        var operationSecurities = document.Paths.Values
+            .SelectMany(path => path.Operations.Values)
+            .Select(op => op.Security);
+
+        foreach (var security in operationSecurities)
         {
-            if (op.Security is null) continue;
-            var bearerReq = op.Security.FirstOrDefault(
+            if (security is null) continue;
+            var bearerReq = security.FirstOrDefault(
                 r => r.Keys.Any(k => k.Reference?.Id == "bearer_auth"));
             if (bearerReq is null) continue;
-            op.Security.Remove(bearerReq);
-            op.Security.Add(new OpenApiSecurityRequirement { [oauth2Ref] = [scope] });
+            security.Remove(bearerReq);
+            security.Add(new OpenApiSecurityRequirement { [oauth2Ref] = [scope] });
         }
     }
 }

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -30,6 +30,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     private const string NewslettersPartition = "newsletter";
     private const string ArticleType       = "article";
     private const string InReviewStatus    = "in-review";
+    private const string PublishedStatus   = "published";
 
     private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
 
@@ -90,7 +91,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
 
         // Fallback: treat the value as an article id. Covers content created before
         // hybrid slugs existed (empty/blank slug) so it stays addressable.
-        return await GetArticleAsync(slugOrId, "published", ct);
+        return await GetArticleAsync(slugOrId, PublishedStatus, ct);
     }
 
     public async Task<Article?> GetArticleWithNeighboursAsync(string slugOrId, CancellationToken ct)
@@ -98,7 +99,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         // ListArticlesAsync returns newest-first, matching the articles list page order.
         // prev = the article above the current one in the list (newer),
         // next = the article below (older).
-        var sorted = (await ListArticlesAsync("published", ct)).ToList();
+        var sorted = (await ListArticlesAsync(PublishedStatus, ct)).ToList();
 
         var idx = sorted.FindIndex(a =>
             string.Equals(a.Slug, slugOrId, StringComparison.OrdinalIgnoreCase) ||
@@ -572,7 +573,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     {
         EnsureWrites();
 
-        var published = await GetArticleAsync(articleId, "published", ct)
+        var published = await GetArticleAsync(articleId, PublishedStatus, ct)
             ?? throw new InvalidOperationException($"Published article {articleId} not found.");
 
         // Resume an in-progress revision the editor already started for this article,
@@ -610,12 +611,12 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             ?? throw new InvalidOperationException($"Article {id} is not in 'in-review'.");
 
         if (string.IsNullOrEmpty(review.ReplacesArticleId))
-            return await TransitionAsync(id, fromStatus: InReviewStatus, toStatus: "published",
+            return await TransitionAsync(id, fromStatus: InReviewStatus, toStatus: PublishedStatus,
                 update: a => a with { PublishedAt = DateTime.UtcNow, RejectionReason = null }, ct);
 
         // Revision: overwrite the target published article's content in place, keeping its
         // id, slug and original published date so the public URL never changes.
-        var target = await GetArticleAsync(review.ReplacesArticleId, "published", ct)
+        var target = await GetArticleAsync(review.ReplacesArticleId, PublishedStatus, ct)
             ?? throw new InvalidOperationException($"Target published article {review.ReplacesArticleId} not found.");
 
         var replacement = target with
@@ -625,7 +626,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             Category       = review.Category,
             ReadingMinutes = review.ReadingMinutes,
             Type           = review.Type,
-            Status         = "published",
+            Status         = PublishedStatus,
             RejectionReason     = null,
             ReplacesArticleId   = null,
             DeletionRequestedBy = null,
@@ -664,7 +665,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         Article source;
         try
         {
-            var read = await store.Articles.GetEntityAsync<TableEntity>("published", id, cancellationToken: ct);
+            var read = await store.Articles.GetEntityAsync<TableEntity>(PublishedStatus, id, cancellationToken: ct);
             source = Deserialize<Article>(read.Value);
         }
         catch (RequestFailedException ex) when (ex.Status == 404)

--- a/src/api/Slypn.Api/Services/HtmlSanitizer.cs
+++ b/src/api/Slypn.Api/Services/HtmlSanitizer.cs
@@ -74,10 +74,9 @@ public sealed class HtmlSanitizer : IHtmlSanitizer
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .ToList();
 
-            foreach (var required in RequiredBlankRel)
-            {
-                if (!tokens.Contains(required, StringComparer.OrdinalIgnoreCase)) tokens.Add(required);
-            }
+            tokens.AddRange(RequiredBlankRel
+                .Where(required => !tokens.Contains(required, StringComparer.OrdinalIgnoreCase))
+                .ToList());
 
             element.SetAttribute("rel", string.Join(' ', tokens));
         };

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -19,7 +19,7 @@ public interface IContentRepository
     // Reads ------------------------------------------------------------------
     Task<IReadOnlyList<Article>>        ListArticlesAsync(string? status, CancellationToken ct);
     Task<IReadOnlyList<Article>>        ListBlogPostsAsync(string? status, CancellationToken ct);
-    Task<Article?>                      GetArticleBySlugAsync(string slug, CancellationToken ct);
+    Task<Article?>                      GetArticleBySlugAsync(string slugOrId, CancellationToken ct);
     Task<Article?>                      GetArticleWithNeighboursAsync(string slugOrId, CancellationToken ct);
     Task<IReadOnlyList<CommunityEvent>> ListEventsAsync(bool upcomingOnly, CancellationToken ct);
     Task<CommunityEvent?>               GetEventByIdAsync(string id, CancellationToken ct);

--- a/src/web/eslint.config.js
+++ b/src/web/eslint.config.js
@@ -1,7 +1,7 @@
 import pluginVue from 'eslint-plugin-vue'
-import vueTsEslintConfig from '@vue/eslint-config-typescript'
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
 
-export default [
+export default defineConfigWithVueTs(
   {
     name: 'slypn/files-to-lint',
     files: ['**/*.{ts,mts,tsx,vue}'],
@@ -16,12 +16,12 @@ export default [
       '**/*.cjs', '**/*.mjs',
     ],
   },
-  ...pluginVue.configs['flat/essential'],
-  ...vueTsEslintConfig(),
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
   {
     name: 'slypn/rules',
     rules: {
       'vue/multi-word-component-names': 'off',
     },
   },
-]
+)

--- a/src/web/public/swagger.html
+++ b/src/web/public/swagger.html
@@ -9,35 +9,32 @@
 <body>
   <div id="swagger-ui"></div>
   <script src="https://unpkg.com/swagger-ui-dist@5.32.8/swagger-ui-bundle.js" integrity="sha384-IKpAWwsTL0pcw7/Amtnt2eXF4P1BK64WNuY2E/RG15SWLUW5HXzFuyqCSAr/DP8C" crossorigin="anonymous"></script>
-  <script>
-    fetch('/api/swagger.json')
-      .then(r => r.json())
-      .then(spec => {
-        const oauth2 = spec.components?.securitySchemes?.oauth2
-        const clientId = oauth2?.['x-client-id'] ?? ''
-        const scopes = Object.keys(oauth2?.flows?.authorizationCode?.scopes ?? {}).join(' ')
-        const ui = SwaggerUIBundle({
-          spec,
-          dom_id: '#swagger-ui',
-          presets: [SwaggerUIBundle.presets.apis],
-          layout: 'BaseLayout',
-          oauth2RedirectUrl: window.location.origin + '/oauth2-redirect.html',
-          validatorUrl: null,
-          requestInterceptor: (req) => {
-            req.url = req.url.replace(/https?:\/\/[^/]+\.azurewebsites\.net\/api/, window.location.origin + '/api')
-            // SWA replaces Authorization with its own HS256 session token before reaching Functions.
-            // Move the Bearer token to X-Slypn-Token which SWA leaves untouched.
-            const auth = req.headers?.['Authorization'] ?? req.headers?.['authorization']
-            if (auth && req.url.includes('/api/')) {
-              req.headers['X-Slypn-Token'] = auth
-              delete req.headers['Authorization']
-              delete req.headers['authorization']
-            }
-            return req
-          },
-        })
-        ui.initOAuth({ clientId, scopes, usePkceWithAuthorizationCodeGrant: true })
-      })
+  <script type="module">
+    const spec = await (await fetch('/api/swagger.json')).json()
+    const oauth2 = spec.components?.securitySchemes?.oauth2
+    const clientId = oauth2?.['x-client-id'] ?? ''
+    const scopes = Object.keys(oauth2?.flows?.authorizationCode?.scopes ?? {}).join(' ')
+    const ui = SwaggerUIBundle({
+      spec,
+      dom_id: '#swagger-ui',
+      presets: [SwaggerUIBundle.presets.apis],
+      layout: 'BaseLayout',
+      oauth2RedirectUrl: window.location.origin + '/oauth2-redirect.html',
+      validatorUrl: null,
+      requestInterceptor: (req) => {
+        req.url = req.url.replace(/https?:\/\/[^/]+\.azurewebsites\.net\/api/, window.location.origin + '/api')
+        // SWA replaces Authorization with its own HS256 session token before reaching Functions.
+        // Move the Bearer token to X-Slypn-Token which SWA leaves untouched.
+        const auth = req.headers?.['Authorization'] ?? req.headers?.['authorization']
+        if (auth && req.url.includes('/api/')) {
+          req.headers['X-Slypn-Token'] = auth
+          delete req.headers['Authorization']
+          delete req.headers['authorization']
+        }
+        return req
+      },
+    })
+    ui.initOAuth({ clientId, scopes, usePkceWithAuthorizationCodeGrant: true })
   </script>
 </body>
 </html>

--- a/src/web/src/components/editor/DraftEditor.vue
+++ b/src/web/src/components/editor/DraftEditor.vue
@@ -5,7 +5,7 @@ import SaveIndicator from '@/components/editor/SaveIndicator.vue'
 import { useAutoSave } from '@/composables/useAutoSave'
 import { useBeforeUnload } from '@/composables/useBeforeUnload'
 import { apiErrorMessage, apiFetch } from '@/lib/api'
-import { EMPTY_DRAFT, type DraftPayload, type DraftSummary } from '@/lib/draft'
+import { EMPTY_DRAFT, htmlToText, type DraftPayload, type DraftSummary } from '@/lib/draft'
 
 const props = defineProps<{
   draftId: string
@@ -46,7 +46,7 @@ function isDirty(): boolean {
 async function loadDraft(id: string) {
   // Read-only mode shows a passed-in in-review payload; there's no draft to fetch.
   if (props.readonly) {
-    draft.value = { ...EMPTY_DRAFT, ...(props.initialContent ?? {}) }
+    draft.value = { ...EMPTY_DRAFT, ...props.initialContent }
     currentEtag.value = null
     conflict.value = null
     submitError.value = null
@@ -177,7 +177,7 @@ const categoryHints = computed(() =>
 // isn't enough — require real text or an image before allowing submit.
 function hasBodyContent(html: string): boolean {
   if (/<img\b/i.test(html)) return true
-  return html.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/gi, ' ').trim().length > 0
+  return htmlToText(html).trim().length > 0
 }
 
 const missingToSubmit = computed(() => {
@@ -203,7 +203,7 @@ useBeforeUnload(computed(() =>
 ))
 
 watch(() => draft.value.body, (html) => {
-  const text  = html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+  const text  = htmlToText(html).replace(/\s+/g, ' ').trim()
   const words = text ? text.split(' ').length : 0
   draft.value.readingMinutes = Math.max(1, Math.round(words / 200))
 })
@@ -331,7 +331,7 @@ watch(() => draft.value.body, (html) => {
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-slypn-800">Reading time</label>
+        <span class="block text-sm font-medium text-slypn-800">Reading time</span>
         <p class="mt-1 rounded-md border border-slypn-100 bg-slypn-50 px-3 py-2 text-sm text-slypn-700">
           {{ draft.readingMinutes }} min <span class="text-slypn-400">· auto-calculated</span>
         </p>

--- a/src/web/src/components/editor/RichTextEditor.spec.ts
+++ b/src/web/src/components/editor/RichTextEditor.spec.ts
@@ -25,7 +25,7 @@ describe('RichTextEditor', () => {
 
   it('hides the toolbar in readonly mode', () => {
     const w = mountEditor({ readonly: true })
-    expect(w.findAll('button').length).toBe(0)
+    expect(w.findAll('button')).toHaveLength(0)
   })
 
   it('runs formatting commands without error', async () => {

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -196,10 +196,10 @@ async function onSignOut() {
                   >{{ approvalsStore.pendingCount }}</span>
                 </RouterLink>
               </li>
-              <li v-if="link.dividerAfter" class="my-1 border-t border-slypn-100" role="separator" aria-hidden="true"></li>
+              <li v-if="link.dividerAfter" aria-hidden="true"><hr class="my-1 border-t border-slypn-100" /></li>
             </template>
             <li>
-              <button class="block w-full px-4 py-2 text-left hover:bg-slypn-50" @click="onSignOut">Sign out</button>
+              <button type="button" class="block w-full px-4 py-2 text-left hover:bg-slypn-50" @click="onSignOut">Sign out</button>
             </li>
           </ul>
         </div>
@@ -256,7 +256,7 @@ async function onSignOut() {
         >
           {{ item.label }}
         </RouterLink>
-        <button
+        <button type="button"
           v-if="!auth.isAuthenticated"
           class="mt-1 rounded-md bg-slypn-600 px-3 py-2 text-center text-base font-semibold text-white hover:bg-slypn-700"
           @click="mobileOpen = false; onSignIn()"
@@ -292,9 +292,9 @@ async function onSignOut() {
               class="ml-2 rounded-full bg-amber-500 px-1.5 py-0.5 text-xs font-bold text-white"
             >{{ approvalsStore.pendingCount }}</span>
           </RouterLink>
-          <div v-if="link.dividerAfter" class="my-1 border-t border-slypn-100" role="separator" aria-hidden="true"></div>
+          <hr v-if="link.dividerAfter" class="my-1 border-t border-slypn-100" aria-hidden="true" />
         </template>
-        <button
+        <button type="button"
           class="mt-1 rounded-md border border-slypn-200 bg-white px-3 py-2 text-center text-base font-semibold text-slypn-700 hover:bg-slypn-50"
           @click="onSignOut"
         >

--- a/src/web/src/lib/draft.ts
+++ b/src/web/src/lib/draft.ts
@@ -25,11 +25,18 @@ export const EMPTY_DRAFT: DraftPayload = {
 }
 
 export function makeDraftId(): string {
-  if ('randomUUID' in crypto) return crypto.randomUUID().replace(/-/g, '')
+  if ('randomUUID' in crypto) return crypto.randomUUID().replaceAll('-', '')
   return randomHexFallback()
 }
 
 function randomHexFallback(): string {
   const bytes = crypto.getRandomValues(new Uint8Array(16))
   return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+// Strips markup so callers can reason about the text a draft actually carries.
+// Parsing beats a tag-stripping regex here: it can't backtrack on malformed
+// HTML, and it decodes entities (&nbsp; and friends) for free.
+export function htmlToText(html: string): string {
+  return new DOMParser().parseFromString(html, 'text/html').body.textContent ?? ''
 }

--- a/src/web/src/stores/auth.ts
+++ b/src/web/src/stores/auth.ts
@@ -68,6 +68,19 @@ function makeDevAccount(): AccountInfo {
   } as AccountInfo
 }
 
+/**
+ * Dev-skip only: switch the active test persona. Persists the choice and
+ * reloads so every Pinia store + fetched dataset is rebuilt under the new
+ * identity (simpler and more reliable than re-running each store's loaders).
+ * Kept at module scope: it touches no store state, so re-creating it per
+ * store instance buys nothing.
+ */
+function setPersona(key: DevPersonaKey) {
+  if (!isDevSkipAuth) return
+  setActivePersonaKey(key)
+  globalThis.location.reload()
+}
+
 export const useAuthStore = defineStore('auth', () => {
   const account = ref<AccountInfo | null>(null)
   const apiRoles = ref<string[]>([])
@@ -203,17 +216,6 @@ export const useAuthStore = defineStore('auth', () => {
       return
     }
     await msalInstance.logoutRedirect({ account: account.value })
-  }
-
-  /**
-   * Dev-skip only: switch the active test persona. Persists the choice and
-   * reloads so every Pinia store + fetched dataset is rebuilt under the new
-   * identity (simpler and more reliable than re-running each store's loaders).
-   */
-  function setPersona(key: DevPersonaKey) {
-    if (!isDevSkipAuth) return
-    setActivePersonaKey(key)
-    globalThis.location.reload()
   }
 
   /**

--- a/src/web/src/views/ArticlesView.vue
+++ b/src/web/src/views/ArticlesView.vue
@@ -55,7 +55,7 @@ const visible = computed(() => {
 
     <div v-else-if="error" class="mt-12 rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load articles: {{ error }}.
-      <button class="ml-2 underline" @click="refresh">Retry</button>
+      <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
     <div v-else class="mt-8 grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/web/src/views/BlogView.vue
+++ b/src/web/src/views/BlogView.vue
@@ -59,7 +59,7 @@ const formatDate = (iso: string) =>
 
     <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load the blog: {{ error }}.
-      <button class="ml-2 underline" @click="refresh">Retry</button>
+      <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
     <p v-else-if="!sorted.length" class="text-center text-slypn-900/70">

--- a/src/web/src/views/EditorView.spec.ts
+++ b/src/web/src/views/EditorView.spec.ts
@@ -90,7 +90,7 @@ describe('EditorView', () => {
     mockLists([draftSummary()])
     const w = mountV()
     await flushPromises()
-    await w.find('[role="button"]').trigger('click')
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
     await flushPromises()
     expect(w.find('.draft-editor-stub').exists()).toBe(true)
   })
@@ -122,7 +122,7 @@ describe('EditorView', () => {
     await flushPromises()
     expect(w.text()).toContain('Pending Article')
     expect(w.text()).toContain('In review')
-    await w.find('[role="button"]').trigger('click')
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
     expect(w.find('.draft-editor-stub').exists()).toBe(true)
   })
 
@@ -133,7 +133,7 @@ describe('EditorView', () => {
     ])
     const w = mountV()
     await flushPromises()
-    const rows = w.findAll('[role="button"]').map(el => el.text())
+    const rows = w.findAll('[data-testid="draft-row-open"]').map(el => el.text())
     expect(rows[0]).toContain('Newer item')
   })
 
@@ -141,7 +141,7 @@ describe('EditorView', () => {
     mockLists([draftSummary()])
     const w = mountV()
     await flushPromises()
-    await w.find('[role="button"]').trigger('click')
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
     expect(w.find('.draft-editor-stub').exists()).toBe(true)
     await w.findAll('button').find(b => b.text() === 'Close editor')!.trigger('click')
     await flushPromises()
@@ -152,7 +152,7 @@ describe('EditorView', () => {
     mockLists([draftSummary()])
     const w = mountV()
     await flushPromises()
-    await w.find('[role="button"]').trigger('click')
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
     await w.findAll('button').find(b => b.text() === 'Save draft')!.trigger('click')
     expect(w.text()).toContain('Saved title')
   })
@@ -161,7 +161,7 @@ describe('EditorView', () => {
     mockLists([draftSummary()])
     const w = mountV()
     await flushPromises()
-    await w.find('[role="button"]').trigger('click')
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
     await w.findAll('button').find(b => b.text() === 'Submit draft')!.trigger('click')
     await flushPromises()
     expect(w.text()).toContain('Submitted for admin review')
@@ -213,7 +213,7 @@ describe('EditorView', () => {
     apiFetch.mockResolvedValue(ok({}))
     const w = mountV()
     await flushPromises()
-    await w.find('[role="button"]').trigger('click') // open draft d1
+    await w.find('[data-testid="draft-row-open"]').trigger('click') // open draft d1
     expect(w.find('.draft-editor-stub').exists()).toBe(true)
     apiJson.mockResolvedValue([]) // refresh returns empty list
     await w.find('button[title="Delete draft"]').trigger('click')
@@ -225,20 +225,20 @@ describe('EditorView', () => {
     mockLists([draftSummary()])
     const w = mountV()
     await flushPromises()
-    await w.find('[role="button"]').trigger('click')
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
     expect(w.find('.draft-editor-stub').exists()).toBe(true)
     const saveCount = (apiFetch as ReturnType<typeof vi.fn>).mock.calls.length
-    await w.find('[role="button"]').trigger('click') // second click on same draft — should early-return
-    expect((apiFetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(saveCount)
+    await w.find('[data-testid="draft-row-open"]').trigger('click') // second click on same draft — should early-return
+    expect((apiFetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(saveCount)
   })
 
   it('does not re-open read-only when the same pending item is already open', async () => {
     mockWithPending([], [pendingItem()])
     const w = mountV()
     await flushPromises()
-    await w.find('[role="button"]').trigger('click')
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
     expect(w.find('.draft-editor-stub').exists()).toBe(true)
-    await w.find('[role="button"]').trigger('click') // second click — early-return
+    await w.find('[data-testid="draft-row-open"]').trigger('click') // second click — early-return
     expect(w.find('.draft-editor-stub').exists()).toBe(true)
   })
 
@@ -258,7 +258,7 @@ describe('EditorView', () => {
     mockLists([draftSummary()])
     const w = mountV()
     await flushPromises()
-    await w.find('[role="button"]').trigger('click')
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
     // emit saved with an id that does not exist in the current list
     await w.findAll('button').find(b => b.text() === 'Save draft')!.trigger('click')
     // The DraftEditorStub emits the same id (d1) which IS in the list — splice replaces it

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -245,10 +245,7 @@ const fmtDate = (iso: string) =>
             data-testid="draft-row"
             :data-id="e.id"
             :data-state="e.state"
-            role="button"
-            tabindex="0"
-            :aria-current="editorOpen && e.id === draftId"
-            :class="['flex cursor-pointer items-center gap-3 px-6 py-3 transition-colors',
+            :class="['flex items-center gap-3 px-6 py-3 transition-colors',
               editorOpen && e.id === draftId
                 ? (e.state === 'in-review'
                     ? 'bg-amber-100/60 ring-1 ring-inset ring-amber-300'
@@ -256,37 +253,43 @@ const fmtDate = (iso: string) =>
                 : (e.state === 'in-review'
                     ? 'bg-amber-50/40 hover:bg-amber-50'
                     : 'hover:bg-slypn-50/50')]"
-            @click="onRowClick(e)"
-            @keydown.enter="onRowClick(e)"
           >
-            <span class="shrink-0 rounded-full bg-slypn-100 px-2 py-0.5 text-xs font-semibold text-slypn-700">
-              {{ e.type === 'blog' ? 'Blog' : 'Article' }}
-            </span>
-            <p class="min-w-0 flex-1 truncate text-sm font-medium text-slypn-800">
-              {{ e.title || '(untitled)' }}
-            </p>
-            <span
-              v-if="e.state === 'in-review' && e.isRevision"
-              class="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700"
-            >Revision</span>
-            <span
-              v-if="e.state === 'in-review'"
-              data-testid="draft-row-state"
-              class="shrink-0 rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white"
-            >In review</span>
-            <span
-              v-else-if="editorOpen && e.id === draftId"
-              data-testid="draft-row-state"
-              class="shrink-0 rounded-full bg-slypn-600 px-2 py-0.5 text-xs font-semibold text-white"
-            >Editing</span>
-            <span class="shrink-0 text-xs text-slypn-400">{{ fmtDate(e.date) }}</span>
+            <button
+              type="button"
+              data-testid="draft-row-open"
+              class="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left"
+              :aria-current="editorOpen && e.id === draftId"
+              @click="onRowClick(e)"
+            >
+              <span class="shrink-0 rounded-full bg-slypn-100 px-2 py-0.5 text-xs font-semibold text-slypn-700">
+                {{ e.type === 'blog' ? 'Blog' : 'Article' }}
+              </span>
+              <span class="min-w-0 flex-1 truncate text-sm font-medium text-slypn-800">
+                {{ e.title || '(untitled)' }}
+              </span>
+              <span
+                v-if="e.state === 'in-review' && e.isRevision"
+                class="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700"
+              >Revision</span>
+              <span
+                v-if="e.state === 'in-review'"
+                data-testid="draft-row-state"
+                class="shrink-0 rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white"
+              >In review</span>
+              <span
+                v-else-if="editorOpen && e.id === draftId"
+                data-testid="draft-row-state"
+                class="shrink-0 rounded-full bg-slypn-600 px-2 py-0.5 text-xs font-semibold text-white"
+              >Editing</span>
+              <span class="shrink-0 text-xs text-slypn-400">{{ fmtDate(e.date) }}</span>
+            </button>
             <button
               v-if="e.state === 'draft'"
               type="button"
               data-testid="draft-row-delete"
               class="shrink-0 rounded px-2 py-1 text-xs font-semibold text-rose-500 hover:bg-rose-50"
               title="Delete draft"
-              @click.stop="deleteDraft(e.id, e.etag)"
+              @click="deleteDraft(e.id, e.etag)"
             >✕</button>
             <span v-else class="w-7 shrink-0" aria-hidden="true"></span>
           </div>

--- a/src/web/src/views/EventManagementView.vue
+++ b/src/web/src/views/EventManagementView.vue
@@ -203,7 +203,7 @@ async function deleteEvent(event: CommunityEvent) {
       <p v-if="loading" class="mt-4 text-sm text-slypn-900/60">Loading events…</p>
       <p v-else-if="loadError" class="mt-4 rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
         Couldn&rsquo;t load events: {{ loadError }}.
-        <button class="ml-1 underline" @click="refresh">Retry</button>
+        <button type="button" class="ml-1 underline" @click="refresh">Retry</button>
       </p>
       <p v-else-if="!filtered.length" class="mt-4 text-sm text-slypn-900/60">No events match.</p>
 

--- a/src/web/src/views/EventsPreviousView.vue
+++ b/src/web/src/views/EventsPreviousView.vue
@@ -92,7 +92,7 @@ onBeforeUnmount(() => observer?.disconnect())
 
     <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load events: {{ error }}.
-      <button class="ml-2 underline" @click="refresh">Retry</button>
+      <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
     <template v-else>

--- a/src/web/src/views/EventsView.vue
+++ b/src/web/src/views/EventsView.vue
@@ -137,7 +137,7 @@ onBeforeUnmount(() => observer?.disconnect())
 
     <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load events: {{ error }}.
-      <button class="ml-2 underline" @click="refresh">Retry</button>
+      <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
     <template v-else>

--- a/src/web/src/views/MemberManagementView.vue
+++ b/src/web/src/views/MemberManagementView.vue
@@ -240,12 +240,12 @@ const fmtDate = (iso: string) =>
 
       <div v-else-if="error" class="px-6 py-4 text-sm text-rose-700">
         Couldn't load members: {{ error }}.
-        <button class="ml-2 underline" @click="refresh">Retry</button>
+        <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
       </div>
 
       <p v-else-if="saveError" data-testid="member-save-error" class="px-6 py-3 text-sm text-rose-700 bg-rose-50">
         {{ saveError }}
-        <button class="ml-2 underline" @click="saveError = null">Dismiss</button>
+        <button type="button" class="ml-2 underline" @click="saveError = null">Dismiss</button>
       </p>
 
       <div v-if="members?.length" class="divide-y divide-slypn-100">

--- a/src/web/src/views/NewsletterView.vue
+++ b/src/web/src/views/NewsletterView.vue
@@ -87,7 +87,7 @@ async function subscribe() {
 
     <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load newsletters: {{ error }}.
-      <button class="ml-2 underline" @click="refresh">Retry</button>
+      <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
     <p v-else-if="!newsletters?.length" class="text-slypn-900/70">

--- a/src/web/src/views/ResourceManagementView.vue
+++ b/src/web/src/views/ResourceManagementView.vue
@@ -140,12 +140,12 @@ async function remove(r: Resource) {
 
     <div v-else-if="error" class="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load resources: {{ error }}.
-      <button class="ml-2 underline" @click="refresh">Retry</button>
+      <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
     <p v-if="listError" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
       {{ listError }}
-      <button class="ml-2 underline" @click="listError = null">Dismiss</button>
+      <button type="button" class="ml-2 underline" @click="listError = null">Dismiss</button>
     </p>
 
     <div v-for="group in grouped" :key="group.category" class="space-y-3">

--- a/src/web/src/views/ResourcesView.vue
+++ b/src/web/src/views/ResourcesView.vue
@@ -48,7 +48,7 @@ const visible = computed(() => {
 
     <div v-else-if="error" class="mt-12 rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-700">
       Couldn&rsquo;t load resources: {{ error }}.
-      <button class="ml-2 underline" @click="refresh">Retry</button>
+      <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
     </div>
 
     <div v-else class="mt-8 grid gap-5 md:grid-cols-2 lg:grid-cols-3">

--- a/src/web/src/views/SubscriberManagementView.vue
+++ b/src/web/src/views/SubscriberManagementView.vue
@@ -120,12 +120,12 @@ const fmtDate = (iso: string) =>
 
       <div v-else-if="error" class="px-6 py-4 text-sm text-rose-700">
         Couldn't load subscribers: {{ error }}.
-        <button class="ml-2 underline" @click="refresh">Retry</button>
+        <button type="button" class="ml-2 underline" @click="refresh">Retry</button>
       </div>
 
       <p v-else-if="saveError" data-testid="subscriber-save-error" class="bg-rose-50 px-6 py-3 text-sm text-rose-700">
         {{ saveError }}
-        <button class="ml-2 underline" @click="saveError = null">Dismiss</button>
+        <button type="button" class="ml-2 underline" @click="saveError = null">Dismiss</button>
       </p>
 
       <div v-if="filteredSubscribers.length" class="divide-y divide-slypn-100">
@@ -156,7 +156,7 @@ const fmtDate = (iso: string) =>
 
       <p v-else-if="isFiltering" data-testid="subscriber-no-matches" class="px-6 py-8 text-center text-sm text-slypn-900/60">
         No subscribers match &ldquo;{{ search.trim() }}&rdquo;.
-        <button class="ml-1 underline" @click="search = ''">Clear search</button>
+        <button type="button" class="ml-1 underline" @click="search = ''">Clear search</button>
       </p>
 
       <p v-else-if="subscribers" class="px-6 py-8 text-center text-sm text-slypn-900/60">


### PR DESCRIPTION
Clears the **44 OPEN issues** on `sinclapa_slypn` (main branch) reported at
https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=sinclapa_slypn

## Web

| Rule | Fix |
|---|---|
| `S9011` ×17 | Explicit `type="button"` on buttons across the views and `AppNav` |
| `S6819` ×2 | `role="separator"` div/li → `<hr>` in `AppNav` |
| `S6819` | `EditorView` draft row: the outer `div` carried `role="button"` but wrapped a `<p>` **and** a nested delete button, so it can't simply become a `<button>`. Rebuilt as a plain row containing a real `<button data-testid="draft-row-open">` for the open action, with the delete button as its sibling. |
| `S8786` ×2 | Tag-stripping regexes replaced with a shared `htmlToText()` on `DOMParser` — no polynomial backtracking, and entities (`&nbsp;`) decode for free |
| `S7744` | Dropped the useless `...(props.initialContent ?? {})` empty-object spread |
| `S6853` | Read-only reading-time `<label>` → `<span>` (it labels no control) |
| `S7781` | `replaceAll('-', '')` |
| `S7721` | `setPersona` hoisted out of the store setup — it touches no store state |
| `S5906` ×2 | `toHaveLength(n)` over `.length` + `toBe(n)` |
| `S7785` | `swagger.html`: module script with top-level await instead of a `.then()` chain |
| `S1874` | `eslint.config.js` migrated to `defineConfigWithVueTs` / `vueTsConfigs` |

## API

| Rule | Fix |
|---|---|
| `S1192` | `PublishedStatus` const in `ContentRepository` (was 7 `"published"` literals) |
| `S927` | Interface parameter renamed `slug` → `slugOrId`, matching the implementation's actual contract and its sibling method |
| `S3973`, `S3267` | `SwaggerOAuthFilter`: brace-less nested `foreach` flattened into a `SelectMany`/`Select` over operation securities |
| `S3267` | `HtmlSanitizer`: `Where` filter before adding `rel` tokens |
| `CA1822` ×2 | `MeSelfFunctions.WhoAmI` and `SwaggerOAuth2RedirectFunction.Run` are `static` |
| `CA1859` | `DevPersonas.ByKey` typed as `Dictionary` |
| `CA1826` | `MediaFunctions` indexes `Files` instead of `FirstOrDefault()` |
| `S3604` | `OpenApiConfig`: dropped the initializer the constructor always overwrites |
| `S8949` | `JwtMiddleware` passes `context.CancellationToken` to `WriteStringAsync` |

## CI

`S7688` ×3 — `spa-redirect-uri.sh` uses `[[ ]]` conditionals.

## Verification

- web: `npm run lint` clean, **413/413** unit tests pass, `npm run build` (vue-tsc) succeeds
- api: `dotnet build -warnaserror` → **0 warnings, 0 errors**; **332/332** tests pass

Test call sites for the two now-`static` functions and the `EditorView` row selector were updated accordingly. Playwright e2e still clicks the row itself (`draft-row`); the hit point lands on the descendant open button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe