### PR TITLE
feat(infra): manage the SWA custom domain in bicep and setup.ps1

### DIFF
--- a/docs/custom-domain.md
+++ b/docs/custom-domain.md
@@ -25,6 +25,43 @@ Some registrars don't support `ALIAS`/`ANAME` on the apex — in that case eithe
 
 ## 2. Add the custom domain in Azure
 
+### The managed path (preferred)
+
+For the production hostname this is now **declarative** — `infra/main.bicep` owns it:
+
+```bicep
+param customDomain string = ''   // '' skips custom-domain setup entirely
+
+resource swaCustomDomain 'Microsoft.Web/staticSites/customDomains@2025-05-01' = if (!empty(customDomain)) {
+  parent: swa
+  name: customDomain
+  properties: { validationMethod: 'cname-delegation' }
+}
+```
+
+Set the hostname in `infra/main.parameters.prod.json` and deploy — `infra/setup.ps1` Phase 1 does
+this for you, and stores the resulting URL as `customDomainUrl` in `infra/secrets.json`:
+
+```json
+"customDomain": { "value": "slypn.cookingcode.com" },
+```
+
+> **Order matters.** `cname-delegation` validates by following the CNAME the hostname already
+> carries, so **the DNS record must exist before you deploy**. If it doesn't, validation fails and
+> takes the *whole deployment* down with it, not just this resource. Add the record (step 3) first.
+
+Phase 2 then adds `https://<customDomain>/auth/callback` and `/oauth2-redirect.html` to the SPA app
+registration automatically. Do **not** add those by hand in the portal: the preview-URI preservation
+logic in Phase 2 only carries over `azurestaticapps.net` hosts, so a hand-added custom-domain URI is
+pruned on the next run of the script.
+
+The default `*.azurestaticapps.net` hostname keeps working alongside it and remains the canonical
+`prodUrl`.
+
+### The manual path
+
+Still useful for a one-off or a non-production host.
+
 Portal route:
 1. SWA → **Custom domains → + Add**.
 2. **Custom domain on an existing domain** → enter `slypn.org.uk`.
@@ -120,6 +157,11 @@ Then remove the DNS records. The managed SSL cert auto-cleans within a day.
 ## 8. Troubleshooting
 
 - **"DNS validation failed"** → the TXT record hasn't propagated yet. Wait 5-10 min, click Re-validate.
+- **"An unknown error has occurred while adding your custom domain. Please try again later."** →
+  generic and usually transient, *not* a DNS problem — confirm the CNAME against the
+  authoritative nameservers (`nslookup -type=CNAME <host> <ns>`) and if it is correct, delete the
+  failed entry and re-add. Note the deletion carries its own **~15 minute propagation delay**;
+  re-adding inside that window tends to fail the same way.
 - **Apex `A` record but Azure still shows "DNS_VALIDATION"** → your registrar's apex isn't pointing where you think; `dig slypn.org.uk` to confirm.
 - **`SSL certificate is invalid`** → the cert provisioned but DNS is still pointing somewhere else (e.g. an old A record). Remove competing records.
 - **Sign-in fails after switching to the custom domain** → you forgot section 5's Entra redirect URI step. Add it and clear the Entra session cache (incognito tab).

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -33,6 +33,13 @@ param repositoryUrl string = 'https://github.com/sinclapa/slypn'
 @description('Branch to track for the Static Web App.')
 param repositoryBranch string = 'main'
 
+@description('''Custom hostname for the production site, e.g. slypn.cookingcode.com.
+Empty skips custom-domain setup entirely.
+The CNAME must ALREADY point at the SWA default hostname before you deploy: validation runs
+during deployment, and a missing or wrong record fails the whole deployment, not just this
+resource. Free-tier SWA allows two custom domains.''')
+param customDomain string = ''
+
 @description('Tags applied to every resource.')
 param tags object = {
   app: 'slypn'
@@ -136,9 +143,28 @@ resource swa 'Microsoft.Web/staticSites@2025-05-01' = { // NOSONAR (S6378) — s
 }
 
 // ---------------------------------------------------------------------------
+// Custom domain. cname-delegation validates by following the CNAME the hostname
+// already carries, so no _dnsauth TXT record is needed — but that CNAME has to
+// exist first (see docs/custom-domain.md). The SWA's managed certificate is
+// issued automatically once validation passes and auto-renews.
+//
+// This is additive: the default *.azurestaticapps.net hostname keeps working and
+// stays the canonical prodUrl, which is what the PR-preview redirect-URI logic in
+// setup.ps1 keys on.
+// ---------------------------------------------------------------------------
+resource swaCustomDomain 'Microsoft.Web/staticSites/customDomains@2025-05-01' = if (!empty(customDomain)) {
+  parent: swa
+  name: customDomain
+  properties: {
+    validationMethod: 'cname-delegation'
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Outputs — consumed by the deploy workflow in #41.
 // ---------------------------------------------------------------------------
 output swaUrl              string = 'https://${swa.properties.defaultHostname}'
+output customDomainUrl     string = empty(customDomain) ? '' : 'https://${customDomain}'
 output swaName             string = swa.name
 output storageAccountName  string = storage.name
 output mediaContainerName  string = mediaContainer.name

--- a/infra/main.parameters.prod.json
+++ b/infra/main.parameters.prod.json
@@ -4,6 +4,7 @@
   "parameters": {
     "env":              { "value": "prod" },
     "location":         { "value": "uksouth" },
+    "customDomain":     { "value": "slypn.cookingcode.com" },
     "repositoryUrl":    { "value": "https://github.com/sinclapa/slypn" },
     "repositoryBranch": { "value": "main" }
   }

--- a/infra/setup.ps1
+++ b/infra/setup.ps1
@@ -243,8 +243,19 @@ if (-not $SkipBicep) {
     $s['storageAccountName']   = $deployResult.storageAccountName.value
     $s['mediaContainerName']   = $deployResult.mediaContainerName.value
     $s['contentContainerName'] = $deployResult.contentContainerName.value
+
+    # Custom domain is optional (customDomain param empty = not configured). Store it
+    # only when set, so Phase 2 can tell "no custom domain" from "custom domain = ''".
+    $customDomainUrl = $deployResult.customDomainUrl.value
+    if (-not [string]::IsNullOrWhiteSpace($customDomainUrl)) {
+        $s['customDomainUrl'] = $customDomainUrl.TrimEnd('/')
+    } else {
+        $s.Remove('customDomainUrl')
+    }
+
     Save-Secrets $s
     Ok "SWA deployed: $($s['prodUrl'])"
+    if ($s.Contains('customDomainUrl')) { Ok "Custom domain: $($s['customDomainUrl'])" }
 
     # Storage connection string (Table + Blob) — permanent auth path; Free-tier SWA has no managed identity to use instead.
     Info 'Fetching Storage connection string...'
@@ -591,6 +602,16 @@ if (-not $SkipEntra) {
     $pUrl = if ($s.Contains('prodUrl')) { $s['prodUrl'] } else { '' }
     if (-not [string]::IsNullOrWhiteSpace($pUrl)) {
         $redirectUris = @("$pUrl/auth/callback", "$pUrl/oauth2-redirect.html") + $redirectUris
+    }
+
+    # The custom domain is a separate origin, so it needs its own callbacks — MSAL
+    # matches redirect URIs exactly. This must be built into the list rather than
+    # added by hand in the portal: the preview-preservation filter below only keeps
+    # azurestaticapps.net hosts, so a hand-added custom-domain URI would be pruned
+    # on the next run of this script.
+    $cUrl = if ($s.Contains('customDomainUrl')) { $s['customDomainUrl'] } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($cUrl)) {
+        $redirectUris = @("$cUrl/auth/callback", "$cUrl/oauth2-redirect.html") + $redirectUris
     }
 
     $spaApp           = Invoke-Graph GET "/applications/$spaObjectId"


### PR DESCRIPTION
`slypn.cookingcode.com` now points at the production site. This makes that setup reproducible instead of a one-off pile of CLI calls.

Split by what owns what: **the hostname is a resource**, so `main.bicep` declares it; **the Entra redirect URIs are Graph calls**, so `setup.ps1` Phase 2 reconciles them.

## `infra/main.bicep`

```bicep
param customDomain string = ''   // '' skips custom-domain setup entirely

resource swaCustomDomain 'Microsoft.Web/staticSites/customDomains@2025-05-01' = if (!empty(customDomain)) {
  parent: swa
  name: customDomain
  properties: { validationMethod: 'cname-delegation' }
}
```

Plus a `customDomainUrl` output. `cname-delegation` validates by following the CNAME the hostname already carries, so no `_dnsauth` TXT record is needed.

> ⚠️ **Ordering constraint.** The DNS record must exist *before* you deploy. A missing or wrong CNAME fails **the whole deployment**, not just this resource. Documented in `custom-domain.md`.

## `infra/setup.ps1`

- **Phase 1** stores `customDomainUrl` in `secrets.json` — or clears it when the param is empty, so Phase 2 can distinguish "not configured" from "configured as empty".
- **Phase 2** adds `/auth/callback` and `/oauth2-redirect.html` for the custom host.

That second one is the part that **has to be scripted rather than clicked into the portal**: Phase 2's preview-URI preservation filter only carries over `azurestaticapps.net` hosts, so a hand-added custom-domain URI gets pruned on the next run of the script. That's not hypothetical — it's exactly the trap this PR closes.

The default `*.azurestaticapps.net` hostname keeps working throughout and remains the canonical `prodUrl`, which the PR-preview redirect logic keys on.

## `docs/custom-domain.md`

Documents the declarative path as preferred, keeps the manual path for one-offs, and adds a troubleshooting entry for:

> An unknown error has occurred while adding your custom domain. Please try again later.

Generic, transient, and **not** a DNS problem — but the delete-then-retry carries its own ~15 minute propagation delay, and re-adding inside that window fails the same way. That is what it took to get this hostname live.

## Verification

Template/script:
- `az bicep build` clean (the BCP081 warnings are pre-existing — the parent SWA uses the same API version)
- `setup.ps1` parses
- `what-if` shows the template claiming `.../customDomains/slypn.cookingcode.com`

Live, after applying:

| Check | Result |
|---|---|
| SWA hostname status | `Ready` |
| `https://slypn.cookingcode.com/` | `200`, chain verifies (`Verify return code: 0`) |
| `http://` → `https://` | redirects, `200` |
| Certificate | `CN=slypn.cookingcode.com`, DigiCert/GeoTrust, valid to 2027-02-24, auto-renews |
| Entra sign-in | redirect URIs registered; all 7 pre-existing URIs preserved, including the PR-preview host |

## Not included

- **Faro allowed origins** still need `https://slypn.cookingcode.com` adding — that lives in Grafana and isn't scripted from this repo.
- `infra/secrets.json` is gitignored (`.gitignore:76`), so the `customDomainUrl` value written there is not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe