### PR TITLE
feat(web): move Members and Newsletter subscribers to the end of the admin menu

### DIFF
--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -36,10 +36,10 @@ const accountLinks = computed(() => ([
   { to: '/admin/content',   label: 'Content management', show: auth.isContributor || auth.isAdmin },
   { to: '/editor',          label: 'Editor',             show: auth.isContributor || auth.isAdmin },
   { to: '/admin/events',    label: 'Event management',   show: auth.isContributor || auth.isAdmin },
-  { to: '/admin/members',   label: 'Members',            show: auth.isAdmin },
-  { to: '/admin/subscribers', label: 'Newsletter subscribers', show: auth.isAdmin },
   { to: '/admin/resources', label: 'Resources',          show: auth.isAdmin },
   { to: '/admin/newsletters', label: 'Newsletters',      show: auth.isAdmin },
+  { to: '/admin/members',   label: 'Members',            show: auth.isAdmin },
+  { to: '/admin/subscribers', label: 'Newsletter subscribers', show: auth.isAdmin },
 ] as { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }[]).filter(l => l.show))
 
 const envMenuOpen = ref(false)

--- a/src/web/src/views/DashboardView.vue
+++ b/src/web/src/views/DashboardView.vue
@@ -87,26 +87,6 @@ onMounted(() => { if (auth.isAdmin) approvalsStore.refresh() })
       </RouterLink>
       <RouterLink
         v-if="auth.isAdmin"
-        to="/admin/members"
-        class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
-      >
-        <p class="font-display font-bold text-slypn-700">Members</p>
-        <p class="mt-2 text-sm text-slypn-900/75">
-          Invite new members, view all members, and manage roles.
-        </p>
-      </RouterLink>
-      <RouterLink
-        v-if="auth.isAdmin"
-        to="/admin/subscribers"
-        class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
-      >
-        <p class="font-display font-bold text-slypn-700">Newsletter subscribers</p>
-        <p class="mt-2 text-sm text-slypn-900/75">
-          View who signed up for the newsletter, and remove addresses.
-        </p>
-      </RouterLink>
-      <RouterLink
-        v-if="auth.isAdmin"
         to="/admin/resources"
         class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
       >
@@ -123,6 +103,26 @@ onMounted(() => { if (auth.isAdmin) approvalsStore.refresh() })
         <p class="font-display font-bold text-slypn-700">Newsletters</p>
         <p class="mt-2 text-sm text-slypn-900/75">
           Add, edit, and remove newsletter issues, and attach their files.
+        </p>
+      </RouterLink>
+      <RouterLink
+        v-if="auth.isAdmin"
+        to="/admin/members"
+        class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+      >
+        <p class="font-display font-bold text-slypn-700">Members</p>
+        <p class="mt-2 text-sm text-slypn-900/75">
+          Invite new members, view all members, and manage roles.
+        </p>
+      </RouterLink>
+      <RouterLink
+        v-if="auth.isAdmin"
+        to="/admin/subscribers"
+        class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+      >
+        <p class="font-display font-bold text-slypn-700">Newsletter subscribers</p>
+        <p class="mt-2 text-sm text-slypn-900/75">
+          View who signed up for the newsletter, and remove addresses.
         </p>
       </RouterLink>
     </section>


### PR DESCRIPTION
Both are people-management rather than content, so they sat awkwardly in the middle of the content admin links. They now come **last, immediately before Sign out**.

## Order

| Before | After |
|---|---|
| Dashboard | Dashboard |
| *— divider —* | *— divider —* |
| Approvals | Approvals |
| Content management | Content management |
| Editor | Editor |
| Event management | Event management |
| **Members** | Resources |
| **Newsletter subscribers** | Newsletters |
| Resources | **Members** |
| Newsletters | **Newsletter subscribers** |
| Sign out | Sign out |

## Both surfaces

- **`AppNav.vue`** — one `accountLinks` array feeds both the desktop dropdown and the mobile account panel, so reordering it covers both.
- **`DashboardView.vue`** — has no Sign out, so the equivalent position is last in the tile grid. That also keeps the two surfaces consistent with each other, which they were already and would otherwise have drifted apart.

## Verification

- `npm run lint` clean, **413/413** unit tests pass, `npm run build` (vue-tsc) succeeds
- Checked the specs for ordering assertions before moving anything — every reference to `/admin/members` and `/admin/subscribers` navigates by URL (`router.push`, `page.goto`) rather than by menu position, so none of them depend on the order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe