### PR TITLE
feat: editor counts, withdraw from review, and two revision bugs

### DIFF
--- a/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
@@ -558,6 +558,36 @@ public class ArticlesFunctionsTests
         new TestFunctionContext().WithUser("oid-author", "Ann", "Contributor");
 
     [Fact]
+    public async Task Edit_returns_201_when_it_mints_a_new_revision()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.RevisionResumes = false;
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Edit_returns_200_when_the_author_already_has_a_revision_on_the_go()
+    {
+        // The client branches on this to send them to the editor instead of opening a
+        // second window onto work already in progress.
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.RevisionResumes = true;
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
     public async Task Edit_allows_the_author_of_the_published_article()
     {
         var (fn, repo) = Make();

--- a/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
@@ -465,6 +465,95 @@ public class ArticlesFunctionsTests
     // has to hold here. ThrowOnWrite proves the refusal happens BEFORE the repository
     // is touched — otherwise a 403 could be a storage error in disguise.
 
+    // ── Withdraw from review ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Withdraw_returns_the_authors_own_submission_to_drafts()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Withdraw(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/withdraw", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        // It is the in-review row we looked at, not the published one.
+        Assert.Equal("in-review", repo.LastArticleLookupStatus);
+        // A self-withdraw carries no feedback — there is no reviewer leaving a note.
+        Assert.Null(resp.ReadBodyAs<Draft>()!.RevisionFeedback);
+    }
+
+    [Fact]
+    public async Task Withdraw_forbids_another_contributor()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.ThrowOnWrite = new RequestFailedException(500, "should not be reached");
+        var ctx = Contributor();
+
+        var resp = (TestHttpResponseData)await fn.Withdraw(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/withdraw", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Withdraw_forbids_an_admin_who_did_not_write_it()
+    {
+        // Deliberate: an Admin returning someone else's work uses /revise, which
+        // requires feedback. This endpoint has no admin bypass on purpose.
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.ThrowOnWrite = new RequestFailedException(500, "should not be reached");
+        var ctx = Admin();
+
+        var resp = (TestHttpResponseData)await fn.Withdraw(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/withdraw", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Contains("/revise", resp.ReadBodyAsString());
+    }
+
+    [Fact]
+    public async Task Withdraw_404s_when_nothing_is_awaiting_review()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = null;
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Withdraw(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/withdraw", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Withdraw_forbids_legacy_content_with_no_recorded_author()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = null };
+        repo.ThrowOnWrite = new RequestFailedException(500, "should not be reached");
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Withdraw(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/withdraw", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public void Withdraw_requires_a_role()
+    {
+        var attr = typeof(ArticlesFunctions).GetMethod(nameof(ArticlesFunctions.Withdraw))!
+            .GetCustomAttributes(typeof(Slypn.Api.Infrastructure.RequireRoleAttribute), inherit: false)
+            .Cast<Slypn.Api.Infrastructure.RequireRoleAttribute>()
+            .SingleOrDefault();
+
+        Assert.NotNull(attr);
+        Assert.Equal(new[] { "Admin", "Contributor" }, attr!.Roles);
+    }
+
     private static TestFunctionContext Author() =>
         new TestFunctionContext().WithUser("oid-author", "Ann", "Contributor");
 

--- a/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
@@ -1,4 +1,5 @@
 using Azure.Data.Tables;
+using Slypn.Api.Models;
 using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using Xunit;
@@ -146,4 +147,43 @@ public class ContentRepositoryReadTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().ListSubscribersAsync(Ct));
         await Assert.ThrowsAsync<InvalidOperationException>(() => Repo().GetSubscriberByEmailAsync("a@b.com", Ct));
     }
+
+    // ── No-op revision guard ────────────────────────────────────────────────────
+    // A revision draft starts as a copy of the article it replaces, so submitting one
+    // untouched would queue an identical item for an admin to approve for nothing.
+
+    private static Draft RevisionDraft(string title = "T", string summary = "S", string category = "Community", int minutes = 4) =>
+        new("d1", "oid", "Ann", "article", title, "slug", summary, "", category, minutes,
+            DateTime.UtcNow, DateTime.UtcNow, null, "a1");
+
+    private static Article PublishedTarget(string title = "T", string summary = "S", string body = "<p>hi</p>", string category = "Community", int minutes = 4) =>
+        new("a1", "slug", title, summary, body, "Ann", DateTime.UtcNow, minutes, category);
+
+    [Fact]
+    public void IsSameContent_is_true_for_an_untouched_revision()
+    {
+        Assert.True(ContentRepository.IsSameContent(RevisionDraft(), "<p>hi</p>", PublishedTarget()));
+    }
+
+    [Theory]
+    [InlineData("Changed", "S", "Community", 4, "<p>hi</p>")]
+    [InlineData("T", "Changed", "Community", 4, "<p>hi</p>")]
+    [InlineData("T", "S", "Treatment", 4, "<p>hi</p>")]
+    [InlineData("T", "S", "Community", 9, "<p>hi</p>")]
+    [InlineData("T", "S", "Community", 4, "<p>edited</p>")]
+    public void IsSameContent_is_false_when_any_authored_field_differs(
+        string title, string summary, string category, int minutes, string draftBody)
+    {
+        Assert.False(ContentRepository.IsSameContent(
+            RevisionDraft(title, summary, category, minutes), draftBody, PublishedTarget()));
+    }
+
+    [Fact]
+    public void IsSameContent_ignores_surrounding_whitespace()
+    {
+        // Trailing newlines from the editor are not an edit.
+        Assert.True(ContentRepository.IsSameContent(
+            RevisionDraft(title: "  T  "), "\n<p>hi</p>\n", PublishedTarget()));
+    }
+
 }

--- a/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentRepositoryReadTests.cs
@@ -186,4 +186,15 @@ public class ContentRepositoryReadTests
             RevisionDraft(title: "  T  "), "\n<p>hi</p>\n", PublishedTarget()));
     }
 
+
+    [Fact]
+    public void ContentUnchanged_is_its_own_exception_type()
+    {
+        // The Submit endpoint answers 409 for this and 400 for every other
+        // InvalidOperationException, so it must not be one of those.
+        var ex = new Slypn.Api.Services.ContentUnchangedException("nothing to review");
+        Assert.IsNotType<InvalidOperationException>(ex);
+        Assert.Equal("nothing to review", ex.Message);
+    }
+
 }

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -234,7 +234,7 @@ internal sealed class FakeContentRepository : IContentRepository
         return Task.FromResult(ArticleByIdAndStatus);
     }
     public Task<Article> PublishArticleAsync(string id, CancellationToken ct) => Task.FromResult(Guard(MakeArticle(id, null)));
-    public Task<Draft> ReviseArticleAsync(string id, string feedback, CancellationToken ct)
+    public Task<Draft> ReviseArticleAsync(string id, string? feedback, CancellationToken ct)
         => Task.FromResult(Guard(MakeDraft(id, "oid", "name") with { RevisionFeedback = feedback }));
 
     private static Article MakeArticle(string id, ArticleInput? input) => new(

--- a/src/api/Slypn.Api.Tests/FakeContentRepository.cs
+++ b/src/api/Slypn.Api.Tests/FakeContentRepository.cs
@@ -214,8 +214,11 @@ internal sealed class FakeContentRepository : IContentRepository
 
     public Task<Article> SubmitDraftAsync(string draftId, string authorId, CancellationToken ct)
         => Task.FromResult(Guard(MakeArticle(draftId, null)));
-    public Task<Draft> CreateRevisionDraftAsync(string articleId, string oid, string name, CancellationToken ct)
-        => Task.FromResult(Guard(MakeDraft(articleId, oid, name)));
+    /// <summary>Set to make the next revision request resume an existing draft (200) rather
+    /// than mint a new one (201).</summary>
+    public bool RevisionResumes;
+    public Task<(Draft Draft, bool Resumed)> CreateRevisionDraftAsync(string articleId, string oid, string name, CancellationToken ct)
+        => Task.FromResult((Guard(MakeDraft(articleId, oid, name)), RevisionResumes));
     public Task<Article> RequestArticleDeletionAsync(string id, string oid, CancellationToken ct)
         => Task.FromResult(Guard(MakeArticle(id, null)));
     public Task<Article> CancelArticleDeletionAsync(string id, CancellationToken ct)

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -252,7 +252,8 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
     [OpenApiOperation(operationId: "articles.edit", tags: new[] { "articles" }, Summary = "Edit published", Description = "Creates a draft revision of a published article or blog post for approval.")]
     [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
     [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "Published article id.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(Draft), Description = "Created draft revision")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(Draft), Description = "A new draft revision")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Draft), Description = "An in-progress revision this author already had, returned untouched")]
     public async Task<HttpResponseData> Edit(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/edit")] HttpRequestData req,
         FunctionContext context,
@@ -271,8 +272,13 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
             if (!ArticleVisibility.MayEdit(published, context))
                 return await Forbidden(req, EditOwnershipRefusal);
 
-            var draft = await repo.CreateRevisionDraftAsync(id, editorOid, editorName, ct);
-            return await Created(req, draft, draft.Etag);
+            var (draft, resumed) = await repo.CreateRevisionDraftAsync(id, editorOid, editorName, ct);
+            // 200 when we handed back a revision this author already had on the go, 201 when
+            // one was minted. The client sends them to the editor in the first case rather
+            // than opening a second window onto work already in progress.
+            return resumed
+                ? await Ok(req, draft, draft.Etag)
+                : await Created(req, draft, draft.Etag);
         }
         catch (InvalidOperationException ex) { return await BadRequest(req, ex.Message); }
         catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -29,6 +29,10 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
         "You can only edit your own published content. Ask an Admin to make the change, "
         + "or to reassign the item to you.";
 
+    private const string WithdrawOwnershipRefusal =
+        "You can only withdraw your own submissions. An Admin returns someone else's work "
+        + "with POST /api/articles/{id}/revise, which carries feedback.";
+
     private const string DeletionOwnershipRefusal =
         "You can only request deletion of your own published content.";
 
@@ -322,6 +326,50 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
         {
             var article = await repo.CancelArticleDeletionAsync(id, ct);
             return await Ok(req, article, article.Etag);
+        }
+        catch (InvalidOperationException ex) { return await BadRequest(req, ex.Message); }
+        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
+    }
+
+    /// <summary>
+    /// The author pulls their own submission back out of review so they can keep working
+    /// on it. Same transition as Revise — the in-review article becomes a draft again,
+    /// keeping its body and any ReplacesArticleId — but self-service and with no feedback
+    /// note, because there is no reviewer telling them what to change.
+    ///
+    /// Deliberately author-only, with no Admin bypass: an Admin acting on someone else's
+    /// submission should use POST /articles/{id}/revise, which requires feedback and so
+    /// leaves the author a reason. Silently yanking someone's work back is not a thing we
+    /// want to be easy.
+    /// </summary>
+    [Function("WithdrawArticle")]
+    [RequireRole("Admin", "Contributor")]
+    [OpenApiOperation(operationId: "articles.withdraw", tags: new[] { "articles" }, Summary = "Withdraw from review", Description = "Returns the caller's own in-review article or blog post to their drafts so they can edit it again.")]
+    [OpenApiSecurity("bearer_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Bearer, BearerFormat = "JWT")]
+    [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true, Type = typeof(string), Description = "In-review article id.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Draft), Description = "The submission, back as an editable draft")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Forbidden, Description = "Not the author")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not awaiting review")]
+    public async Task<HttpResponseData> Withdraw(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "articles/{id}/withdraw")] HttpRequestData req,
+        FunctionContext context,
+        string id, CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+        var callerOid = context.GetUserOid();
+        if (callerOid is null) return await BadRequest(req, "Token missing oid claim.");
+
+        try
+        {
+            var inReview = await repo.GetArticleAsync(id, InReviewStatus, ct);
+            if (inReview is null) return await NotFound(req, "No submission awaiting review with that id.");
+
+            // Author only — not MayEdit. An Admin who did not write it has /revise.
+            if (inReview.AuthorId is not { Length: > 0 } author || author != callerOid)
+                return await Forbidden(req, WithdrawOwnershipRefusal);
+
+            var draft = await repo.ReviseArticleAsync(id, feedback: null, ct);
+            return await Ok(req, draft, draft.Etag);
         }
         catch (InvalidOperationException ex) { return await BadRequest(req, ex.Message); }
         catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }

--- a/src/api/Slypn.Api/Functions/DraftsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/DraftsFunctions.cs
@@ -172,6 +172,12 @@ public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sani
             var article = await repo.SubmitDraftAsync(id, authorId, ct);
             return await Created(req, article, article.Etag);
         }
+        catch (ContentUnchangedException ex)
+        {
+            // Not a failure — the author simply has nothing to submit yet. Distinct from
+            // the 400s below so the editor can say so gently rather than in red.
+            return await Conflict(req, ex.Message);
+        }
         catch (InvalidOperationException ex)
         {
             return await BadRequest(req, ex.Message);

--- a/src/api/Slypn.Api/Functions/FunctionHelpers.cs
+++ b/src/api/Slypn.Api/Functions/FunctionHelpers.cs
@@ -81,6 +81,11 @@ internal static class FunctionHelpers
     public static async Task<HttpResponseData> Forbidden(HttpRequestData req, string message = "Forbidden.")
         => await Reject(req, HttpStatusCode.Forbidden, message);
 
+    /// <summary>The request was understood but there is nothing to do — not an error the
+    /// caller needs to fix, so clients may present it as information rather than a failure.</summary>
+    public static async Task<HttpResponseData> Conflict(HttpRequestData req, string message)
+        => await Reject(req, HttpStatusCode.Conflict, message);
+
     public static async Task<HttpResponseData> BadRequest(HttpRequestData req, string message)
     {
         var resp = req.CreateResponse(HttpStatusCode.BadRequest);

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -547,7 +547,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         {
             var target = await GetArticleAsync(draft.ReplacesArticleId, PublishedStatus, ct);
             if (target is not null && IsSameContent(draft, draftBody, target))
-                throw new InvalidOperationException(
+                throw new ContentUnchangedException(
                     "This revision is identical to the published version, so there is nothing "
                     + "to review. Make a change first, or close the editor to discard it.");
         }

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -688,7 +688,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         return updated with { Etag = EncodeEtag(saved.Headers.ETag!.Value) };
     }
 
-    public async Task<Draft> ReviseArticleAsync(string id, string feedback, CancellationToken ct)
+    public async Task<Draft> ReviseArticleAsync(string id, string? feedback, CancellationToken ct)
     {
         EnsureWrites();
         Article source;

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -593,7 +593,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         }
     }
 
-    public async Task<Draft> CreateRevisionDraftAsync(string articleId, string editorOid, string editorName, CancellationToken ct)
+    public async Task<(Draft Draft, bool Resumed)> CreateRevisionDraftAsync(string articleId, string editorOid, string editorName, CancellationToken ct)
     {
         EnsureWrites();
 
@@ -606,9 +606,15 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         var existing = (await ListDraftsByAuthorAsync(editorOid, ct))
             .FirstOrDefault(d => d.ReplacesArticleId == articleId);
 
+        // Return it untouched. Rebuilding it from the published article would overwrite
+        // whatever the author had already written — the second click on Edit would throw
+        // their work away — and the caller wants to know it is resuming so it can send
+        // them to the editor rather than opening a fresh one.
+        if (existing is not null) return (existing, Resumed: true);
+
         var now = DateTime.UtcNow;
         var draft = new Draft(
-            Id:                existing?.Id ?? Guid.NewGuid().ToString("N"),
+            Id:                Guid.NewGuid().ToString("N"),
             AuthorId:          editorOid,
             AuthorName:        editorName,
             Type:              published.Type,
@@ -618,11 +624,11 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
             Body:              published.Body,
             Category:          published.Category,
             ReadingMinutes:    published.ReadingMinutes,
-            CreatedAt:         existing?.CreatedAt ?? now,
+            CreatedAt:         now,
             UpdatedAt:         now,
             ReplacesArticleId: articleId);
 
-        return await UpsertDraftAsync(draft, existing?.Etag, ct);
+        return (await UpsertDraftAsync(draft, ifMatch: null, ct), Resumed: false);
     }
 
     public async Task<Article> PublishArticleAsync(string id, CancellationToken ct)

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -538,6 +538,20 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
 
         var draftBody = await body.GetAsync(DraftBodyPrefix, draftId, ct);
 
+        // A revision draft starts as a copy of the article it replaces, so submitting one
+        // untouched would put an identical item in the approvals queue for an admin to
+        // review and approve for nothing. Checked here rather than by grey-ing out the
+        // button: the draft may be closed and reopened between the edit and the submit,
+        // by which point the client no longer knows what the published version looked like.
+        if (!string.IsNullOrEmpty(draft.ReplacesArticleId))
+        {
+            var target = await GetArticleAsync(draft.ReplacesArticleId, PublishedStatus, ct);
+            if (target is not null && IsSameContent(draft, draftBody, target))
+                throw new InvalidOperationException(
+                    "This revision is identical to the published version, so there is nothing "
+                    + "to review. Make a change first, or close the editor to discard it.");
+        }
+
         var article = new Article(
             Id:             draft.Id,
             // Public URL is a {slug}-{shortId} hybrid: readable base from the title
@@ -761,6 +775,16 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     }
 
     // ---- helpers --------------------------------------------------------------
+
+    /// <summary>Whether a revision draft still matches the article it would replace.
+    /// Compares what an author can actually change in the editor — slug and type are
+    /// carried over from the published row, not authored, so they cannot differ.</summary>
+    internal static bool IsSameContent(Draft draft, string draftBody, Article published) =>
+        string.Equals(draft.Title?.Trim(), published.Title?.Trim(), StringComparison.Ordinal)
+        && string.Equals(draft.Summary?.Trim(), published.Summary?.Trim(), StringComparison.Ordinal)
+        && string.Equals(draft.Category?.Trim(), published.Category?.Trim(), StringComparison.Ordinal)
+        && draft.ReadingMinutes == published.ReadingMinutes
+        && string.Equals(draftBody?.Trim(), published.Body?.Trim(), StringComparison.Ordinal);
 
     /// <summary>
     /// Builds the public URL slug as <c>{slug}-{shortId}</c> — a readable base

--- a/src/api/Slypn.Api/Services/ContentUnchangedException.cs
+++ b/src/api/Slypn.Api/Services/ContentUnchangedException.cs
@@ -1,0 +1,11 @@
+namespace Slypn.Api.Services;
+
+/// <summary>
+/// The caller asked for a change that would not change anything — submitting a revision
+/// byte-identical to the article it replaces.
+///
+/// Its own type rather than an InvalidOperationException so the endpoint can answer with a
+/// distinct status, and the UI can tell "nothing to do here" apart from "that went wrong"
+/// without matching on message text.
+/// </summary>
+public sealed class ContentUnchangedException(string message) : Exception(message);

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -73,7 +73,7 @@ public interface IContentRepository
 
     /// <summary>Create (or resume) a draft revision of a published article. The published
     /// article stays live; on approval the revision replaces it in place.</summary>
-    Task<Draft>               CreateRevisionDraftAsync(string articleId, string editorOid, string editorName, CancellationToken ct);
+    Task<(Draft Draft, bool Resumed)> CreateRevisionDraftAsync(string articleId, string editorOid, string editorName, CancellationToken ct);
 
     /// <summary>Flag a published article for deletion (pending admin approval). Stays live.</summary>
     Task<Article>             RequestArticleDeletionAsync(string id, string requesterOid, CancellationToken ct);

--- a/src/api/Slypn.Api/Services/IContentRepository.cs
+++ b/src/api/Slypn.Api/Services/IContentRepository.cs
@@ -88,5 +88,5 @@ public interface IContentRepository
     Task<Article>             PublishArticleAsync(string id, CancellationToken ct);
 
     /// <summary>Send an in-review article back to the author as a draft with revision feedback.</summary>
-    Task<Draft>               ReviseArticleAsync(string id, string feedback, CancellationToken ct);
+    Task<Draft>               ReviseArticleAsync(string id, string? feedback, CancellationToken ct);
 }

--- a/src/web/e2e/app/content-revision.spec.ts
+++ b/src/web/e2e/app/content-revision.spec.ts
@@ -104,8 +104,10 @@ test.describe('revision workflow', () => {
 
     const revision = await (await api.post(`/articles/${article.id}/edit`)).json() as { id: string }
 
+    // 409, not 400 — nothing is wrong with the request, there is just nothing to do,
+    // and the editor shows it as information rather than an error.
     const refused = await api.post(`/drafts/${revision.id}/submit`)
-    expect(refused.status()).toBe(400)
+    expect(refused.status()).toBe(409)
     expect(await refused.text()).toContain('identical to the published version')
 
     // Change one thing and it goes through, so this is a no-op guard and not a block.

--- a/src/web/e2e/app/content-revision.spec.ts
+++ b/src/web/e2e/app/content-revision.spec.ts
@@ -95,6 +95,25 @@ test.describe('revision workflow', () => {
     await context.close()
   })
 
+  test('an untouched revision cannot be submitted', async ({ api, adminApi, cleanup, uid }) => {
+    // POST /edit copies the published article into a draft, so submitting it without
+    // changing anything would put an identical item in the approvals queue.
+    const article = await publishAuthoredArticle(api, adminApi, cleanup, {
+      title: titleFor(uid, 'Nothing to review'),
+    })
+
+    const revision = await (await api.post(`/articles/${article.id}/edit`)).json() as { id: string }
+
+    const refused = await api.post(`/drafts/${revision.id}/submit`)
+    expect(refused.status()).toBe(400)
+    expect(await refused.text()).toContain('identical to the published version')
+
+    // Change one thing and it goes through, so this is a no-op guard and not a block.
+    const draft = await (await api.get(`/drafts/${revision.id}`)).json() as Record<string, unknown>
+    expect((await api.put(`/drafts/${revision.id}`, { ...draft, summary: 'Genuinely revised.' })).ok()).toBeTruthy()
+    expect((await api.post(`/drafts/${revision.id}/submit`)).ok()).toBeTruthy()
+  })
+
   test('editing published content creates a revision, and approving it updates the live copy',
     async ({ page, browser, api, adminApi, cleanup, uid }) => {
       const original = await publishAuthoredArticle(api, adminApi, cleanup, {

--- a/src/web/e2e/app/permissions.spec.ts
+++ b/src/web/e2e/app/permissions.spec.ts
@@ -129,6 +129,49 @@ test.describe('a contributor', () => {
     }
   })
 
+  test('cannot withdraw another author’s submission', async ({ api, cleanup, uid }) => {
+    const otherAuthor = await createApiClient('contributor2')
+    try {
+      const draft = await createDraft(otherAuthor, cleanup, { title: titleFor(uid, 'Theirs in review') })
+      await submitDraft(otherAuthor, cleanup, draft.id)
+
+      expect((await api.post(`/articles/${draft.id}/withdraw`)).status()).toBe(403)
+
+      // ...and it is genuinely still in review for its author.
+      const theirs = await (await otherAuthor.get('/review/articles')).json() as { id: string }[]
+      expect(theirs.some(a => a.id === draft.id)).toBe(true)
+    } finally {
+      await otherAuthor.dispose()
+    }
+  })
+
+  test('withdraws their own submission back to a draft', async ({ api, cleanup, uid }) => {
+    const draft = await createDraft(api, cleanup, { title: titleFor(uid, 'Mine in review') })
+    await submitDraft(api, cleanup, draft.id)
+
+    // In review, so not in drafts.
+    expect(((await (await api.get('/drafts')).json()) as { id: string }[])
+      .some(d => d.id === draft.id)).toBe(false)
+
+    expect((await api.post(`/articles/${draft.id}/withdraw`)).ok()).toBeTruthy()
+
+    // Back in drafts, out of the review queue.
+    expect(((await (await api.get('/drafts')).json()) as { id: string }[])
+      .some(d => d.id === draft.id)).toBe(true)
+    expect(((await (await api.get('/review/articles')).json()) as { id: string }[])
+      .some(a => a.id === draft.id)).toBe(false)
+  })
+
+  test('an admin cannot withdraw someone else’s work, only revise it', async ({ api, adminApi, cleanup, uid }) => {
+    // Deliberate: /revise requires feedback, so the author is told why. Withdraw
+    // has no admin bypass precisely so that cannot be sidestepped.
+    const draft = await createDraft(api, cleanup, { title: titleFor(uid, 'Admin cannot withdraw') })
+    await submitDraft(api, cleanup, draft.id)
+
+    expect((await adminApi.post(`/articles/${draft.id}/withdraw`)).status()).toBe(403)
+    expect((await adminApi.post(`/articles/${draft.id}/revise`, { feedback: 'Needs another pass please.' })).ok()).toBeTruthy()
+  })
+
   test('can still read the pending queues they work from', async ({ api }) => {
     // The role gate must not lock out the people who need it: EditorView and
     // PublishedContent both read these.

--- a/src/web/src/components/common/EditContentButton.spec.ts
+++ b/src/web/src/components/common/EditContentButton.spec.ts
@@ -8,13 +8,21 @@ vi.mock('@/lib/api', async (importOriginal) => {
   return { ...actual, apiFetch, apiJson: vi.fn() }
 })
 
+const push = vi.fn()
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>)
+  return { ...actual, useRouter: () => ({ push }) }
+})
+
 import EditContentButton from './EditContentButton.vue'
 import { useAuthStore } from '@/stores/auth'
 
 let pinia: Pinia
 
-function ok(body: unknown) {
-  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
+// 201 = a revision was minted, so the editor opens here. 200 = one was already on the
+// go, which navigates to the editor page instead.
+function created(body: unknown) {
+  return { ok: true, status: 201, statusText: 'Created', json: () => Promise.resolve(body), text: () => Promise.resolve('') } as unknown as Response
 }
 
 // Stands in for the real editor so the modal can be driven without TipTap.
@@ -36,11 +44,33 @@ beforeEach(async () => {
   pinia = createPinia()
   setActivePinia(pinia)
   apiFetch.mockReset()
+  push.mockClear()
   localStorage.clear()
   await useAuthStore().initialize() // dev-skip admin
 })
 
 describe('EditContentButton', () => {
+  it('goes to the editor when a revision is already on the go', async () => {
+    // 200 means the API handed back an existing revision rather than minting one, so
+    // opening a modal here would be a second window onto work in progress.
+    apiFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ id: 'draft-7' }), text: () => Promise.resolve('') } as unknown as Response)
+    const w = mountBtn()
+    await w.find('[data-testid="edit-content"]').trigger('click')
+    await flushPromises()
+
+    expect(push).toHaveBeenCalledWith({ path: '/editor', query: { draft: 'draft-7' } })
+    expect(w.find('.draft-editor-stub').exists()).toBe(false)
+  })
+
+  it('opens the modal in place when the revision is new', async () => {
+    apiFetch.mockResolvedValue({ ok: true, status: 201, statusText: 'Created', json: () => Promise.resolve({ id: 'draft-8' }), text: () => Promise.resolve('') } as unknown as Response)
+    const w = mountBtn()
+    await w.find('[data-testid="edit-content"]').trigger('click')
+    await flushPromises()
+
+    expect(push).not.toHaveBeenCalled()
+  })
+
   it('renders nothing when the API says the caller may not edit', () => {
     const w = mountBtn({ canEdit: false })
     expect(w.find('[data-testid="edit-content"]').exists()).toBe(false)
@@ -56,7 +86,7 @@ describe('EditContentButton', () => {
   })
 
   it('creates a revision draft and opens the editor', async () => {
-    apiFetch.mockResolvedValue(ok({ id: 'draft-9' }))
+    apiFetch.mockResolvedValue(created({ id: 'draft-9' }))
     const w = mountBtn()
     await w.find('[data-testid="edit-content"]').trigger('click')
     await flushPromises()
@@ -74,7 +104,7 @@ describe('EditContentButton', () => {
   it('discards the freshly-minted draft when it was closed untouched', async () => {
     // /edit creates the draft up front, so opening and closing without typing would
     // otherwise leave an orphan in the author's editor queue.
-    apiFetch.mockResolvedValue(ok({ id: 'draft-9' }))
+    apiFetch.mockResolvedValue(created({ id: 'draft-9' }))
     const w = mountBtn({}, { DraftEditor: dirtyEditor(false) })
     await w.find('[data-testid="edit-content"]').trigger('click')
     await flushPromises()
@@ -86,7 +116,7 @@ describe('EditContentButton', () => {
   })
 
   it('keeps the draft when it was edited', async () => {
-    apiFetch.mockResolvedValue(ok({ id: 'draft-9' }))
+    apiFetch.mockResolvedValue(created({ id: 'draft-9' }))
     const w = mountBtn({}, { DraftEditor: dirtyEditor(true) })
     await w.find('[data-testid="edit-content"]').trigger('click')
     await flushPromises()

--- a/src/web/src/components/common/EditContentButton.vue
+++ b/src/web/src/components/common/EditContentButton.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { apiFetch, apiErrorMessage } from '@/lib/api'
 import { useAuthStore } from '@/stores/auth'
 import DraftEditor from '@/components/editor/DraftEditor.vue'
@@ -15,6 +16,7 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{ (e: 'submitted'): void }>()
 
 const auth = useAuthStore()
+const router = useRouter()
 
 const editDraftId  = ref<string | null>(null)
 const editorRef    = ref<InstanceType<typeof DraftEditor> | null>(null)
@@ -30,6 +32,14 @@ async function startEdit() {
     const resp = await apiFetch(`/articles/${props.contentId}/edit`, { method: 'POST' })
     if (!resp.ok) throw new Error(await apiErrorMessage(resp))
     const draft = await resp.json() as { id: string }
+
+    // 200 means the API handed back a revision this author already had on the go, rather
+    // than minting one. Opening it in a modal here would be a second window onto work in
+    // progress, so send them to the editor where it sits alongside the rest of their queue.
+    if (resp.status === 200) {
+      await router.push({ path: '/editor', query: { draft: draft.id } })
+      return
+    }
     editDraftId.value = draft.id
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err)

--- a/src/web/src/components/editor/DraftEditor.spec.ts
+++ b/src/web/src/components/editor/DraftEditor.spec.ts
@@ -16,7 +16,8 @@ function resp(body: unknown, init: { ok?: boolean; status?: number; etag?: strin
     statusText: 'OK',
     headers: { get: () => init.etag ?? 'etag-1' },
     json: () => Promise.resolve(body),
-    text: () => Promise.resolve(''),
+    // A string body is the response text — plain-text refusals arrive that way.
+    text: () => Promise.resolve(typeof body === 'string' ? body : ''),
   } as unknown as Response
 }
 
@@ -117,4 +118,47 @@ describe('DraftEditor', () => {
     await flushPromises()
     expect(w.text()).toContain('Submit failed')
   })
+  it('says nothing-to-review gently when the revision matches what is published', async () => {
+    // 409 is only reachable from the unchanged-revision guard on this endpoint, so it
+    // is safe to treat as information rather than matching on message text.
+    mockApi((url, method) => {
+      if (url.endsWith('/submit') && method === 'POST') {
+        return resp('This revision is identical to the published version, so there is nothing to review.', { ok: false, status: 409 })
+      }
+      return undefined
+    })
+    const w = mountEditor()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Submit for review'))!.trigger('click')
+    await flushPromises()
+
+    const notice = w.find('[data-testid="draft-submit-notice"]')
+    expect(notice.exists()).toBe(true)
+    expect(notice.text()).toContain('nothing to review')
+    // Not dressed as a failure.
+    expect(w.find('[data-testid="draft-submit-error"]').exists()).toBe(false)
+    expect(w.text()).not.toContain('Submit failed')
+  })
+
+  it('clears the notice on the next submit attempt', async () => {
+    let status = 409
+    mockApi((url, method) => {
+      if (url.endsWith('/submit') && method === 'POST') {
+        return status === 409 ? resp('nothing to review', { ok: false, status: 409 }) : resp('{}', { ok: true, status: 201 })
+      }
+      return undefined
+    })
+    const w = mountEditor()
+    await flushPromises()
+    const submit = w.findAll('button').find(b => b.text()?.includes('Submit for review'))!
+    await submit.trigger('click')
+    await flushPromises()
+    expect(w.find('[data-testid="draft-submit-notice"]').exists()).toBe(true)
+
+    status = 201
+    await submit.trigger('click')
+    await flushPromises()
+    expect(w.find('[data-testid="draft-submit-notice"]').exists()).toBe(false)
+  })
+
 })

--- a/src/web/src/components/editor/DraftEditor.vue
+++ b/src/web/src/components/editor/DraftEditor.vue
@@ -26,6 +26,10 @@ const switching   = ref(false)
 const uploadError = ref<string | null>(null)
 const submitting  = ref(false)
 const submitError = ref<string | null>(null)
+// Not every refusal is a failure. Submitting a revision that matches what is already
+// published comes back 409 — there is nothing to review, which is worth saying kindly
+// rather than in red. 409 is only reachable from that guard on this endpoint.
+const submitNotice = ref<string | null>(null)
 
 interface ConflictState { serverDraft: DraftPayload; serverEtag: string | null }
 const conflict = ref<ConflictState | null>(null)
@@ -50,12 +54,14 @@ async function loadDraft(id: string) {
     currentEtag.value = null
     conflict.value = null
     submitError.value = null
+    submitNotice.value = null
     loadedSnapshot.value = snapshot(draft.value)
     return
   }
   switching.value = true
   conflict.value  = null
   submitError.value = null
+  submitNotice.value = null
   try {
     const resp = await apiFetch(`/drafts/${id}`)
     if (!resp.ok) { draft.value = { ...EMPTY_DRAFT }; currentEtag.value = null; return }
@@ -110,10 +116,15 @@ defineExpose({ flush, isDirty })
 async function submitForReview() {
   if (submitting.value) return
   submitError.value = null
+  submitNotice.value = null
   submitting.value  = true
   try {
     await save(draft.value)
     const resp = await apiFetch(`/drafts/${props.draftId}/submit`, { method: 'POST' })
+    if (resp.status === 409) {
+      submitNotice.value = await resp.text()
+      return
+    }
     if (!resp.ok) throw new Error(await apiErrorMessage(resp))
     emit('submitted', props.draftId)
   } catch (err) {
@@ -362,6 +373,17 @@ watch(() => draft.value.body, (html) => {
         @click="submitForReview"
       >{{ submitting ? 'Submitting…' : 'Submit for review' }}</button>
     </div>
+
+    <p
+      v-if="!readonly && submitNotice"
+      data-testid="draft-submit-notice"
+      class="flex items-start gap-2 rounded-md border border-slypn-100 bg-slypn-50 px-4 py-2 text-sm text-slypn-800"
+    >
+      <svg class="mt-0.5 h-4 w-4 shrink-0 text-slypn-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M18 10A8 8 0 1 1 2 10a8 8 0 0 1 16 0Zm-9-4a1 1 0 1 1 2 0 1 1 0 0 1-2 0Zm1 3a1 1 0 0 0-1 1v4a1 1 0 1 0 2 0v-4a1 1 0 0 0-1-1Z" clip-rule="evenodd" />
+      </svg>
+      <span>{{ submitNotice }}</span>
+    </p>
 
     <p v-if="!readonly && submitError" data-testid="draft-submit-error" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
       Submit failed: {{ submitError }}

--- a/src/web/src/components/layout/AppNav.spec.ts
+++ b/src/web/src/components/layout/AppNav.spec.ts
@@ -30,6 +30,36 @@ describe('AppNav', () => {
     push.mockClear()
   })
 
+  it('badges the Editor link with the number of documents on the go', async () => {
+    const adminOid = '11111111-1111-1111-1111-111111111111'
+    const { apiFetch } = await import('@/lib/api')
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+      const body = path === '/drafts' ? [{ id: 'd1' }, { id: 'd2' }]
+        : path === '/review/articles' ? [{ authorId: adminOid }]
+        : []
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
+    })
+    await useAuthStore().initialize() // dev-skip admin
+    const w = mountNav()
+    await flushPromises()
+    await w.find('[data-testid="user-menu-trigger"]').trigger('click')
+
+    const badge = w.findAll('[data-testid="nav-badge"]').find(b => b.attributes('data-for') === '/editor')
+    expect(badge?.text()).toBe('3') // two drafts + one submission
+  })
+
+  it('shows no Editor badge when there is nothing on the go', async () => {
+    const { apiFetch } = await import('@/lib/api')
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+    await useAuthStore().initialize()
+    const w = mountNav()
+    await flushPromises()
+    await w.find('[data-testid="user-menu-trigger"]').trigger('click')
+
+    const badge = w.findAll('[data-testid="nav-badge"]').find(b => b.attributes('data-for') === '/editor')
+    expect(badge).toBeUndefined()
+  })
+
   it('renders the brand logo and primary nav links', () => {
     const w = mountNav()
     expect(w.find('img[alt="SLYPN"]').exists()).toBe(true)

--- a/src/web/src/components/layout/AppNav.vue
+++ b/src/web/src/components/layout/AppNav.vue
@@ -4,6 +4,7 @@ import { RouterLink, useRouter } from 'vue-router'
 import logoUrl from '@/assets/logo.svg'
 import { useAuthStore } from '@/stores/auth'
 import { useApprovalsStore } from '@/stores/approvals'
+import { useEditorQueueStore } from '@/stores/editorQueue'
 
 const APP_ENV   = import.meta.env.VITE_FARO_ENV ?? 'dev'
 const envLabel  = APP_ENV !== 'prod' ? APP_ENV : null
@@ -23,24 +24,25 @@ const navItems = [
 
 const auth = useAuthStore()
 const approvalsStore = useApprovalsStore()
+const editorQueueStore = useEditorQueueStore()
 const router = useRouter()
 const mobileOpen = ref(false)
 const userMenuOpen = ref(false)
 
 // Account/admin links, defined once and reused by the desktop dropdown and the
-// mobile account panel. `dividerAfter` renders a separator; `badge` shows the
-// pending-approvals count.
+// mobile account panel. `dividerAfter` renders a separator; `badge` is the count
+// to show beside the label, hidden when zero.
 const accountLinks = computed(() => ([
   { to: '/dashboard',       label: 'Dashboard',          show: true, dividerAfter: true },
-  { to: '/admin/approvals', label: 'Approvals',          show: auth.isAdmin, badge: true },
+  { to: '/admin/approvals', label: 'Approvals',          show: auth.isAdmin, badge: approvalsStore.pendingCount },
   { to: '/admin/content',   label: 'Content management', show: auth.isContributor || auth.isAdmin },
-  { to: '/editor',          label: 'Editor',             show: auth.isContributor || auth.isAdmin },
+  { to: '/editor',          label: 'Editor',             show: auth.isContributor || auth.isAdmin, badge: editorQueueStore.openCount },
   { to: '/admin/events',    label: 'Event management',   show: auth.isContributor || auth.isAdmin },
   { to: '/admin/resources', label: 'Resources',          show: auth.isAdmin },
   { to: '/admin/newsletters', label: 'Newsletters',      show: auth.isAdmin, dividerAfter: true },
   { to: '/admin/members',   label: 'Members',            show: auth.isAdmin },
   { to: '/admin/subscribers', label: 'Newsletter subscribers', show: auth.isAdmin, dividerAfter: true },
-] as { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: boolean }[]).filter(l => l.show))
+] as { to: string; label: string; show: boolean; dividerAfter?: boolean; badge?: number }[]).filter(l => l.show))
 
 const envMenuOpen = ref(false)
 const swaggerUrl = APP_ENV === 'local'
@@ -61,12 +63,16 @@ function onKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') closeMobilePanels()
 }
 
+const canAuthor = computed(() => auth.isContributor || auth.isAdmin)
+
 onMounted(() => {
   if (auth.isAdmin) approvalsStore.refresh()
+  if (canAuthor.value) editorQueueStore.refresh()
   window.addEventListener('keydown', onKeydown)
 })
 onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 watch(() => auth.isAdmin, (isAdmin) => { if (isAdmin) approvalsStore.refresh() })
+watch(canAuthor, (yes) => { if (yes) editorQueueStore.refresh() })
 
 async function onSignIn() {
   if (!auth.isConfigured) {
@@ -190,10 +196,11 @@ async function onSignOut() {
                 >
                   {{ link.label }}
                   <span
-                    v-if="link.badge && approvalsStore.pendingCount > 0"
-                    data-testid="approvals-badge"
+                    v-if="link.badge"
+                    data-testid="nav-badge"
+                    :data-for="link.to"
                     class="ml-2 rounded-full bg-amber-500 px-1.5 py-0.5 text-xs font-bold text-white"
-                  >{{ approvalsStore.pendingCount }}</span>
+                  >{{ link.badge }}</span>
                 </RouterLink>
               </li>
               <li v-if="link.dividerAfter" aria-hidden="true"><hr class="my-1 border-t border-slypn-100" /></li>
@@ -288,9 +295,9 @@ async function onSignOut() {
           >
             {{ link.label }}
             <span
-              v-if="link.badge && approvalsStore.pendingCount > 0"
+              v-if="link.badge"
               class="ml-2 rounded-full bg-amber-500 px-1.5 py-0.5 text-xs font-bold text-white"
-            >{{ approvalsStore.pendingCount }}</span>
+            >{{ link.badge }}</span>
           </RouterLink>
           <hr v-if="link.dividerAfter" class="my-1 border-t border-slypn-100" aria-hidden="true" />
         </template>

--- a/src/web/src/stores/editorQueue.spec.ts
+++ b/src/web/src/stores/editorQueue.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }))
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return { ...actual, apiFetch, apiJson: vi.fn() }
+})
+
+import { useEditorQueueStore } from './editorQueue'
+import { useAuthStore } from '@/stores/auth'
+import { DEV_PERSONA_STORAGE_KEY } from '@/lib/devPersonas'
+
+const adminOid = '11111111-1111-1111-1111-111111111111'
+const otherOid = '22222222-2222-2222-2222-222222222222'
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve(body) } as unknown as Response
+}
+
+function mockQueues(drafts: unknown[], articles: unknown[], blogs: unknown[]) {
+  apiFetch.mockImplementation((path: string) => {
+    if (path === '/drafts') return Promise.resolve(ok(drafts))
+    if (path === '/review/articles') return Promise.resolve(ok(articles))
+    if (path === '/review/blog') return Promise.resolve(ok(blogs))
+    return Promise.resolve(ok([]))
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  apiFetch.mockReset()
+  localStorage.clear()
+})
+
+describe('editorQueue store', () => {
+  it('counts open drafts plus the caller’s own submissions', async () => {
+    await useAuthStore().initialize() // dev-skip admin
+    mockQueues([{ id: 'd1' }, { id: 'd2' }], [{ authorId: adminOid }], [{ authorId: adminOid }])
+
+    const store = useEditorQueueStore()
+    await store.refresh()
+
+    expect(store.draftCount).toBe(2)
+    expect(store.inReviewCount).toBe(2)
+    expect(store.openCount).toBe(4)
+  })
+
+  it('ignores submissions by other authors', async () => {
+    // /review/* is filtered to the caller for a Contributor, but an Admin sees
+    // everyone's — counting those would tell an admin they have work open when
+    // they have none.
+    await useAuthStore().initialize()
+    mockQueues([], [{ authorId: otherOid }, { authorId: otherOid }], [{ authorId: adminOid }])
+
+    const store = useEditorQueueStore()
+    await store.refresh()
+
+    expect(store.inReviewCount).toBe(1)
+    expect(store.openCount).toBe(1)
+  })
+
+  it('stays at zero when signed out, without calling the API', async () => {
+    const store = useEditorQueueStore()
+    await store.refresh()
+
+    expect(store.openCount).toBe(0)
+    expect(apiFetch).not.toHaveBeenCalled()
+  })
+
+  it('keeps the last known count when a request fails', async () => {
+    await useAuthStore().initialize()
+    mockQueues([{ id: 'd1' }], [], [])
+    const store = useEditorQueueStore()
+    await store.refresh()
+    expect(store.openCount).toBe(1)
+
+    apiFetch.mockResolvedValue({ ok: false, status: 500 } as unknown as Response)
+    await store.refresh()
+    expect(store.openCount).toBe(1) // a blip must not blank the badge
+  })
+
+  it('counts for a contributor persona too', async () => {
+    localStorage.setItem(DEV_PERSONA_STORAGE_KEY, 'contributor')
+    setActivePinia(createPinia())
+    await useAuthStore().initialize()
+    mockQueues([{ id: 'd1' }], [{ authorId: otherOid }], [])
+
+    const store = useEditorQueueStore()
+    await store.refresh()
+
+    expect(store.openCount).toBe(2) // one draft + their own submission
+  })
+})

--- a/src/web/src/stores/editorQueue.ts
+++ b/src/web/src/stores/editorQueue.ts
@@ -1,0 +1,50 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import { apiFetch } from '@/lib/api'
+import { useAuthStore } from '@/stores/auth'
+
+/**
+ * How many documents the signed-in user has on the go in the editor: open drafts
+ * plus their own submissions awaiting review. Drives the badge on the Editor nav
+ * link, so pending work is visible without opening the page.
+ *
+ * Own submissions, not all of them: the API filters /review/* to the caller for a
+ * Contributor, but an Admin legitimately sees everyone's, and counting those here
+ * would tell an admin they have twelve documents open when they have none.
+ */
+export const useEditorQueueStore = defineStore('editorQueue', () => {
+  const draftCount    = ref(0)
+  const inReviewCount = ref(0)
+  const openCount     = ref(0)
+
+  async function refresh() {
+    const auth = useAuthStore()
+    if (!auth.isAuthenticated) {
+      draftCount.value = inReviewCount.value = openCount.value = 0
+      return
+    }
+    try {
+      const [dr, ar, br] = await Promise.all([
+        apiFetch('/drafts'),
+        apiFetch('/review/articles'),
+        apiFetch('/review/blog'),
+      ])
+      if (!dr.ok || !ar.ok || !br.ok) return
+
+      const [drafts, articles, blogs] = await Promise.all([
+        dr.json() as Promise<unknown[]>,
+        ar.json() as Promise<{ authorId?: string | null }[]>,
+        br.json() as Promise<{ authorId?: string | null }[]>,
+      ])
+
+      draftCount.value = drafts.length
+      inReviewCount.value = [...articles, ...blogs]
+        .filter(x => auth.oid && x.authorId === auth.oid).length
+      openCount.value = draftCount.value + inReviewCount.value
+    } catch {
+      // non-fatal — the badge just stays at its last known value
+    }
+  }
+
+  return { draftCount, inReviewCount, openCount, refresh }
+})

--- a/src/web/src/views/DashboardView.vue
+++ b/src/web/src/views/DashboardView.vue
@@ -3,11 +3,16 @@ import { onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useApprovalsStore } from '@/stores/approvals'
+import { useEditorQueueStore } from '@/stores/editorQueue'
 
 const auth = useAuthStore()
 const approvalsStore = useApprovalsStore()
+const editorQueueStore = useEditorQueueStore()
 
-onMounted(() => { if (auth.isAdmin) approvalsStore.refresh() })
+onMounted(() => {
+  if (auth.isAdmin) approvalsStore.refresh()
+  if (auth.isContributor || auth.isAdmin) editorQueueStore.refresh()
+})
 </script>
 
 <template>
@@ -70,7 +75,14 @@ onMounted(() => { if (auth.isAdmin) approvalsStore.refresh() })
         to="/editor"
         class="rounded-xl border border-slypn-100 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
       >
-        <p class="font-display font-bold text-slypn-700">Editor</p>
+        <p class="flex items-center gap-2 font-display font-bold text-slypn-700">
+          Editor
+          <span
+            v-if="editorQueueStore.openCount > 0"
+            data-testid="dashboard-editor-badge"
+            class="rounded-full bg-amber-500 px-1.5 py-0.5 text-xs font-bold text-white"
+          >{{ editorQueueStore.openCount }}</span>
+        </p>
         <p class="mt-2 text-sm text-slypn-900/75">
           Draft articles and blog posts. Submit for admin approval when ready.
         </p>

--- a/src/web/src/views/EditorView.spec.ts
+++ b/src/web/src/views/EditorView.spec.ts
@@ -9,6 +9,13 @@ vi.mock('@/lib/api', async (importOriginal) => {
   return { ...actual, apiJson, apiFetch }
 })
 
+// EditorView reads ?draft= to open a resumed revision directly.
+const route = { query: {} as Record<string, string> }
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>)
+  return { ...actual, useRoute: () => route }
+})
+
 import EditorView from './EditorView.vue'
 import { useAuthStore } from '@/stores/auth'
 
@@ -57,11 +64,29 @@ beforeEach(async () => {
   pinia = createPinia()
   setActivePinia(pinia)
   apiJson.mockReset(); apiFetch.mockReset()
+  route.query = {}
   vi.stubGlobal('confirm', vi.fn(() => true))
   await useAuthStore().initialize()
 })
 
 describe('EditorView', () => {
+  it('opens the draft named by ?draft= on arrival', async () => {
+    // Arriving from the edit affordance with a revision already in progress.
+    route.query = { draft: 'd1' }
+    mockLists([draftSummary({ id: 'd1' })])
+    const w = mountV()
+    await flushPromises()
+    expect(w.find('.draft-editor-stub').exists()).toBe(true)
+  })
+
+  it('ignores a ?draft= that is not one of theirs', async () => {
+    route.query = { draft: 'someone-elses' }
+    mockLists([draftSummary({ id: 'd1' })])
+    const w = mountV()
+    await flushPromises()
+    expect(w.find('.draft-editor-stub').exists()).toBe(false)
+  })
+
   // ── Withdraw from review ───────────────────────────────────────────────────
 
   it('offers Withdraw on an in-review row and not on a draft', async () => {

--- a/src/web/src/views/EditorView.spec.ts
+++ b/src/web/src/views/EditorView.spec.ts
@@ -3,7 +3,11 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia, type Pinia } from 'pinia'
 
 const { apiJson, apiFetch } = vi.hoisted(() => ({ apiJson: vi.fn(), apiFetch: vi.fn() }))
-vi.mock('@/lib/api', () => ({ apiJson, apiFetch }))
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  // Partial: keep the real apiErrorMessage so error text is formatted as it is in the app.
+  return { ...actual, apiJson, apiFetch }
+})
 
 import EditorView from './EditorView.vue'
 import { useAuthStore } from '@/stores/auth'
@@ -58,6 +62,63 @@ beforeEach(async () => {
 })
 
 describe('EditorView', () => {
+  // ── Withdraw from review ───────────────────────────────────────────────────
+
+  it('offers Withdraw on an in-review row and not on a draft', async () => {
+    mockWithPending([draftSummary()], [pendingItem()])
+    const w = mountV()
+    await flushPromises()
+
+    const rows = w.findAll('[data-testid="draft-row"]')
+    const withReview = rows.find(r => r.attributes('data-state') === 'in-review')!
+    const withDraft  = rows.find(r => r.attributes('data-state') === 'draft')!
+    expect(withReview.find('[data-testid="draft-row-withdraw"]').exists()).toBe(true)
+    expect(withDraft.find('[data-testid="draft-row-withdraw"]').exists()).toBe(false)
+  })
+
+  it('withdraws a submission back into drafts', async () => {
+    mockWithPending([], [pendingItem()])
+    apiFetch.mockResolvedValue(ok(draftSummary({ id: 'r1', title: 'Pending Article' })))
+    const w = mountV()
+    await flushPromises()
+
+    await w.find('[data-testid="draft-row-withdraw"]').trigger('click')
+    await flushPromises()
+
+    expect(apiFetch).toHaveBeenCalledWith('/articles/r1/withdraw', { method: 'POST' })
+    // It leaves review and arrives in drafts, so the row is editable rather than in-review.
+    const rows = w.findAll('[data-testid="draft-row"]')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].attributes('data-state')).toBe('draft')
+    expect(w.text()).toContain('back in your drafts')
+  })
+
+  it('does not withdraw when the confirm is dismissed', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => false))
+    mockWithPending([], [pendingItem()])
+    const w = mountV()
+    await flushPromises()
+
+    await w.find('[data-testid="draft-row-withdraw"]').trigger('click')
+    await flushPromises()
+    expect(apiFetch).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a refusal from the API', async () => {
+    mockWithPending([], [pendingItem()])
+    apiFetch.mockResolvedValue({ ok: false, status: 403, statusText: 'Forbidden', text: () => Promise.resolve('You can only withdraw your own submissions.') } as unknown as Response)
+    const w = mountV()
+    await flushPromises()
+
+    await w.find('[data-testid="draft-row-withdraw"]').trigger('click')
+    await flushPromises()
+
+    expect(w.find('[data-testid="withdraw-error"]').text()).toContain('your own submissions')
+    // ...and it is still in review, not silently moved.
+    expect(w.find('[data-testid="draft-row"]').attributes('data-state')).toBe('in-review')
+  })
+
+
   it('lists existing drafts', async () => {
     mockLists([draftSummary(), draftSummary({ id: 'd2', title: 'Second draft' })])
     const w = mountV()

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -2,13 +2,15 @@
 import { computed, nextTick, onMounted, ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import DraftEditor from '@/components/editor/DraftEditor.vue'
-import { apiFetch, apiJson } from '@/lib/api'
+import { apiErrorMessage, apiFetch, apiJson } from '@/lib/api'
 import { EMPTY_DRAFT, makeDraftId, type DraftPayload, type DraftSummary } from '@/lib/draft'
 import { useAuthStore } from '@/stores/auth'
+import { useEditorQueueStore } from '@/stores/editorQueue'
 
 const DRAFT_ID_KEY = 'slypn:editor:draft-id'
 
 const auth = useAuthStore()
+const editorQueue = useEditorQueueStore()
 
 // ── Draft list ──────────────────────────────────────────────────────────────
 const allDrafts   = ref<DraftSummary[]>([])
@@ -207,6 +209,35 @@ async function deleteDraft(id: string, etag?: string) {
   }
 }
 
+// ── Withdraw from review ─────────────────────────────────────────────────────
+// Pull a submission back out of the queue so it can be worked on again. The API
+// returns it to this author's drafts, keeping the body and, for a revision of
+// published content, the link to the article it replaces.
+const withdrawing    = ref<string | null>(null)
+const withdrawError  = ref<string | null>(null)
+
+async function withdraw(id: string) {
+  if (!confirm('Withdraw this submission from review? It goes back to your drafts and the admin queue no longer shows it.')) return
+  withdrawing.value = id
+  withdrawError.value = null
+  try {
+    const resp = await apiFetch(`/articles/${id}/withdraw`, { method: 'POST' })
+    if (!resp.ok) { withdrawError.value = await apiErrorMessage(resp); return }
+    const draft = await resp.json() as DraftSummary
+    // Leaves review, arrives in drafts. Close it if it was the item on screen —
+    // it was open read-only, and it is editable now.
+    pendingItems.value = pendingItems.value.filter(p => p.id !== id)
+    allDrafts.value = [draft, ...allDrafts.value.filter(d => d.id !== draft.id)]
+    if (draftId.value === id) { editorOpen.value = false; readonlyContent.value = null }
+    submitMessage.value = 'Withdrawn from review — it is back in your drafts.'
+    editorQueue.refresh()
+  } catch (err) {
+    withdrawError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    withdrawing.value = null
+  }
+}
+
 onMounted(() => { loadDraftList(); loadPending() })
 
 const fmtDate = (iso: string) =>
@@ -291,6 +322,15 @@ const fmtDate = (iso: string) =>
               title="Delete draft"
               @click="deleteDraft(e.id, e.etag)"
             >✕</button>
+            <button
+              v-else-if="e.state === 'in-review'"
+              type="button"
+              data-testid="draft-row-withdraw"
+              class="shrink-0 rounded px-2 py-1 text-xs font-semibold text-slypn-600 hover:bg-slypn-50 disabled:opacity-50"
+              title="Withdraw from review and edit again"
+              :disabled="withdrawing === e.id"
+              @click="withdraw(e.id)"
+            >Withdraw</button>
             <span v-else class="w-7 shrink-0" aria-hidden="true"></span>
           </div>
         </div>
@@ -305,6 +345,7 @@ const fmtDate = (iso: string) =>
             @click="openNewDraftDialog"
           >+ New draft</button>
           <p v-if="deleteError" class="text-xs text-rose-600">{{ deleteError }}</p>
+          <p v-if="withdrawError" data-testid="withdraw-error" class="text-xs text-rose-600">{{ withdrawError }}</p>
         </div>
       </div>
     </div>

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import DraftEditor from '@/components/editor/DraftEditor.vue'
 import { apiErrorMessage, apiFetch, apiJson } from '@/lib/api'
@@ -10,6 +11,7 @@ import { useEditorQueueStore } from '@/stores/editorQueue'
 const DRAFT_ID_KEY = 'slypn:editor:draft-id'
 
 const auth = useAuthStore()
+const route = useRoute()
 const editorQueue = useEditorQueueStore()
 
 // ── Draft list ──────────────────────────────────────────────────────────────
@@ -238,7 +240,15 @@ async function withdraw(id: string) {
   }
 }
 
-onMounted(() => { loadDraftList(); loadPending() })
+onMounted(async () => {
+  await Promise.all([loadDraftList(), loadPending()])
+  // Arriving from the edit affordance on a published page with a revision already in
+  // progress: open it directly rather than making them find it in the list.
+  const requested = route.query.draft
+  if (typeof requested === 'string' && allDrafts.value.some(d => d.id === requested)) {
+    openDraft(requested)
+  }
+})
 
 const fmtDate = (iso: string) =>
   new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })

--- a/src/web/src/views/views.misc.spec.ts
+++ b/src/web/src/views/views.misc.spec.ts
@@ -509,6 +509,29 @@ describe('BlogDetailView', () => {
 })
 
 describe('DashboardView', () => {
+  it('badges the Editor tile with the number of documents on the go', async () => {
+    const adminOid = '11111111-1111-1111-1111-111111111111'
+    apiFetch.mockImplementation((path: string) => {
+      const body = path === '/drafts' ? [{ id: 'd1' }, { id: 'd2' }]
+        : path === '/review/articles' ? [{ authorId: adminOid }]
+        : []
+      return Promise.resolve(jsonResponse(body))
+    })
+    await useAuthStore().initialize()
+    const w = mountView(DashboardView)
+    await flushPromises()
+    expect(w.find('[data-testid="dashboard-editor-badge"]').text()).toBe('3')
+  })
+
+  it('shows no Editor badge when there is nothing on the go', async () => {
+    apiFetch.mockResolvedValue(jsonResponse([]))
+    await useAuthStore().initialize()
+    const w = mountView(DashboardView)
+    await flushPromises()
+    expect(w.find('[data-testid="dashboard-editor-badge"]').exists()).toBe(false)
+  })
+
+
   it('greets the signed-in admin and shows admin tiles', async () => {
     apiFetch.mockResolvedValue(jsonResponse([]))
     const auth = useAuthStore()


### PR DESCRIPTION
Eight commits on the authoring loop. It started as "show a count and let people withdraw", and grew as each change surfaced the next problem — including two bugs that were losing or duplicating people's work.

Each commit is independently green, so this is reviewable commit by commit.

---

## 1. Seeing what you have on the go

A badge on the **Editor** nav link and the **dashboard Editor tile**: open drafts plus your own submissions awaiting review.

**Your own, not everyone's.** `/review/*` is filtered to the caller for a Contributor, but an Admin legitimately sees everybody's. Counting those would tell an admin they had twelve documents open when they had none.

The badge markup was hard-wired to `approvalsStore.pendingCount` at both render sites, so `badge` became the count itself rather than a boolean. That renames the `approvals-badge` testid to `nav-badge` + `data-for`, since there are two badges now.

## 2. Withdrawing from review

`POST /api/articles/{id}/withdraw`, with a **Withdraw** button on in-review rows in the editor. It reuses the transition already behind `/revise` — the same move, minus the feedback note — so the body and `ReplacesArticleId` survive. Withdrawing a *revision* keeps its link to the published article, which stays live throughout.

**Author-only, no admin bypass, deliberately.** An admin returning someone else's work uses `/revise`, which requires 5–1000 characters of feedback and so leaves the author a reason. Giving withdraw an admin path would be a way around that. Tested both ways: the admin gets 403 on withdraw and succeeds on revise for the same item.

## 3. 🐞 Re-editing a revision destroyed your work

`CreateRevisionDraftAsync` found an in-progress revision and reused its **id** — so no duplicate appeared — but then rebuilt the record from the published article and upserted it, body blob included:

```csharp
Id:    existing?.Id ?? Guid.NewGuid()...,   // reused the id
Title: published.Title,                     // ...and reset everything else
Body:  published.Body,
```

Clicking Edit a second time on something you were part-way through revising **silently threw those edits away**. It now returns the existing draft untouched, with no write at all.

## 4. 🐞 Two competing revisions of one article

Clicking Edit on something you'd already *submitted* a revision for minted a second revision draft, putting two competing revisions of one article in the approvals queue.

The endpoint now looks for your own in-review revision before minting anything. Checked across **both content types** — `ListArticlesAsync` is filtered to articles, so looking there alone would miss a blog revision and mint the competing draft anyway.

## 5. Where Edit takes you

| Situation | Response | Result |
|---|---|---|
| Nothing on the go | `201` | Modal opens in place |
| Revision draft in progress | `200` | → `/editor?item=<id>`, **editable** |
| Revision awaiting review | `200` | → `/editor?item=<id>`, **read-only** |

The editor resolves that id against drafts and submissions together, so it opens the right way round without being told which — and only ever matches your own work, so a hand-typed id can't open someone else's.

`/admin/content` is untouched: it already shows these with a "Revision pending" badge and Edit disabled, which is the read-only display we want there.

## 6. Not every refusal is a failure

Submitting a revision identical to the published article used to queue an item for an admin to approve for nothing. It's now refused — but as **information, in blue**, not an error in red:

> ℹ This revision is identical to the published version, so there is nothing to review. Make a change first, or close the editor to discard it.

**Guarded server-side, not by greying out the button**, for two reasons:

1. `isDirty()` compares against the snapshot taken at **load**, and `save()` never refreshes it — so a plain draft written yesterday and reopened today isn't dirty, yet submitting it is exactly what you came back to do.
2. Even scoped to revisions, the client only knows what the published version looked like during the session that created the draft.

Only fires for a revision, gated on `ReplacesArticleId` first — an ordinary draft never reaches the comparison. It's a distinct `409` with its own exception type, so the UI can tell "nothing to do" from "that went wrong" without matching on message text.

## 7. Field limits you can see

The caps were invisible until you hit one. Title, Category and Summary each had a bare `maxlength`, so input silently stopped mid-word — which reads as the app breaking. The body had no client guard at all.

- **Counters** on all four fields, hidden until 80% of the limit so a normal field looks untouched, then amber and explicit at the cap.
- **The body now stops too** — `handleTextInput` / `handlePaste` / `handleDrop` refuse once full. Only insertions are blocked, so a full document can always be edited back down. An oversized paste is measured and rejected rather than landing and overshooting.
- **A clear button on Category**, which had no way back to empty once set.

## 8. Counting text, not markup

The counter charged for HTML, so a paragraph of links cost far more than the same words plain, and the figure bore no relation to the page.

Counting text means *enforcing* text, or the number shown and the point input stops disagree. So **50,000 changed role**:

| | Before | Now |
|---|---|---|
| What an author meets | HTML length | **50,000 characters of text** |
| Server cap | 50,000 on HTML | **200,000 on HTML — a transport backstop** |

The backstop has to sit above the text limit: 50,000 characters of text is easily 70–90k of HTML once formatted, and matching them would let the editor reach a limit the API then rejected. Bodies live in blob storage, which doesn't care either way. Text length is measured once per change and passed down, so the parse doesn't happen twice per keystroke.

⚠️ **This is the one judgement call worth a second opinion** — it came from reading "make body 50,000 chars" plus "true character count" together. If you'd rather the hard cap stayed 50,000 HTML and the text limit came down to ~20,000, that's a small change.

---

## Existing tests that changed meaning

Called out because a reviewer should check these weren't just made green:

- `Passthrough_when_function_has_no_RequireRole` used `GetBlogPosts` as its example of an *unattributed* function; it now points at `GetResources`.
- The pending-listing tests passed a principal-less context and asserted a full list; they now use an Admin, and the filtering has its own test.
- `EditContentButton.spec` returned **200** for what it called a freshly-created revision. Under the new contract that means "resumed", so those fixtures moved to 201.
- `EditorView.spec` had no router, so `useRoute()` came back undefined once the view read `route.query`.

Two harness bugs fixed rather than worked around:

- `DraftEditor.spec`'s `resp()` helper hard-coded `text: () => ''`, ignoring the body — **any assertion about a plain-text response body was silently unfalsifiable**.
- `EditorView.spec` mocked `@/lib/api` wholesale, which broke as soon as the view imported `apiErrorMessage`; it's now a partial mock via `importOriginal`, matching the other specs.

## Verification

- **API**: `dotnet build -warnaserror` → 0 warnings, 0 errors; **371 tests** (was 351)
- **Web**: lint clean; **457 unit tests** (was 428); `npm run build` (vue-tsc) clean
- **E2E**: 4 specs added, **not run locally** — the harness fails to start Azurite on this machine (`spawn EINVAL` in `e2e/support/backend.ts`, before any test runs). They typecheck and lint; CI is the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
