### PR TITLE
feat(web): fence Members and Newsletter subscribers with dividers

### DIFF
--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -37,9 +37,9 @@ const accountLinks = computed(() => ([
   { to: '/editor',          label: 'Editor',             show: auth.isContributor || auth.isAdmin },
   { to: '/admin/events',    label: 'Event management',   show: auth.isContributor || auth.isAdmin },
   { to: '/admin/resources', label: 'Resources',          show: auth.isAdmin },
-  { to: '/admin/newsletters', label: 'Newsletters',      show: auth.isAdmin },
+  { to: '/admin/newsletters', label: 'Newsletters',      show: auth.isAdmin, dividerAfter: true },
   { to: '/admin/members',   label: 'Members',            show: auth.isAdmin },
-  { to: '/admin/subscribers', label: 'Newsletter subscribers', show: auth.isAdmin },
+  { to: '/admin/subscribers', label: 'Newsletter subscribers', show: auth.isAdmin, dividerAfter: true },
 ] as { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }[]).filter(l => l.show))
 
 const envMenuOpen = ref(false)


### PR DESCRIPTION
Follows #184. The two people-management links now read as their own group rather than trailing off the end of the content admin links.

## Result

```
Dashboard
─────────────────
Approvals
Content management
Editor
Event management
Resources
Newsletters
─────────────────
Members
Newsletter subscribers
─────────────────
Sign out
```

## How

Two flags on the existing `accountLinks` array — no template changes:

- `dividerAfter: true` on **Newsletters** → the divider *before* Members
- `dividerAfter: true` on **Newsletter subscribers** → the divider *after*

Because `dividerAfter` already drives both the desktop dropdown (line 199) and the mobile account panel (line 295), both surfaces pick this up for free.

## Non-admins don't get dangling separators

Worth calling out, since it's the obvious way this kind of change goes wrong: both flags sit on links that are themselves `show: auth.isAdmin`, and `.filter(l => l.show)` drops the flag along with the link. A Contributor still sees just Dashboard's divider, with nothing orphaned at the bottom.

## Scope

`DashboardView.vue` is untouched — its tiles are a responsive grid, which has no separator concept. Unlike #184, this one genuinely only applies to the menu.

## Verification

`npm run lint` clean, **413/413** unit tests pass, `npm run build` (vue-tsc) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe