### PR TITLE
feat: edit affordance on article and blog detail pages

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -35,6 +35,7 @@ Optimistic concurrency uses the **native Table entity ETag**. `ContentRepository
 
 - **`articles` partition on `status`** creates a hot `published` partition (the vast majority of reads). Fine at our scale (hundreds of articles, light traffic).
 - **List endpoints fetch bodies.** Article/draft list responses include the body (the approvals queue renders it), so those lists fetch the body blobs in parallel. Cheap at our volumes; could be trimmed to summaries later.
+- **`authorId` never leaves the API on a public read.** It is an Entra OID, so anonymous-reachable responses (`/articles`, `/articles/{slug}`, `/blog`, `/blog/{slug}`) are projected through `ArticleVisibility.ForPublic`, which strips it and adds a computed `canEdit` — Admin, or the Contributor who wrote it — for the caller to gate the edit affordance on. `canEdit` is per-request and never persisted; `/review/*` and `/drafts/*` are gated, so they still carry `authorId`. Content published before `AuthorId` existed has none, which makes it admin-only by construction.
 - **Workflow transitions are not atomic.** Submit/publish/revise and an event partition-key change are read→write→delete sequences. Admin actions are rare and re-runs are idempotent (the source is gone, surfacing a clean error). The body blob is keyed by id, so it never moves during a status change.
 
 ## Bootstrap

--- a/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
@@ -37,7 +37,8 @@ public class ArticlesFunctionsTests
     public async Task GetArticles_always_asks_for_published(string url)
     {
         var (fn, repo) = Make();
-        var resp = (TestHttpResponseData)await fn.GetArticles(TestHttp.Get(new TestFunctionContext(), url), Ct);
+        var rctx = new TestFunctionContext();
+        var resp = (TestHttpResponseData)await fn.GetArticles(TestHttp.Get(rctx, url), rctx, Ct);
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("published", repo.LastArticlesStatus);
@@ -49,8 +50,9 @@ public class ArticlesFunctionsTests
         var (fn, repo) = Make();
         repo.Articles.Add(Sample());
 
+        var ctx = Admin();
         var resp = (TestHttpResponseData)await fn.GetPendingArticles(
-            TestHttp.Get(new TestFunctionContext(), "http://localhost/api/review/articles"), Ct);
+            TestHttp.Get(ctx, "http://localhost/api/review/articles"), ctx, Ct);
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("in-review", repo.LastArticlesStatus);
@@ -78,7 +80,7 @@ public class ArticlesFunctionsTests
         var (fn, repo) = Make();
         repo.Articles.Add(Sample());
         var ctx = new TestFunctionContext();
-        var resp = (TestHttpResponseData)await fn.GetArticles(TestHttp.Get(ctx, "http://localhost/api/articles"), Ct);
+        var resp = (TestHttpResponseData)await fn.GetArticles(TestHttp.Get(ctx, "http://localhost/api/articles"), ctx, Ct);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var body = resp.ReadBodyAs<List<Article>>();
         Assert.Single(body!);
@@ -89,7 +91,7 @@ public class ArticlesFunctionsTests
     {
         var (fn, _) = Make();
         var ctx = new TestFunctionContext();
-        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(TestHttp.Get(ctx, "http://localhost/api/articles/x"), "x", Ct);
+        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(TestHttp.Get(ctx, "http://localhost/api/articles/x"), ctx, "x", Ct);
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
@@ -99,7 +101,7 @@ public class ArticlesFunctionsTests
         var (fn, repo) = Make();
         repo.ArticleBySlug = Sample();
         var ctx = new TestFunctionContext();
-        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(TestHttp.Get(ctx, "http://localhost/api/articles/slug"), "slug", Ct);
+        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(TestHttp.Get(ctx, "http://localhost/api/articles/slug"), ctx, "slug", Ct);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }
 
@@ -165,7 +167,9 @@ public class ArticlesFunctionsTests
     [Fact]
     public async Task Edit_requires_oid_and_returns_201_with_user()
     {
-        var (fn, _) = Make();
+        var (fn, repo) = Make();
+        // The ownership check reads the live row first, so it must exist and be ours.
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-1" };
         var noUser = new TestFunctionContext();
         var bad = (TestHttpResponseData)await fn.Edit(TestHttp.Raw(noUser, "POST", "http://localhost/api/articles/a1/edit", ""), noUser, "a1", Ct);
         Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
@@ -214,6 +218,8 @@ public class ArticlesFunctionsTests
         Assert.Equal(HttpStatusCode.BadRequest, noOid.StatusCode);
 
         var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
+        // The ownership check reads the live row first, so it must exist and be ours.
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-1" };
         repo.Writes = false;
         var disabled = (TestHttpResponseData)await fn.RequestDeletion(TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/request-deletion", ""), ctx, "a1", Ct);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, disabled.StatusCode);
@@ -328,8 +334,9 @@ public class ArticlesFunctionsTests
         var (fn, repo) = Make();
         repo.ArticleBySlug = Sample();
         var ctx = new TestFunctionContext();
+        var rctx = ctx;
         var resp = (TestHttpResponseData)await fn.GetArticleBySlug(
-            TestHttp.Get(ctx, "http://localhost/api/articles/slug"), "slug", Ct);
+            TestHttp.Get(rctx, "http://localhost/api/articles/slug"), rctx, "slug", Ct);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }
 
@@ -372,6 +379,8 @@ public class ArticlesFunctionsTests
     {
         var (fn, repo) = Make();
         var ctx = new TestFunctionContext().WithUser("oid-1", "Ed", "Contributor");
+        // The ownership check reads the live row first, so it must exist and be ours.
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-1" };
 
         repo.ThrowOnWrite = new InvalidOperationException("Article not published");
         var bad = (TestHttpResponseData)await fn.Edit(
@@ -389,6 +398,8 @@ public class ArticlesFunctionsTests
     {
         var (fn, repo) = Make();
         var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
+        // The ownership check reads the live row first, so it must exist and be ours.
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-1" };
 
         repo.ThrowOnWrite = new InvalidOperationException("Not eligible");
         var bad = (TestHttpResponseData)await fn.RequestDeletion(
@@ -448,6 +459,183 @@ public class ArticlesFunctionsTests
         body = "Body content long enough.", author = "Jane", readingMinutes = 5,
         category = "Community", status,
     };
+
+    // ── Ownership on the revision + deletion endpoints ──────────────────────────
+    // The UI hides these controls, but the routes are reachable directly, so the rule
+    // has to hold here. ThrowOnWrite proves the refusal happens BEFORE the repository
+    // is touched — otherwise a 403 could be a storage error in disguise.
+
+    private static TestFunctionContext Author() =>
+        new TestFunctionContext().WithUser("oid-author", "Ann", "Contributor");
+
+    [Fact]
+    public async Task Edit_allows_the_author_of_the_published_article()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
+        Assert.Equal("published", repo.LastArticleLookupStatus);
+    }
+
+    [Fact]
+    public async Task Edit_forbids_a_contributor_who_is_not_the_author()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.ThrowOnWrite = new RequestFailedException(500, "should not be reached");
+        var ctx = Contributor();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Contains("your own", resp.ReadBodyAsString());
+    }
+
+    [Fact]
+    public async Task Edit_allows_an_admin_regardless_of_author()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "someone-else" };
+        var ctx = Admin();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
+    }
+
+    [Fact]
+    public async Task Edit_is_admin_only_on_legacy_content_that_has_no_author()
+    {
+        // Everything published before AuthorId existed carries none. A null author must
+        // match nobody rather than everybody — including an anonymous caller's null oid.
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = null };
+        repo.ThrowOnWrite = new RequestFailedException(500, "should not be reached");
+        var contributor = Contributor();
+
+        var refused = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(contributor, "POST", "http://localhost/api/articles/a1/edit", ""), contributor, "a1", Ct);
+        Assert.Equal(HttpStatusCode.Forbidden, refused.StatusCode);
+
+        repo.ThrowOnWrite = null;
+        var admin = Admin();
+        var allowed = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(admin, "POST", "http://localhost/api/articles/a1/edit", ""), admin, "a1", Ct);
+        Assert.Contains((int)allowed.StatusCode, new[] { 200, 201 });
+    }
+
+    [Fact]
+    public async Task Edit_404s_when_the_published_article_is_missing()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = null;
+        var ctx = Admin();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/nope/edit", ""), ctx, "nope", Ct);
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task RequestDeletion_forbids_a_contributor_who_is_not_the_author()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.ThrowOnWrite = new RequestFailedException(500, "should not be reached");
+        var ctx = Contributor();
+
+        var resp = (TestHttpResponseData)await fn.RequestDeletion(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/request-deletion", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    // ── canEdit / authorId on public reads ──────────────────────────────────────
+
+    [Fact]
+    public async Task GetArticleBySlug_never_leaks_the_author_oid()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleBySlug = Sample() with { AuthorId = "oid-secret" };
+        var anon = new TestFunctionContext();
+
+        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(
+            TestHttp.Get(anon, "http://localhost/api/articles/slug"), anon, "slug", Ct);
+
+        // Asserted on the raw body: deserialising into Article would hide the leak.
+        var body = resp.ReadBodyAsString();
+        Assert.DoesNotContain("authorId", body);
+        Assert.DoesNotContain("oid-secret", body);
+    }
+
+    [Theory]
+    [InlineData("oid-author", "Contributor", true)]   // the author
+    [InlineData("oid-other", "Contributor", false)]   // a different contributor
+    [InlineData("oid-admin", "Admin", true)]          // any admin
+    [InlineData("oid-author", "Member", false)]       // authored it, but lost the role
+    public async Task GetArticleBySlug_reports_canEdit_for_the_caller(string oid, string role, bool expected)
+    {
+        var (fn, repo) = Make();
+        repo.ArticleBySlug = Sample() with { AuthorId = "oid-author" };
+        var ctx = new TestFunctionContext().WithUser(oid, "U", role);
+
+        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(
+            TestHttp.Get(ctx, "http://localhost/api/articles/slug"), ctx, "slug", Ct);
+
+        Assert.Equal(expected, resp.ReadBodyAs<Article>()!.CanEdit);
+    }
+
+    [Fact]
+    public async Task GetArticleBySlug_reports_canEdit_false_when_anonymous()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleBySlug = Sample() with { AuthorId = "oid-author" };
+        var anon = new TestFunctionContext();
+
+        var resp = (TestHttpResponseData)await fn.GetArticleBySlug(
+            TestHttp.Get(anon, "http://localhost/api/articles/slug"), anon, "slug", Ct);
+
+        Assert.False(resp.ReadBodyAs<Article>()!.CanEdit);
+    }
+
+    [Fact]
+    public void Public_reads_carry_OptionalAuth()
+    {
+        // Without it JwtMiddleware never populates a principal on these routes, so
+        // canEdit would be silently false for everyone — including the author.
+        foreach (var name in new[] { nameof(ArticlesFunctions.GetArticles), nameof(ArticlesFunctions.GetArticleBySlug) })
+        {
+            var attrs = typeof(ArticlesFunctions).GetMethod(name)!
+                .GetCustomAttributes(typeof(Slypn.Api.Infrastructure.OptionalAuthAttribute), inherit: false);
+            Assert.True(attrs.Length == 1, name + " is missing [OptionalAuth]");
+        }
+    }
+
+    [Fact]
+    public async Task GetPendingArticles_shows_a_contributor_only_their_own_submissions()
+    {
+        var (fn, repo) = Make();
+        repo.Articles.Add(Sample("mine") with { AuthorId = "oid-contrib" });
+        repo.Articles.Add(Sample("theirs") with { AuthorId = "oid-someone-else" });
+
+        var ctx = Contributor();
+        var mine = (TestHttpResponseData)await fn.GetPendingArticles(
+            TestHttp.Get(ctx, "http://localhost/api/review/articles"), ctx, Ct);
+        Assert.Equal("mine", Assert.Single(mine.ReadBodyAs<List<Article>>()!).Id);
+
+        var admin = Admin();
+        var all = (TestHttpResponseData)await fn.GetPendingArticles(
+            TestHttp.Get(admin, "http://localhost/api/review/articles"), admin, Ct);
+        Assert.Equal(2, all.ReadBodyAs<List<Article>>()!.Count);
+    }
 
     private static TestFunctionContext Contributor() =>
         new TestFunctionContext().WithUser("oid-contrib", "Carla", "Contributor");

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -34,7 +34,8 @@ public class ContentFunctionsTests
         var repo = new FakeContentRepository();
         repo.Blogs.Add(new Article("b1", "s", "T", "Sum", "B", "A", DateTime.UtcNow, 3, "News") { Type = "blog" });
         var fn = new BlogFunctions(repo);
-        var resp = (TestHttpResponseData)await fn.GetBlogPosts(TestHttp.Get(new TestFunctionContext(), "http://localhost/api/blog"), Ct);
+        var rctx = new TestFunctionContext();
+        var resp = (TestHttpResponseData)await fn.GetBlogPosts(TestHttp.Get(rctx, "http://localhost/api/blog"), rctx, Ct);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }
 
@@ -48,7 +49,8 @@ public class ContentFunctionsTests
         var repo = new FakeContentRepository();
         var fn = new BlogFunctions(repo);
 
-        var resp = (TestHttpResponseData)await fn.GetBlogPosts(TestHttp.Get(new TestFunctionContext(), url), Ct);
+        var rctx = new TestFunctionContext();
+        var resp = (TestHttpResponseData)await fn.GetBlogPosts(TestHttp.Get(rctx, url), rctx, Ct);
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("published", repo.LastBlogStatus);
@@ -61,8 +63,9 @@ public class ContentFunctionsTests
         repo.Blogs.Add(new Article("b1", "s", "T", "Sum", "B", "A", DateTime.UtcNow, 3, "News") { Type = "blog" });
         var fn = new BlogFunctions(repo);
 
+        var ctx = new TestFunctionContext().WithUser("oid-admin", "Ada", "Admin");
         var resp = (TestHttpResponseData)await fn.GetPendingBlogPosts(
-            TestHttp.Get(new TestFunctionContext(), "http://localhost/api/review/blog"), Ct);
+            TestHttp.Get(ctx, "http://localhost/api/review/blog"), ctx, Ct);
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("in-review", repo.LastBlogStatus);

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -57,6 +57,54 @@ public class ContentFunctionsTests
     }
 
     [Fact]
+    public async Task Blog_getBySlug_404s_when_missing_and_200s_when_found()
+    {
+        var repo = new FakeContentRepository();
+        var fn = new BlogFunctions(repo);
+        var ctx = new TestFunctionContext();
+
+        var missing = (TestHttpResponseData)await fn.GetBlogPostBySlug(
+            TestHttp.Get(ctx, "http://localhost/api/blog/nope"), ctx, "nope", Ct);
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+
+        repo.BlogPostBySlug = new Article("b1", "s", "T", "Sum", "B", "A", DateTime.UtcNow, 3, "News") { Type = "blog" };
+        var found = (TestHttpResponseData)await fn.GetBlogPostBySlug(
+            TestHttp.Get(ctx, "http://localhost/api/blog/s"), ctx, "s", Ct);
+        Assert.Equal(HttpStatusCode.OK, found.StatusCode);
+    }
+
+    [Fact]
+    public async Task Blog_getBySlug_strips_the_author_oid_and_reports_canEdit()
+    {
+        var repo = new FakeContentRepository();
+        var fn = new BlogFunctions(repo);
+        repo.BlogPostBySlug = new Article("b1", "s", "T", "Sum", "B", "A", DateTime.UtcNow, 3, "News")
+        { Type = "blog", AuthorId = "oid-author" };
+
+        var anon = new TestFunctionContext();
+        var anonResp = (TestHttpResponseData)await fn.GetBlogPostBySlug(
+            TestHttp.Get(anon, "http://localhost/api/blog/s"), anon, "s", Ct);
+        Assert.DoesNotContain("oid-author", anonResp.ReadBodyAsString());
+        Assert.False(anonResp.ReadBodyAs<Article>()!.CanEdit);
+
+        var author = new TestFunctionContext().WithUser("oid-author", "Ann", "Contributor");
+        var authorResp = (TestHttpResponseData)await fn.GetBlogPostBySlug(
+            TestHttp.Get(author, "http://localhost/api/blog/s"), author, "s", Ct);
+        Assert.True(authorResp.ReadBodyAs<Article>()!.CanEdit);
+    }
+
+    [Fact]
+    public void Blog_public_reads_carry_OptionalAuth()
+    {
+        foreach (var name in new[] { nameof(BlogFunctions.GetBlogPosts), nameof(BlogFunctions.GetBlogPostBySlug) })
+        {
+            var attrs = typeof(BlogFunctions).GetMethod(name)!
+                .GetCustomAttributes(typeof(Slypn.Api.Infrastructure.OptionalAuthAttribute), inherit: false);
+            Assert.True(attrs.Length == 1, name + " is missing [OptionalAuth]");
+        }
+    }
+
+    [Fact]
     public async Task Blog_pending_asks_for_in_review_and_requires_a_role()
     {
         var repo = new FakeContentRepository();

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -62,6 +62,9 @@ internal sealed class FakeContentRepository : IContentRepository
         => Task.FromResult(ArticleBySlug);
     public Task<Article?> GetArticleWithNeighboursAsync(string slugOrId, CancellationToken ct)
         => Task.FromResult(ArticleBySlug);
+    public Article? BlogPostBySlug;
+    public Task<Article?> GetBlogPostWithNeighboursAsync(string slugOrId, CancellationToken ct)
+        => Task.FromResult(BlogPostBySlug);
     public Task<IReadOnlyList<CommunityEvent>> ListEventsAsync(bool upcomingOnly, CancellationToken ct)
         => Task.FromResult<IReadOnlyList<CommunityEvent>>(Events);
     public Task<CommunityEvent?> GetEventByIdAsync(string id, CancellationToken ct)

--- a/src/api/Slypn.Api.Tests/JwtMiddlewareTests.cs
+++ b/src/api/Slypn.Api.Tests/JwtMiddlewareTests.cs
@@ -72,12 +72,37 @@ public class JwtMiddlewareTests
     [Fact]
     public async Task Passthrough_when_function_has_no_RequireRole()
     {
-        var ctx = new TestMiddlewareContext("Slypn.Api.Functions.BlogFunctions.GetBlogPosts");
+        // GetResources carries no auth attribute at all. (GetBlogPosts used to serve as
+        // the example here, until it gained [OptionalAuth] — which takes the authenticate
+        // path and so no longer exercises this branch.)
+        var ctx = new TestMiddlewareContext("Slypn.Api.Functions.ResourcesFunctions.GetResources");
         var called = false;
 
         await Make().Invoke(ctx, _ => { called = true; return Task.CompletedTask; });
 
         Assert.True(called);
+    }
+
+    // [OptionalAuth] relaxes *authentication*, not the HTTP-trigger requirement: reaching
+    // it on a non-HTTP trigger is still a misconfiguration and must fail loudly rather
+    // than silently serving everyone as anonymous.
+    [Fact]
+    public async Task Throws_when_OptionalAuth_is_on_a_non_http_context()
+    {
+        var ctx = new TestMiddlewareContext("Slypn.Api.Functions.BlogFunctions.GetBlogPosts");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Make().Invoke(ctx, _ => Task.CompletedTask));
+    }
+
+    [Fact]
+    public void OptionalAuth_is_a_RequireRole_with_no_roles_that_never_refuses()
+    {
+        var optional = new Slypn.Api.Infrastructure.OptionalAuthAttribute();
+        Assert.Empty(optional.Roles);
+        Assert.True(optional.Optional);
+        // The plain attribute must keep refusing, or every gate in the app opens.
+        Assert.False(new Slypn.Api.Infrastructure.RequireRoleAttribute("Admin").Optional);
     }
 
     // Unknown entry point → GetRoleAttribute returns null → next called.

--- a/src/api/Slypn.Api/Functions/ArticleVisibility.cs
+++ b/src/api/Slypn.Api/Functions/ArticleVisibility.cs
@@ -1,0 +1,43 @@
+using Microsoft.Azure.Functions.Worker;
+using Slypn.Api.Infrastructure;
+using Slypn.Api.Models;
+
+namespace Slypn.Api.Functions;
+
+/// <summary>
+/// Who may edit a published article or blog post, and how one is shaped for a
+/// response that an anonymous caller can reach.
+///
+/// Both the <c>canEdit</c> flag on read responses and the 403 on
+/// <c>POST /api/articles/{id}/edit</c> go through <see cref="MayEdit"/>. Keeping
+/// them on one predicate is the point of this class: if they drift apart the UI
+/// offers a button that the API then refuses.
+/// </summary>
+internal static class ArticleVisibility
+{
+    public static bool MayEdit(Article article, FunctionContext context)
+    {
+        if (context.IsAdmin()) return true;
+
+        // The edit endpoint is [RequireRole("Admin", "Contributor")], so a member
+        // who authored something before losing the role must not be offered a
+        // button that would 403.
+        if (!context.IsContributor()) return false;
+
+        // Content published before AuthorId existed carries none, which makes it
+        // Admin-only by construction — a null author matches nobody. Both sides
+        // are checked explicitly so an anonymous caller (null oid) can never
+        // match legacy content (null author).
+        return article.AuthorId is { Length: > 0 } author
+            && context.GetUserOid() is { Length: > 0 } caller
+            && string.Equals(author, caller, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Shape an article for a response an anonymous caller can reach: the author's
+    /// Entra OID is stripped, and canEdit is computed for this caller instead.
+    /// The OID is an internal identifier and has no business in a public payload.
+    /// </summary>
+    public static Article ForPublic(this Article article, FunctionContext context) =>
+        article with { AuthorId = null, CanEdit = MayEdit(article, context) };
+}

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -25,6 +25,13 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     private static readonly HashSet<string> AuthorSettableStatuses =
         new(StringComparer.OrdinalIgnoreCase) { "draft", InReviewStatus };
 
+    private const string EditOwnershipRefusal =
+        "You can only edit your own published content. Ask an Admin to make the change, "
+        + "or to reassign the item to you.";
+
+    private const string DeletionOwnershipRefusal =
+        "You can only request deletion of your own published content.";
+
     private const string PublishedReplaceRefusal =
         "This article is published — only an Admin can replace it. "
         + "Use POST /api/articles/{id}/edit to propose a revision, which keeps the live version up until an Admin approves.";
@@ -52,14 +59,16 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     /// reachable through GetPendingArticles below, which carries a role gate.
     /// </summary>
     [Function("GetArticles")]
+    [OptionalAuth]
     [OpenApiOperation(operationId: "articles.list", tags: new[] { "articles" }, Summary = "List articles", Description = "Returns published articles.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article[]), Description = "List of published articles")]
     public async Task<HttpResponseData> GetArticles(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles")] HttpRequestData req,
+        FunctionContext context,
         CancellationToken ct)
     {
         var articles = await repo.ListArticlesAsync(PublishedStatus, ct);
-        return await Ok(req, articles);
+        return await Ok(req, articles.Select(a => a.ForPublic(context)).ToList());
     }
 
     /// <summary>
@@ -82,24 +91,40 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Forbidden, Description = "Caller lacks the required role")]
     public async Task<HttpResponseData> GetPendingArticles(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "review/articles")] HttpRequestData req,
+        FunctionContext context,
         CancellationToken ct)
     {
         var articles = await repo.ListArticlesAsync(InReviewStatus, ct);
-        return await Ok(req, articles);
+        return await Ok(req, VisibleInReview(articles, context));
     }
 
+    /// <summary>
+    /// In-review items the caller may act on: everything for an Admin, own work only
+    /// for a Contributor. Filtering here rather than in the browser — the client-side
+    /// filter in EditorView is a display convenience, not the boundary.
+    /// </summary>
+    internal static IReadOnlyList<Article> VisibleInReview(
+        IReadOnlyList<Article> items, FunctionContext context) =>
+        context.IsAdmin()
+            ? items
+            : context.GetUserOid() is { Length: > 0 } oid
+                ? items.Where(a => a.AuthorId == oid).ToList()
+                : [];
+
     [Function("GetArticleBySlug")]
+    [OptionalAuth]
     [OpenApiOperation(operationId: "articles.getBySlug", tags: new[] { "articles" }, Summary = "Get article by slug", Description = "Returns a single article identified by slug.")]
     [OpenApiParameter(name: "slug", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Article slug.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article), Description = "Article")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
     public async Task<HttpResponseData> GetArticleBySlug(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "articles/{slug}")] HttpRequestData req,
+        FunctionContext context,
         string slug, CancellationToken ct)
     {
         var article = await repo.GetArticleWithNeighboursAsync(slug, ct);
         if (article is null) return req.CreateResponse(HttpStatusCode.NotFound);
-        return await Ok(req, article, article.Etag);
+        return await Ok(req, article.ForPublic(context), article.Etag);
     }
 
     [Function("CreateArticle")]
@@ -235,6 +260,13 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
         var editorName = context.GetUserName() ?? "Member";
         try
         {
+            // Admins may revise anything; a Contributor only their own work. Checked
+            // here rather than in the UI alone — the endpoint is reachable directly.
+            var published = await repo.GetArticleAsync(id, PublishedStatus, ct);
+            if (published is null) return await NotFound(req, "Published article not found.");
+            if (!ArticleVisibility.MayEdit(published, context))
+                return await Forbidden(req, EditOwnershipRefusal);
+
             var draft = await repo.CreateRevisionDraftAsync(id, editorOid, editorName, ct);
             return await Created(req, draft, draft.Etag);
         }
@@ -262,6 +294,11 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
         if (requesterOid is null) return await BadRequest(req, "Token missing oid claim.");
         try
         {
+            var published = await repo.GetArticleAsync(id, PublishedStatus, ct);
+            if (published is null) return await NotFound(req, "Published article not found.");
+            if (!ArticleVisibility.MayEdit(published, context))
+                return await Forbidden(req, DeletionOwnershipRefusal);
+
             var article = await repo.RequestArticleDeletionAsync(id, requesterOid, ct);
             return await Ok(req, article, article.Etag);
         }

--- a/src/api/Slypn.Api/Functions/BlogFunctions.cs
+++ b/src/api/Slypn.Api/Functions/BlogFunctions.cs
@@ -19,16 +19,18 @@ public sealed class BlogFunctions(IContentRepository repo)
     /// distinguishes by Type if it needs to.
     /// </summary>
     [Function("GetBlogPosts")]
+    [OptionalAuth]
     [OpenApiOperation(operationId: "blog.list", tags: new[] { "blog" }, Summary = "List blog posts", Description = "Returns published blog posts.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article[]), Description = "List of published blog posts")]
     public async Task<HttpResponseData> GetBlogPosts(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "blog")] HttpRequestData req,
+        FunctionContext context,
         CancellationToken ct)
     {
         // Pinned to published: ?status= previously let an anonymous caller read
         // in-review submissions. See GetPendingBlogPosts for the gated route.
         var posts = await repo.ListBlogPostsAsync(PublishedStatus, ct);
-        return await Ok(req, posts);
+        return await Ok(req, posts.Select(p => p.ForPublic(context)).ToList());
     }
 
     /// <summary>Blog posts awaiting review. Role-gated counterpart to the public list.</summary>
@@ -41,9 +43,10 @@ public sealed class BlogFunctions(IContentRepository repo)
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Forbidden, Description = "Caller lacks the required role")]
     public async Task<HttpResponseData> GetPendingBlogPosts(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "review/blog")] HttpRequestData req,
+        FunctionContext context,
         CancellationToken ct)
     {
         var posts = await repo.ListBlogPostsAsync(InReviewStatus, ct);
-        return await Ok(req, posts);
+        return await Ok(req, ArticlesFunctions.VisibleInReview(posts, context));
     }
 }

--- a/src/api/Slypn.Api/Functions/BlogFunctions.cs
+++ b/src/api/Slypn.Api/Functions/BlogFunctions.cs
@@ -33,6 +33,27 @@ public sealed class BlogFunctions(IContentRepository repo)
         return await Ok(req, posts.Select(p => p.ForPublic(context)).ToList());
     }
 
+    /// <summary>
+    /// A single published blog post by slug, with its neighbours for prev/next.
+    /// Blog posts are Article rows with Type == "blog", but /articles/{slug} filters to
+    /// articles, so a blog post is not reachable there — hence this route.
+    /// </summary>
+    [Function("GetBlogPostBySlug")]
+    [OptionalAuth]
+    [OpenApiOperation(operationId: "blog.getBySlug", tags: new[] { "blog" }, Summary = "Get blog post by slug", Description = "Returns a single published blog post identified by slug.")]
+    [OpenApiParameter(name: "slug", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Blog post slug.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Article), Description = "Blog post")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
+    public async Task<HttpResponseData> GetBlogPostBySlug(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "blog/{slug}")] HttpRequestData req,
+        FunctionContext context,
+        string slug, CancellationToken ct)
+    {
+        var post = await repo.GetBlogPostWithNeighboursAsync(slug, ct);
+        if (post is null) return req.CreateResponse(HttpStatusCode.NotFound);
+        return await Ok(req, post.ForPublic(context), post.Etag);
+    }
+
     /// <summary>Blog posts awaiting review. Role-gated counterpart to the public list.</summary>
     [Function("GetPendingBlogPosts")]
     [RequireRole("Admin", "Contributor")]

--- a/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
+++ b/src/api/Slypn.Api/Infrastructure/JwtMiddleware.cs
@@ -49,6 +49,15 @@ public sealed class JwtMiddleware(
 
         if (!result.IsAllowed)
         {
+            // Optional auth: a caller we can't vouch for is simply anonymous. No principal
+            // goes into Items, so GetPrincipal() stays null and every caller-varying
+            // projection falls back to the public shape.
+            if (attr.Optional)
+            {
+                await next(context);
+                return;
+            }
+
             await ShortCircuit(context, httpReq, result.RefusalCode!.Value, result.RefusalMessage!);
             return;
         }
@@ -304,4 +313,7 @@ public static class FunctionContextExtensions
 
     public static bool IsAdmin(this FunctionContext context) =>
         context.GetPrincipal()?.FindAll("roles").Any(c => c.Value == "Admin") ?? false;
+
+    public static bool IsContributor(this FunctionContext context) =>
+        context.GetPrincipal()?.FindAll("roles").Any(c => c.Value == "Contributor") ?? false;
 }

--- a/src/api/Slypn.Api/Infrastructure/RequireRoleAttribute.cs
+++ b/src/api/Slypn.Api/Infrastructure/RequireRoleAttribute.cs
@@ -6,7 +6,32 @@ namespace Slypn.Api.Infrastructure;
 /// means "authenticated, no specific role".
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-public sealed class RequireRoleAttribute(params string[] roles) : Attribute
+public class RequireRoleAttribute(params string[] roles) : Attribute
 {
     public string[] Roles { get; } = roles;
+
+    /// <summary>Whether a caller we cannot authenticate is served anyway. See
+    /// <see cref="OptionalAuthAttribute"/>; false for a plain [RequireRole].</summary>
+    public virtual bool Optional => false;
+}
+
+/// <summary>
+/// Authenticate when the caller presents a usable token, but never refuse — for public
+/// endpoints whose *response* varies by caller (e.g. a canEdit flag) while the content
+/// itself is public. Without this the middleware populates no principal at all on an
+/// unattributed Function, so such an endpoint cannot tell who is asking.
+///
+/// Deliberately a subclass rather than a flag on [RequireRole]: the middleware resolves
+/// the attribute with GetCustomAttribute&lt;RequireRoleAttribute&gt;(), which already matches
+/// subclasses, so nothing else changes — and it makes [RequireRole("Admin", Optional = true)]
+/// unexpressible, which would otherwise silently downgrade a valid non-Admin to anonymous.
+///
+/// Note: when the token validator is not configured, these endpoints serve anonymously
+/// rather than failing. That is intended — an auth misconfiguration should not take the
+/// public site down. Do not "fix" it.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class OptionalAuthAttribute : RequireRoleAttribute
+{
+    public override bool Optional => true;
 }

--- a/src/api/Slypn.Api/Models/Article.cs
+++ b/src/api/Slypn.Api/Models/Article.cs
@@ -17,8 +17,20 @@ public sealed record Article(
     /// <summary>"article" or "blog". Defaults to "article" for rows that predate the field.</summary>
     public string Type { get; init; } = "article";
 
-    /// <summary>Author's Entra oid — set on submit; carries through workflow transitions.</summary>
+    /// <summary>Author's Entra oid — set on submit; carries through workflow transitions.
+    /// Stripped from responses an anonymous caller can reach (see ArticleVisibility.ForPublic):
+    /// it is an internal identifier, not public data. Omitted entirely when null, so the
+    /// key itself does not appear on a public payload; a null round-trips to null either
+    /// way, so storage is unaffected.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? AuthorId { get; init; }
+
+    /// <summary>Whether the calling principal may open this item in the editor — an Admin, or
+    /// the Contributor who authored it. Computed per request, never persisted: the conditional
+    /// ignore keeps it out of the stored Json column, which is serialised from this same record.
+    /// Null (and omitted) on responses where it was not computed.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? CanEdit { get; init; }
 
     /// <summary>Set when an admin rejects an in-review article. Null otherwise.</summary>
     public string? RejectionReason { get; init; }

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -810,7 +810,9 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     {
         var e = new TableEntity(article.Status, article.Id)
         {
-            ["Json"] = Serialize(article with { Body = string.Empty, Etag = null }),
+            // CanEdit is a per-request projection, never storage. Blanked explicitly so a
+            // projected instance can't be written back carrying another caller's answer.
+            ["Json"] = Serialize(article with { Body = string.Empty, Etag = null, CanEdit = null }),
             ["Slug"] = article.Slug,
         };
         return e;

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -29,6 +29,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     private const string SubscribersPartition = "subscriber";
     private const string NewslettersPartition = "newsletter";
     private const string ArticleType       = "article";
+    private const string BlogType          = "blog";
     private const string InReviewStatus    = "in-review";
     private const string PublishedStatus   = "published";
 
@@ -39,7 +40,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         => await ListArticlesAsync(status, type: ArticleType, ct);
 
     public async Task<IReadOnlyList<Article>> ListBlogPostsAsync(string? status, CancellationToken ct)
-        => await ListArticlesAsync(status, type: "blog", ct);
+        => await ListArticlesAsync(status, type: BlogType, ct);
 
     private async Task<IReadOnlyList<Article>> ListArticlesAsync(string? status, string type, CancellationToken ct)
     {
@@ -94,12 +95,21 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         return await GetArticleAsync(slugOrId, PublishedStatus, ct);
     }
 
-    public async Task<Article?> GetArticleWithNeighboursAsync(string slugOrId, CancellationToken ct)
+    public Task<Article?> GetArticleWithNeighboursAsync(string slugOrId, CancellationToken ct)
+        => WithNeighboursAsync(slugOrId, ArticleType, ct);
+
+    public Task<Article?> GetBlogPostWithNeighboursAsync(string slugOrId, CancellationToken ct)
+        => WithNeighboursAsync(slugOrId, BlogType, ct);
+
+    /// <summary>Find one published item of the given type and the two either side of it,
+    /// so a detail page can offer prev/next. Neighbours stay within the type: a blog post
+    /// never links into the article list.</summary>
+    private async Task<Article?> WithNeighboursAsync(string slugOrId, string type, CancellationToken ct)
     {
-        // ListArticlesAsync returns newest-first, matching the articles list page order.
-        // prev = the article above the current one in the list (newer),
-        // next = the article below (older).
-        var sorted = (await ListArticlesAsync(PublishedStatus, ct)).ToList();
+        // The list is newest-first, matching the list page order.
+        // prev = the item above the current one in the list (newer),
+        // next = the item below (older).
+        var sorted = (await ListArticlesAsync(PublishedStatus, type, ct)).ToList();
 
         var idx = sorted.FindIndex(a =>
             string.Equals(a.Slug, slugOrId, StringComparison.OrdinalIgnoreCase) ||

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -21,6 +21,7 @@ public interface IContentRepository
     Task<IReadOnlyList<Article>>        ListBlogPostsAsync(string? status, CancellationToken ct);
     Task<Article?>                      GetArticleBySlugAsync(string slugOrId, CancellationToken ct);
     Task<Article?>                      GetArticleWithNeighboursAsync(string slugOrId, CancellationToken ct);
+    Task<Article?>                      GetBlogPostWithNeighboursAsync(string slugOrId, CancellationToken ct);
     Task<IReadOnlyList<CommunityEvent>> ListEventsAsync(bool upcomingOnly, CancellationToken ct);
     Task<CommunityEvent?>               GetEventByIdAsync(string id, CancellationToken ct);
     Task<CommunityEvent?>               GetEventWithNeighboursAsync(string id, CancellationToken ct);

--- a/src/web/e2e/anon/public-browsing.spec.ts
+++ b/src/web/e2e/anon/public-browsing.spec.ts
@@ -76,6 +76,29 @@ test.describe('public browsing', () => {
     expect(detail.body.length).toBeGreaterThan(0)
   })
 
+  test('a blog post opens a detail page with its body', async ({ page, request }) => {
+    const [post] = await apiJson<Article[]>(request, '/blog?status=published')
+
+    await page.goto('/blog')
+    await page.getByRole('link', { name: post.title }).first().click()
+
+    await expect(page).toHaveURL(`/blog/${post.slug}`)
+    await expect(page.getByRole('heading', { name: post.title })).toBeVisible()
+  })
+
+  test('a signed-out visitor is offered no edit control', async ({ page, request }) => {
+    // UI gate only. The API here runs with SkipAuth, which resolves a caller with
+    // no persona header to the admin persona, so canEdit comes back true — see
+    // permissions.spec.ts. The anonymous API case is covered in the xUnit suite.
+    const [article] = await apiJson<Article[]>(request, '/articles?status=published')
+    await page.goto(`/articles/${article.slug}`)
+    await expect(page.getByTestId('edit-content')).toHaveCount(0)
+
+    const [post] = await apiJson<Article[]>(request, '/blog?status=published')
+    await page.goto(`/blog/${post.slug}`)
+    await expect(page.getByTestId('edit-content')).toHaveCount(0)
+  })
+
   test('the blog page lists published posts', async ({ page, request }) => {
     const posts = await apiJson<Article[]>(request, '/blog?status=published')
     expect(posts.length).toBeGreaterThan(0)

--- a/src/web/e2e/app/permissions.spec.ts
+++ b/src/web/e2e/app/permissions.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../support/fixtures'
-import { PIXEL_PNG, createDraft, publishAuthoredArticle, submitDraft } from '../support/data'
+import { PIXEL_PNG, createDraft, createPublishedArticle, publishAuthoredArticle, submitDraft } from '../support/data'
+import { createApiClient } from '../support/api-client'
 import { titleFor } from '../support/ids'
 
 /**
@@ -60,6 +61,72 @@ test.describe('a contributor', () => {
 
     // ...and it really is still there.
     expect((await adminApi.get(`/articles/${article.slug}`)).ok()).toBeTruthy()
+  })
+
+  test('cannot revise or flag another author’s published content', async ({ api, adminApi, cleanup, uid }) => {
+    // The pencil on the detail page is hidden for content you did not write, so the
+    // only way to prove the rule is enforced is to ask the API without the UI in the way.
+    const otherAuthor = await createApiClient('contributor2')
+    try {
+      const theirs = await publishAuthoredArticle(otherAuthor, adminApi, cleanup, {
+        title: titleFor(uid, 'Owned by contributor2'),
+      })
+
+      expect((await api.post(`/articles/${theirs.id}/edit`)).status()).toBe(403)
+      expect((await api.post(`/articles/${theirs.id}/request-deletion`)).status()).toBe(403)
+
+      // ...and our own is still editable, so this is ownership and not a blanket refusal.
+      const mine = await publishAuthoredArticle(api, adminApi, cleanup, {
+        title: titleFor(uid, 'Owned by contributor'),
+      })
+      expect((await api.post(`/articles/${mine.id}/edit`)).ok()).toBeTruthy()
+    } finally {
+      await otherAuthor.dispose()
+    }
+  })
+
+  test('cannot revise legacy content that has no recorded author', async ({ api, adminApi, cleanup, uid }) => {
+    // createPublishedArticle leaves authorId null, exactly like everything published
+    // before the field existed. A null author must match nobody, not everybody.
+    const legacy = await createPublishedArticle(adminApi, cleanup, {
+      title: titleFor(uid, 'Legacy no author'),
+    })
+
+    expect((await api.post(`/articles/${legacy.id}/edit`)).status()).toBe(403)
+    expect((await adminApi.post(`/articles/${legacy.id}/edit`)).ok()).toBeTruthy()
+  })
+
+  test('sees only their own submissions in the review queues', async ({ api, adminApi, cleanup, uid }) => {
+    const otherAuthor = await createApiClient('contributor2')
+    try {
+      await publishAuthoredArticle(otherAuthor, adminApi, cleanup, {
+        title: titleFor(uid, 'Not mine'),
+      })
+      const listed = await (await api.get('/review/articles')).json() as { title: string }[]
+      expect(listed.some(a => a.title === titleFor(uid, 'Not mine'))).toBe(false)
+    } finally {
+      await otherAuthor.dispose()
+    }
+  })
+
+  test('is offered the edit control on their own article, and not on another’s', async ({ page, api, adminApi, cleanup, uid }) => {
+    const mine = await publishAuthoredArticle(api, adminApi, cleanup, {
+      title: titleFor(uid, 'My article'),
+    })
+    const otherAuthor = await createApiClient('contributor2')
+    try {
+      const theirs = await publishAuthoredArticle(otherAuthor, adminApi, cleanup, {
+        title: titleFor(uid, 'Their article'),
+      })
+
+      await page.goto(`/articles/${mine.slug}`)
+      await expect(page.getByTestId('edit-content')).toBeVisible()
+
+      await page.goto(`/articles/${theirs.slug}`)
+      await expect(page.getByTestId('edit-content')).toHaveCount(0)
+    } finally {
+      await otherAuthor.dispose()
+    }
   })
 
   test('can still read the pending queues they work from', async ({ api }) => {

--- a/src/web/src/components/common/EditContentButton.spec.ts
+++ b/src/web/src/components/common/EditContentButton.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia, type Pinia } from 'pinia'
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return { ...actual, apiFetch, apiJson: vi.fn() }
+})
+
+import EditContentButton from './EditContentButton.vue'
+import { useAuthStore } from '@/stores/auth'
+
+let pinia: Pinia
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+}
+
+// Stands in for the real editor so the modal can be driven without TipTap.
+const dirtyEditor = (dirty: boolean) => ({
+  name: 'DraftEditor',
+  template: '<div class="draft-editor-stub" />',
+  setup(_p: unknown, { expose }: { expose: (e: unknown) => void }) {
+    expose({ isDirty: () => dirty, flush: vi.fn() })
+  },
+})
+
+const mountBtn = (props = {}, stubs = {}) =>
+  mount(EditContentButton, {
+    props: { contentId: 'a1', canEdit: true, ...props },
+    global: { plugins: [pinia], stubs: { DraftEditor: { template: '<div class="draft-editor-stub" />' }, ...stubs } },
+  })
+
+beforeEach(async () => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+  apiFetch.mockReset()
+  localStorage.clear()
+  await useAuthStore().initialize() // dev-skip admin
+})
+
+describe('EditContentButton', () => {
+  it('renders nothing when the API says the caller may not edit', () => {
+    const w = mountBtn({ canEdit: false })
+    expect(w.find('[data-testid="edit-content"]').exists()).toBe(false)
+  })
+
+  it('renders nothing when signed out, even if canEdit is true', async () => {
+    // Dev-skip resolves a header-less API caller to the admin persona, so canEdit
+    // alone would light this up for a signed-out visitor locally.
+    pinia = createPinia()
+    setActivePinia(pinia) // fresh store, never initialised => not authenticated
+    const w = mountBtn({ canEdit: true })
+    expect(w.find('[data-testid="edit-content"]').exists()).toBe(false)
+  })
+
+  it('creates a revision draft and opens the editor', async () => {
+    apiFetch.mockResolvedValue(ok({ id: 'draft-9' }))
+    const w = mountBtn()
+    await w.find('[data-testid="edit-content"]').trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/articles/a1/edit', { method: 'POST' })
+  })
+
+  it('surfaces the error when the API refuses', async () => {
+    apiFetch.mockResolvedValue({ ok: false, status: 403, statusText: 'Forbidden', text: () => Promise.resolve('You can only edit your own published content.') } as unknown as Response)
+    const w = mountBtn()
+    await w.find('[data-testid="edit-content"]').trigger('click')
+    await flushPromises()
+    expect(w.find('[data-testid="edit-content-error"]').text()).toContain('your own')
+  })
+
+  it('discards the freshly-minted draft when it was closed untouched', async () => {
+    // /edit creates the draft up front, so opening and closing without typing would
+    // otherwise leave an orphan in the author's editor queue.
+    apiFetch.mockResolvedValue(ok({ id: 'draft-9' }))
+    const w = mountBtn({}, { DraftEditor: dirtyEditor(false) })
+    await w.find('[data-testid="edit-content"]').trigger('click')
+    await flushPromises()
+
+    apiFetch.mockClear()
+    await w.findComponent({ name: 'DraftEditor' }).vm.$emit('close')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/drafts/draft-9', { method: 'DELETE' })
+  })
+
+  it('keeps the draft when it was edited', async () => {
+    apiFetch.mockResolvedValue(ok({ id: 'draft-9' }))
+    const w = mountBtn({}, { DraftEditor: dirtyEditor(true) })
+    await w.find('[data-testid="edit-content"]').trigger('click')
+    await flushPromises()
+
+    apiFetch.mockClear()
+    await w.findComponent({ name: 'DraftEditor' }).vm.$emit('close')
+    await flushPromises()
+    expect(apiFetch).not.toHaveBeenCalledWith('/drafts/draft-9', { method: 'DELETE' })
+  })
+})

--- a/src/web/src/components/common/EditContentButton.vue
+++ b/src/web/src/components/common/EditContentButton.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { apiFetch, apiErrorMessage } from '@/lib/api'
+import { useAuthStore } from '@/stores/auth'
+import DraftEditor from '@/components/editor/DraftEditor.vue'
+
+const props = withDefaults(defineProps<{
+  /** Published article or blog post id. */
+  contentId: string
+  /** Server-computed permission. See Article.canEdit. */
+  canEdit?: boolean
+  label?: string
+}>(), { label: 'Edit this page' })
+
+const emit = defineEmits<{ (e: 'submitted'): void }>()
+
+const auth = useAuthStore()
+
+const editDraftId  = ref<string | null>(null)
+const editorRef    = ref<InstanceType<typeof DraftEditor> | null>(null)
+const busy         = ref(false)
+const error        = ref<string | null>(null)
+
+// Editing published content creates a revision draft; the live version stays up
+// until an admin approves the revision. Same endpoint for articles and blog posts.
+async function startEdit() {
+  busy.value = true
+  error.value = null
+  try {
+    const resp = await apiFetch(`/articles/${props.contentId}/edit`, { method: 'POST' })
+    if (!resp.ok) throw new Error(await apiErrorMessage(resp))
+    const draft = await resp.json() as { id: string }
+    editDraftId.value = draft.id
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    busy.value = false
+  }
+}
+
+// The revision draft is minted up front, so opening and closing without typing
+// would otherwise leave an orphan in the author's editor queue. Keep it only if
+// they actually changed something.
+async function closeEdit() {
+  const id = editDraftId.value
+  const editor = editorRef.value
+  if (id && editor) {
+    if (editor.isDirty()) await editor.flush()
+    else try { await apiFetch(`/drafts/${id}`, { method: 'DELETE' }) } catch { /* best-effort */ }
+  }
+  editDraftId.value = null
+}
+
+// Submit consumes the draft server-side (it becomes an in-review revision), so
+// there is nothing to clean up.
+function submittedEdit() {
+  editDraftId.value = null
+  emit('submitted')
+}
+</script>
+
+<template>
+  <!--
+    canEdit is paired with isAuthenticated because in dev-skip mode the API resolves a
+    caller with no persona header to the admin persona, which would otherwise light this
+    up for a signed-out visitor locally. The real boundary is the API's ownership check
+    on POST /articles/{id}/edit — this is only the affordance.
+  -->
+  <button
+    v-if="canEdit && auth.isAuthenticated"
+    type="button"
+    data-testid="edit-content"
+    :aria-label="label"
+    :title="label"
+    class="inline-flex shrink-0 items-center rounded border border-slypn-200 p-1 text-slypn-400 transition-colors hover:bg-slypn-50 hover:text-slypn-600 disabled:opacity-50"
+    :disabled="busy"
+    @click="startEdit"
+  >
+    <svg
+      class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"
+    >
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+    </svg>
+  </button>
+
+  <p v-if="error" data-testid="edit-content-error" class="mt-2 text-sm text-rose-600">{{ error }}</p>
+
+  <!-- Edit dialog — reuses the editor control, as /admin/content does. -->
+  <Teleport to="body">
+    <div
+      v-if="editDraftId"
+      class="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slypn-900/40 p-4"
+    >
+      <div class="my-8 w-full max-w-3xl rounded-xl bg-white p-6 shadow-xl">
+        <div class="mb-4 flex items-center justify-between">
+          <h3 class="font-display text-lg font-bold text-slypn-700">Edit published content</h3>
+          <p class="text-xs text-slypn-500">Submitting sends a revision for approval.</p>
+        </div>
+        <DraftEditor
+          ref="editorRef"
+          :draft-id="editDraftId"
+          @close="closeEdit"
+          @submitted="submittedEdit"
+        />
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/web/src/components/common/PublishedContent.spec.ts
+++ b/src/web/src/components/common/PublishedContent.spec.ts
@@ -37,7 +37,9 @@ function ok(body: unknown) {
 
 const item = (over = {}) => ({
   id: 'i1', slug: 's', title: 'Live article', summary: 'sum', author: 'Jo',
-  authorId: 'oid1', publishedAt: '2026-05-01T00:00:00Z', category: 'Community',
+  // canEdit is computed by the API (Admin, or the authoring Contributor). The author's
+  // OID is no longer sent to the browser, so ownership is no longer compared here.
+  canEdit: true, publishedAt: '2026-05-01T00:00:00Z', category: 'Community',
   type: 'article', status: 'published', ...over,
 })
 
@@ -141,8 +143,8 @@ describe('PublishedContent', () => {
     await useAuthStore().initialize() // member persona
     apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
       const method = init?.method ?? 'GET'
-      if (url.endsWith('/request-deletion') && method === 'POST') return Promise.resolve(ok(item({ authorId: memberOid, deletionRequestedBy: memberOid })))
-      if (method === 'GET' && url === '/articles?status=published') return Promise.resolve(ok([item({ authorId: memberOid })]))
+      if (url.endsWith('/request-deletion') && method === 'POST') return Promise.resolve(ok(item({ deletionRequestedBy: memberOid })))
+      if (method === 'GET' && url === '/articles?status=published') return Promise.resolve(ok([item()]))
       if (method === 'GET') return Promise.resolve(ok([]))
       return Promise.resolve(ok({}))
     })
@@ -315,7 +317,7 @@ describe('PublishedContent', () => {
   it('uses "blog post" in the confirm prompt for blog-type items', async () => {
     const confirmSpy = vi.fn(() => true)
     vi.stubGlobal('confirm', confirmSpy)
-    mockLoad([item({ type: 'blog', id: 'b1', title: 'My Blog', authorId: 'oid1' })])
+    mockLoad([item({ type: 'blog', id: 'b1', title: 'My Blog' })])
     const w = mountC()
     await flushPromises()
     apiFetch.mockResolvedValue(ok({}))
@@ -369,12 +371,11 @@ describe('PublishedContent', () => {
   })
 
   it('shows the non-admin description for a contributor', async () => {
-    const memberOid = '33333333-3333-3333-3333-333333333333'
     localStorage.setItem(DEV_PERSONA_STORAGE_KEY, 'member')
     pinia = createPinia()
     setActivePinia(pinia)
     await useAuthStore().initialize()
-    mockLoad([item({ authorId: memberOid })])
+    mockLoad([item()])
     const w = mountC()
     await flushPromises()
     expect(w.text()).toContain('Your published articles')

--- a/src/web/src/components/common/PublishedContent.vue
+++ b/src/web/src/components/common/PublishedContent.vue
@@ -10,7 +10,7 @@ interface PublishedItem {
   title: string
   summary: string
   author: string
-  authorId?: string | null
+  canEdit?: boolean
   publishedAt: string
   category: string
   type?: 'article' | 'blog'
@@ -29,12 +29,15 @@ const errors    = ref<Record<string, string | null>>({})
 const revisionPending = ref<Set<string>>(new Set())
 
 // Admins manage everything; contributors only their own published content.
+// canEdit is computed by the API — the author's OID is no longer sent to the
+// browser, so there is nothing to compare here. The API enforces the same rule
+// on every write, so this is presentation only.
 const visibleItems = computed(() => {
   const sorted = [...items.value].sort(
     (a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt),
   )
   if (auth.isAdmin) return sorted
-  return sorted.filter(i => i.authorId && i.authorId === auth.oid)
+  return sorted.filter(i => i.canEdit)
 })
 
 // ── Filter / search / pagination ─────────────────────────────────────────────

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -45,6 +45,7 @@ const router = createRouter({
     { path: '/articles',          name: 'articles',        component: ArticlesView },
     { path: '/articles/:slug',    name: 'article-detail',  component: ArticleDetailView },
     { path: '/blog',              name: 'blog',            component: BlogView },
+    { path: '/blog/:slug',        name: 'blog-detail',     component: () => import('@/views/BlogDetailView.vue') },
     { path: '/events',            name: 'events',          component: EventsView },
     { path: '/events/previous',  name: 'events-previous', component: () => import('@/views/EventsPreviousView.vue') },
     { path: '/events/:id',       name: 'event-detail',    component: () => import('@/views/EventDetailView.vue') },

--- a/src/web/src/types/content.ts
+++ b/src/web/src/types/content.ts
@@ -19,6 +19,14 @@ export interface Article {
   publishedAt: string
   readingMinutes: number
   category: ArticleCategory
+  type?: 'article' | 'blog'
+  /**
+   * Server-computed: may the signed-in caller open this in the editor (Admin, or the
+   * Contributor who wrote it)? Deliberately a flag rather than an authorId to compare
+   * against — the author's Entra OID has no business in a public payload. Presentation
+   * only; the API re-checks on POST /articles/{id}/edit.
+   */
+  canEdit?: boolean
   prev?: ArticleNeighbour
   next?: ArticleNeighbour
 }

--- a/src/web/src/views/BlogDetailView.vue
+++ b/src/web/src/views/BlogDetailView.vue
@@ -10,16 +10,16 @@ const route = useRoute()
 const router = useRouter()
 const slug = computed(() => String(route.params.slug ?? ''))
 
-// When we arrived here from the articles list, go back so the kept-alive list
-// view restores its filter + scroll position; otherwise navigate to it directly.
-function backToArticles() {
+// When we arrived from the blog list, go back so the kept-alive list view restores
+// its scroll position; otherwise navigate to it directly.
+function backToBlog() {
   const back = router.options.history.state.back
-  if (typeof back === 'string' && back.split('?')[0] === '/articles') router.back()
-  else router.push('/articles')
+  if (typeof back === 'string' && back.split('?')[0].split('#')[0] === '/blog') router.back()
+  else router.push('/blog')
 }
 
-const { data: article, loading, error, refresh } = useAsyncData(async () => {
-  const resp = await apiFetch(`/articles/${encodeURIComponent(slug.value)}`)
+const { data: post, loading, error, refresh } = useAsyncData(async () => {
+  const resp = await apiFetch(`/blog/${encodeURIComponent(slug.value)}`)
   if (resp.status === 404) return null
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`)
   return resp.json() as Promise<Article>
@@ -32,58 +32,55 @@ const formatDate = (iso: string) =>
 </script>
 
 <template>
-  <article v-if="article" class="page-container-prose py-16">
-    <button type="button" data-testid="article-back" class="text-sm text-slypn-600 hover:text-slypn-700" @click="backToArticles">
-      &larr; All articles
+  <article v-if="post" data-testid="blog-detail" class="page-container-prose py-16">
+    <button type="button" data-testid="blog-back" class="text-sm text-slypn-600 hover:text-slypn-700" @click="backToBlog">
+      &larr; All posts
     </button>
-    <p class="mt-6 font-display text-xs font-semibold uppercase tracking-widest text-slypn-500">
-      {{ article.category }}
-    </p>
-    <h1 class="mt-2 text-4xl font-extrabold text-slypn-700 sm:text-5xl">
-      {{ article.title }}
+    <h1 class="mt-6 text-4xl font-extrabold text-slypn-700 sm:text-5xl">
+      {{ post.title }}
     </h1>
     <p class="mt-4 flex items-center gap-3 text-slypn-900/65">
-      <span>{{ article.author }} &middot; {{ formatDate(article.publishedAt) }} &middot; {{ article.readingMinutes }} min read</span>
+      <span>{{ post.author }} &middot; {{ formatDate(post.publishedAt) }}</span>
       <EditContentButton
-        :content-id="article.id"
-        :can-edit="article.canEdit"
-        label="Edit this article"
+        :content-id="post.id"
+        :can-edit="post.canEdit"
+        label="Edit this post"
         @submitted="refresh"
       />
     </p>
-    <p class="mt-6 text-xl text-slypn-900/85">{{ article.summary }}</p>
+    <p v-if="post.summary" class="mt-6 text-xl text-slypn-900/85">{{ post.summary }}</p>
 
-    <div class="prose prose-slypn mt-8 max-w-none text-slypn-900/85" v-html="article.body" />
+    <div class="prose prose-slypn mt-8 max-w-none text-slypn-900/85" v-html="post.body" />
 
     <nav
-      v-if="article.prev || article.next"
+      v-if="post.prev || post.next"
       class="mt-16 grid grid-cols-2 gap-4 border-t border-slypn-100 pt-8"
-      aria-label="Article navigation"
+      aria-label="Blog navigation"
     >
       <RouterLink
-        v-if="article.prev"
-        :to="`/articles/${article.prev.slug}`"
+        v-if="post.prev"
+        :to="`/blog/${post.prev.slug}`"
         class="group rounded-xl border border-slypn-100 p-5 transition hover:border-slypn-300 hover:shadow-sm"
       >
         <p class="text-xs font-semibold uppercase tracking-wider text-slypn-400 group-hover:text-slypn-600">
           &larr; Previous
         </p>
         <p class="mt-2 text-sm font-medium text-slypn-700 line-clamp-2 group-hover:text-slypn-900">
-          {{ article.prev.title }}
+          {{ post.prev.title }}
         </p>
       </RouterLink>
       <div v-else />
 
       <RouterLink
-        v-if="article.next"
-        :to="`/articles/${article.next.slug}`"
+        v-if="post.next"
+        :to="`/blog/${post.next.slug}`"
         class="group rounded-xl border border-slypn-100 p-5 text-right transition hover:border-slypn-300 hover:shadow-sm"
       >
         <p class="text-xs font-semibold uppercase tracking-wider text-slypn-400 group-hover:text-slypn-600">
           Next &rarr;
         </p>
         <p class="mt-2 text-sm font-medium text-slypn-700 line-clamp-2 group-hover:text-slypn-900">
-          {{ article.next.title }}
+          {{ post.next.title }}
         </p>
       </RouterLink>
       <div v-else />
@@ -95,17 +92,17 @@ const formatDate = (iso: string) =>
   </section>
 
   <section v-else-if="error" class="page-container-prose py-20 text-center">
-    <h1 class="font-display text-2xl font-bold text-slypn-700">Couldn&rsquo;t load this article</h1>
+    <h1 class="font-display text-2xl font-bold text-slypn-700">Couldn&rsquo;t load this post</h1>
     <p class="mt-3 text-sm text-rose-700">{{ error }}</p>
-    <RouterLink to="/articles" class="mt-6 inline-block text-slypn-600 underline underline-offset-4 hover:text-slypn-700">
-      Back to articles
+    <RouterLink to="/blog" class="mt-6 inline-block text-slypn-600 underline underline-offset-4 hover:text-slypn-700">
+      Back to blog
     </RouterLink>
   </section>
 
   <section v-else class="page-container-prose py-20 text-center">
-    <h1 class="font-display text-3xl font-bold text-slypn-700">Article not found</h1>
-    <RouterLink to="/articles" class="mt-6 inline-block text-slypn-600 underline underline-offset-4 hover:text-slypn-700">
-      Back to articles
+    <h1 class="font-display text-2xl font-bold text-slypn-700">Post not found</h1>
+    <RouterLink to="/blog" class="mt-6 inline-block text-slypn-600 underline underline-offset-4 hover:text-slypn-700">
+      Back to blog
     </RouterLink>
   </section>
 </template>

--- a/src/web/src/views/BlogView.vue
+++ b/src/web/src/views/BlogView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { RouterLink, useRoute } from 'vue-router'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import BlogIcon from '@/components/common/BlogIcon.vue'
 import PillFilter from '@/components/common/PillFilter.vue'
@@ -69,7 +69,12 @@ const formatDate = (iso: string) =>
     <ol v-else class="space-y-12">
       <li v-for="post in sorted" :id="`post-${post.id}`" :key="post.id" class="scroll-mt-24 border-b border-slypn-100 pb-12 last:border-b-0">
         <p class="text-xs text-slypn-900/60">{{ formatDate(post.publishedAt) }} &middot; {{ post.author }}</p>
-        <h2 class="mt-2 text-2xl font-bold text-slypn-700">{{ post.title }}</h2>
+        <h2 class="mt-2 text-2xl font-bold text-slypn-700">
+          <RouterLink
+            :to="`/blog/${post.slug || post.id}`"
+            class="hover:text-slypn-900 hover:underline underline-offset-4"
+          >{{ post.title }}</RouterLink>
+        </h2>
         <p class="mt-3 text-slypn-900/85">{{ post.summary }}</p>
         <div class="prose prose-slypn mt-4 max-w-none text-slypn-900/80" v-html="post.body" />
       </li>

--- a/src/web/src/views/views.misc.spec.ts
+++ b/src/web/src/views/views.misc.spec.ts
@@ -20,13 +20,14 @@ import EventsView from './EventsView.vue'
 import EventsPreviousView from './EventsPreviousView.vue'
 import EventDetailView from './EventDetailView.vue'
 import ArticleDetailView from './ArticleDetailView.vue'
+import BlogDetailView from './BlogDetailView.vue'
 import DashboardView from './DashboardView.vue'
 import LoginView from './LoginView.vue'
 import NotFoundView from './NotFoundView.vue'
 import AuthCallbackView from './AuthCallbackView.vue'
 import { useAuthStore } from '@/stores/auth'
 
-const stubs = { RouterLink: RouterLinkStub, EventCalendar: { template: '<div class="event-calendar-stub" />' } }
+const stubs = { RouterLink: RouterLinkStub, EventCalendar: { template: '<div class="event-calendar-stub" />' }, DraftEditor: { template: '<div class="draft-editor-stub" />' } }
 let pinia: Pinia
 const mountView = (C: unknown) => mount(C as never, { global: { plugins: [pinia], stubs } })
 
@@ -359,7 +360,7 @@ describe('ArticleDetailView', () => {
     apiFetch.mockResolvedValue(jsonResponse(art()))
     const w = mountView(ArticleDetailView)
     await flushPromises()
-    await w.find('button').trigger('click')
+    await w.find('[data-testid="article-back"]').trigger('click')
     expect(router.back).toHaveBeenCalled()
     expect(router.push).not.toHaveBeenCalled()
   })
@@ -370,7 +371,7 @@ describe('ArticleDetailView', () => {
     apiFetch.mockResolvedValue(jsonResponse(art()))
     const w = mountView(ArticleDetailView)
     await flushPromises()
-    await w.find('button').trigger('click')
+    await w.find('[data-testid="article-back"]').trigger('click')
     expect(router.push).toHaveBeenCalledWith('/articles')
   })
 
@@ -402,6 +403,108 @@ describe('ArticleDetailView', () => {
     const w = mountView(ArticleDetailView)
     await flushPromises()
     expect(w.text()).toContain('Couldn’t load this article')
+  })
+
+  // ── Edit affordance ────────────────────────────────────────────────────────
+  // canEdit is computed by the API; the view only decides whether to show it.
+  // It is paired with isAuthenticated because in dev-skip mode a caller with no
+  // persona header resolves to the admin persona server-side.
+
+  it('shows the edit button when the API says the caller may edit', async () => {
+    route.params = { slug: 's' }
+    await useAuthStore().initialize() // dev-skip admin; the button also needs a signed-in user
+    apiFetch.mockResolvedValue(jsonResponse(art({ canEdit: true })))
+    const w = mountView(ArticleDetailView)
+    await flushPromises()
+    expect(w.find('[data-testid="edit-content"]').exists()).toBe(true)
+  })
+
+  it('hides the edit button when the API says the caller may not', async () => {
+    route.params = { slug: 's' }
+    apiFetch.mockResolvedValue(jsonResponse(art({ canEdit: false })))
+    const w = mountView(ArticleDetailView)
+    await flushPromises()
+    expect(w.find('[data-testid="edit-content"]').exists()).toBe(false)
+  })
+
+  it('hides the edit button when canEdit is absent', async () => {
+    // An older API response, or any endpoint that did not compute the flag.
+    route.params = { slug: 's' }
+    apiFetch.mockResolvedValue(jsonResponse(art()))
+    const w = mountView(ArticleDetailView)
+    await flushPromises()
+    expect(w.find('[data-testid="edit-content"]').exists()).toBe(false)
+  })
+
+  it('opens a revision draft in the editor when the edit button is clicked', async () => {
+    route.params = { slug: 's' }
+    apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === '/articles/a1/edit' && init?.method === 'POST') return Promise.resolve(jsonResponse({ id: 'draft-9' }))
+      return Promise.resolve(jsonResponse(art({ canEdit: true })))
+    })
+    await useAuthStore().initialize()
+    const w = mountView(ArticleDetailView)
+    await flushPromises()
+    await w.find('[data-testid="edit-content"]').trigger('click')
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/articles/a1/edit', { method: 'POST' })
+  })
+})
+
+describe('BlogDetailView', () => {
+  const post = (over = {}) => ({ id: 'b1', slug: 'p', title: 'A post', summary: 'sum', body: '<p>body text</p>', author: 'Jo', publishedAt: '2026-05-01T00:00:00Z', readingMinutes: 2, category: 'Community', ...over })
+
+  it('renders the fetched post', async () => {
+    route.params = { slug: 'p' }
+    apiFetch.mockResolvedValue(jsonResponse(post()))
+    const w = mountView(BlogDetailView)
+    await flushPromises()
+    expect(apiFetch).toHaveBeenCalledWith('/blog/p')
+    expect(w.text()).toContain('A post')
+    expect(w.html()).toContain('body text')
+  })
+
+  it('renders prev/next navigation pointing at blog URLs', async () => {
+    route.params = { slug: 'p' }
+    apiFetch.mockResolvedValue(jsonResponse(post({
+      prev: { slug: 'older', title: 'Older post' },
+      next: { slug: 'newer', title: 'Newer post' },
+    })))
+    const w = mountView(BlogDetailView)
+    await flushPromises()
+    const targets = w.findAllComponents(RouterLinkStub).map(l => l.props('to'))
+    expect(targets).toContain('/blog/older')
+    expect(targets).toContain('/blog/newer')
+  })
+
+  it('shows not-found when the post is 404', async () => {
+    route.params = { slug: 'missing' }
+    apiFetch.mockResolvedValue(jsonResponse(null, { status: 404, ok: false }))
+    const w = mountView(BlogDetailView)
+    await flushPromises()
+    expect(w.text()).toContain('Post not found')
+  })
+
+  it('shows an error on non-404 failure', async () => {
+    route.params = { slug: 'p' }
+    apiFetch.mockResolvedValue(jsonResponse(null, { status: 500, ok: false }))
+    const w = mountView(BlogDetailView)
+    await flushPromises()
+    expect(w.text()).toContain('Couldn’t load this post')
+  })
+
+  it('gates the edit button on canEdit', async () => {
+    route.params = { slug: 'p' }
+    await useAuthStore().initialize()
+    apiFetch.mockResolvedValue(jsonResponse(post({ canEdit: true })))
+    const shown = mountView(BlogDetailView)
+    await flushPromises()
+    expect(shown.find('[data-testid="edit-content"]').exists()).toBe(true)
+
+    apiFetch.mockResolvedValue(jsonResponse(post({ canEdit: false })))
+    const hidden = mountView(BlogDetailView)
+    await flushPromises()
+    expect(hidden.find('[data-testid="edit-content"]').exists()).toBe(false)
   })
 })
 


### PR DESCRIPTION
A subtle pencil beside the byline opens the editor, for an Admin or the Contributor who wrote the item. Clicking it creates a **revision draft** — the live version stays up until an admin approves — reusing the flow `/admin/content` already uses.

## The rule was not actually enforced

Exploring this turned up that the permission we wanted to *display* did not exist on the server. All three were hidden only by the UI:

| Endpoint | Before |
|---|---|
| `POST /articles/{id}/edit` | `[RequireRole("Admin","Contributor")]`, **no ownership check** — any Contributor could mint a revision of anyone's published article |
| `POST /articles/{id}/request-deletion` | same gap |
| `GET /review/articles`, `/review/blog` | returned **every** in-review item to any Contributor; `EditorView` filtered by `authorId` in the browser |

`e2e/app/permissions.spec.ts` already states the principle: *"The UI hides what a role may not do, which means the only way to prove the API enforces the same rules is to ask it without the UI in the way."* So closing these is as much the point of this PR as the icon.

`ArticleVisibility.MayEdit` is now the single authority — the `canEdit` flag and the 403 both call it, so they cannot drift apart and offer a button that then refuses.

## An OID was on its way to the public internet

The anonymous `GET /api/articles` serialised `authorId` — an Entra OID. It is null on all 10 published articles today, so **nothing has leaked**, but it would have the moment content was published through the draft flow. The naive way to build this feature (compare `article.authorId` to `auth.oid` in the browser) would have made that leak load-bearing.

Instead the API computes ownership and returns `canEdit`; `authorId` no longer reaches a public caller at all. `PublishedContent` moves off `authorId === auth.oid` onto `canEdit` — same predicate, and it deletes the last client-side ownership filter.

## Optional authentication (new mechanism)

A public endpoint could not see its caller: `JwtMiddleware` populates no principal on an unattributed function, and `[RequireRole()]` with no roles means "any authenticated user", which would 401 anonymous readers.

`[OptionalAuth]` authenticates when a usable token is present and never refuses. Deliberately a **subclass** rather than a flag: `GetCustomAttribute<RequireRoleAttribute>()` already matches subclasses, so `GetRoleAttribute` and its cache are untouched — and it makes `[RequireRole("Admin", Optional = true)]`, which would silently downgrade a valid non-Admin to anonymous, unexpressible.

## Blog got a detail page

Blog posts are `Article` rows with `Type == "blog"`, but `/articles/{slug}` resolves through a list hard-filtered to articles, so a blog post was **not reachable by slug at all**. Added `GET /api/blog/{slug}` with prev/next (neighbours stay within the type), plus `BlogDetailView` and `/blog/:slug`. The list keeps its full bodies and `#post-<id>` anchors so existing `/blog#post-<id>` deep links from the home page still work; titles now link through.

## Three things worth a reviewer's eye

1. **`canEdit` is paired with `isAuthenticated` in the UI.** In dev-skip mode `DevPersonas.Resolve(null)` falls back to the **admin** persona, so a header-less caller gets `canEdit: true` locally. Production has no principal and correctly yields false. The real boundary is the API check; this is only the affordance. It also means the `anon` e2e project can assert the UI gate only — the anonymous API case is covered in xUnit, and the test says so.
2. **`CanEdit` must never be persisted.** `ContentRepository.ArticleEntity` serialises the *same* record into the table's `Json` column with the same options as the HTTP response. It is `bool?` with `JsonIgnore(WhenWritingNull)` **and** blanked explicitly in `ArticleEntity`. Same reason `AuthorId` got `WhenWritingNull` rather than a plain `[JsonIgnore]`, which would have stopped persisting it and broken `ReviseArticleAsync`.
3. **`canEdit` requires the Contributor role, not just an OID match.** `/edit` is role-gated, so a member who authored something before losing the role would otherwise be shown a button that 403s.

## Legacy content

All existing published articles have `authorId: null` — it is only set on submit. A null author matches **nobody**, so they stay admin-only, and the author path starts working for anything published through the draft flow. Asserted in both xUnit and e2e. Not backfilling: the only mapping available is the `author` display-name string, which is fuzzy and would be wrong silently.

## Tests

Existing tests that changed meaning rather than breaking by accident, called out because a reviewer should check I did not just make red go green:
- `Passthrough_when_function_has_no_RequireRole` used `GetBlogPosts` as its example of an *unattributed* function; it now points at `GetResources`.
- The pending-listing tests passed a principal-less context and asserted a full list; they now use an Admin, and the filtering has its own test.
- Two `ArticleDetailView` tests located the back button positionally with `find('button')` — an edit button in the same view would have silently stolen that. Now on `data-testid`.

New coverage: ownership matrix on `/edit` and `/request-deletion` (author / other contributor / admin / legacy-null / 404), `canEdit` per caller including the demoted-member case, a raw-body assertion that `authorId` never appears, review-queue filtering, the blog endpoint, `[OptionalAuth]` semantics, the detail-view affordance, and the discard-if-clean draft rule.

## Verification

- **API**: `dotnet build -warnaserror` → 0 warnings, 0 errors; **351 tests** pass (was 332)
- **Web**: `npm run lint` clean; **428 unit tests** pass (was 413); `npm run build` (vue-tsc) clean
- **E2E**: added but **not executed locally** — the harness fails to start Azurite on this machine (`spawn EINVAL` in `e2e/support/backend.ts`, before any test runs). The specs lint and typecheck; CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe