### PR TITLE
feat: editor field limits, text counting, and a competing-revision bug

### DIFF
--- a/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ArticlesFunctionsTests.cs
@@ -558,6 +558,73 @@ public class ArticlesFunctionsTests
         new TestFunctionContext().WithUser("oid-author", "Ann", "Contributor");
 
     [Fact]
+    public async Task Edit_hands_back_the_submission_when_a_revision_is_already_awaiting_review()
+    {
+        // Nothing to edit until an admin has dealt with it, and a second draft would put
+        // two competing revisions of one article in the queue. 200 tells the client to
+        // show the submission — read-only — rather than open a fresh editor.
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.Articles.Add(Sample("pending") with { AuthorId = "oid-author", ReplacesArticleId = "a1" });
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("pending", resp.ReadBodyAs<Article>()!.Id);
+    }
+
+    [Fact]
+    public async Task Edit_finds_an_in_review_revision_of_a_blog_post_too()
+    {
+        // ListArticlesAsync is filtered to articles, so checking it alone would miss a
+        // blog revision and mint a competing draft.
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author", Type = "blog" };
+        repo.Blogs.Add(Sample("pending-blog") with { AuthorId = "oid-author", Type = "blog", ReplacesArticleId = "a1" });
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("pending-blog", resp.ReadBodyAs<Article>()!.Id);
+    }
+
+    [Fact]
+    public async Task Edit_ignores_another_authors_in_review_revision()
+    {
+        // Someone else revising the same article must not block this author, and must
+        // not have their submission handed over either.
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.Articles.Add(Sample("theirs") with { AuthorId = "someone-else", ReplacesArticleId = "a1" });
+        repo.RevisionResumes = false;
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Edit_ignores_an_in_review_item_that_replaces_a_different_article()
+    {
+        var (fn, repo) = Make();
+        repo.ArticleByIdAndStatus = Sample() with { AuthorId = "oid-author" };
+        repo.Articles.Add(Sample("other") with { AuthorId = "oid-author", ReplacesArticleId = "a-different-one" });
+        repo.RevisionResumes = false;
+        var ctx = Author();
+
+        var resp = (TestHttpResponseData)await fn.Edit(
+            TestHttp.Raw(ctx, "POST", "http://localhost/api/articles/a1/edit", ""), ctx, "a1", Ct);
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    [Fact]
     public async Task Edit_returns_201_when_it_mints_a_new_revision()
     {
         var (fn, repo) = Make();

--- a/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
+++ b/src/api/Slypn.Api/Functions/ArticlesFunctions.cs
@@ -272,6 +272,13 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
             if (!ArticleVisibility.MayEdit(published, context))
                 return await Forbidden(req, EditOwnershipRefusal);
 
+            // Already submitted a revision of this item? There is nothing to edit until an
+            // admin has dealt with it, and minting a second draft would put two competing
+            // revisions of one article in the queue. Hand back the submission so the client
+            // can show it — read-only — rather than opening a fresh editor.
+            var awaitingReview = await FindOwnRevisionInReviewAsync(id, editorOid, ct);
+            if (awaitingReview is not null) return await Ok(req, awaitingReview.ForPublic(context));
+
             var (draft, resumed) = await repo.CreateRevisionDraftAsync(id, editorOid, editorName, ct);
             // 200 when we handed back a revision this author already had on the go, 201 when
             // one was minted. The client sends them to the editor in the first case rather
@@ -284,6 +291,17 @@ public sealed class ArticlesFunctions(IContentRepository repo, IHtmlSanitizer sa
         catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
     }
 
+
+    /// <summary>The caller's own in-review revision of this article, if they have one.
+    /// Checks both content types: a blog post is an Article row with Type == "blog", and
+    /// ListArticlesAsync is filtered to articles, so it alone would miss blog revisions.</summary>
+    private async Task<Article?> FindOwnRevisionInReviewAsync(string articleId, string editorOid, CancellationToken ct)
+    {
+        var articles = await repo.ListArticlesAsync(InReviewStatus, ct);
+        var blogs    = await repo.ListBlogPostsAsync(InReviewStatus, ct);
+        return articles.Concat(blogs).FirstOrDefault(a =>
+            a.ReplacesArticleId == articleId && a.AuthorId == editorOid);
+    }
     /// <summary>
     /// Request deletion of a published article (pending admin approval). The article stays
     /// live until an admin approves the deletion via DELETE.

--- a/src/api/Slypn.Api/Models/Inputs/ArticleInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/ArticleInput.cs
@@ -13,7 +13,8 @@ public sealed class ArticleInput
     [Required, StringLength(500, MinimumLength = 10)]
     public string Summary { get; set; } = "";
 
-    [Required, StringLength(50_000, MinimumLength = 10)]
+    // See DraftInput.Body — 200,000 is the HTML backstop, not the authoring limit.
+    [Required, StringLength(200_000, MinimumLength = 10)]
     public string Body { get; set; } = "";
 
     [Required, StringLength(120)]

--- a/src/api/Slypn.Api/Models/Inputs/DraftInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/DraftInput.cs
@@ -15,7 +15,11 @@ public sealed class DraftInput
     [StringLength(200)] public string Title { get; set; } = "";
     [StringLength(120)] public string Slug { get; set; } = "";
     [StringLength(500)] public string Summary { get; set; } = "";
-    [StringLength(50_000)] public string Body { get; set; } = "";
+    // The limit authors see is 50,000 characters of *text*, enforced in the editor.
+    // This is the transport backstop on the HTML that carries it: markup, links and
+    // image URLs all add weight, so it needs room above the text limit rather than
+    // matching it. Bodies live in blob storage, which does not care either way.
+    [StringLength(200_000)] public string Body { get; set; } = "";
     [StringLength(60)]  public string Category { get; set; } = "";
 
     [Range(0, 60)]

--- a/src/web/src/components/common/EditContentButton.spec.ts
+++ b/src/web/src/components/common/EditContentButton.spec.ts
@@ -50,7 +50,7 @@ beforeEach(async () => {
 })
 
 describe('EditContentButton', () => {
-  it('goes to the editor when a revision is already on the go', async () => {
+  it('goes to the editor when work is already on the go for this article', async () => {
     // 200 means the API handed back an existing revision rather than minting one, so
     // opening a modal here would be a second window onto work in progress.
     apiFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK', json: () => Promise.resolve({ id: 'draft-7' }), text: () => Promise.resolve('') } as unknown as Response)
@@ -58,7 +58,7 @@ describe('EditContentButton', () => {
     await w.find('[data-testid="edit-content"]').trigger('click')
     await flushPromises()
 
-    expect(push).toHaveBeenCalledWith({ path: '/editor', query: { draft: 'draft-7' } })
+    expect(push).toHaveBeenCalledWith({ path: '/editor', query: { item: 'draft-7' } })
     expect(w.find('.draft-editor-stub').exists()).toBe(false)
   })
 

--- a/src/web/src/components/common/EditContentButton.vue
+++ b/src/web/src/components/common/EditContentButton.vue
@@ -33,11 +33,12 @@ async function startEdit() {
     if (!resp.ok) throw new Error(await apiErrorMessage(resp))
     const draft = await resp.json() as { id: string }
 
-    // 200 means the API handed back a revision this author already had on the go, rather
-    // than minting one. Opening it in a modal here would be a second window onto work in
-    // progress, so send them to the editor where it sits alongside the rest of their queue.
+    // 200 means this author already has something on the go for this article — either a
+    // revision draft, or one already submitted and awaiting review. Opening a modal here
+    // would be a second window onto that work, so send them to the editor, which shows a
+    // draft for editing and a submission read-only.
     if (resp.status === 200) {
-      await router.push({ path: '/editor', query: { draft: draft.id } })
+      await router.push({ path: '/editor', query: { item: draft.id } })
       return
     }
     editDraftId.value = draft.id

--- a/src/web/src/components/editor/DraftEditor.spec.ts
+++ b/src/web/src/components/editor/DraftEditor.spec.ts
@@ -47,6 +47,53 @@ const mountEditor = (props: Record<string, unknown> = {}) =>
 beforeEach(() => apiFetch.mockReset())
 
 describe('DraftEditor', () => {
+  // ── Field limits ───────────────────────────────────────────────────────────
+  // maxlength stops typing silently, which reads as the app breaking rather than a
+  // limit being reached. The counters appear once the limit is close enough to matter.
+
+  it('hides the summary counter until the limit is close', async () => {
+    const w = mountEditor()
+    await flushPromises()
+    expect(w.find('[data-testid="draft-summary-count"]').exists()).toBe(false)
+
+    await w.find('#draft-summary').setValue('x'.repeat(399)) // 79.8% of 500
+    expect(w.find('[data-testid="draft-summary-count"]').exists()).toBe(false)
+  })
+
+  it('shows the summary counter as it fills, and says so at the limit', async () => {
+    const w = mountEditor()
+    await flushPromises()
+
+    await w.find('#draft-summary').setValue('x'.repeat(450))
+    const counter = w.find('[data-testid="draft-summary-count"]')
+    expect(counter.text()).toContain('450 / 500')
+    expect(counter.text()).not.toContain('limit reached')
+
+    await w.find('#draft-summary').setValue('x'.repeat(500))
+    expect(w.find('[data-testid="draft-summary-count"]').text()).toContain('limit reached')
+  })
+
+  it('counts the title and category too', async () => {
+    const w = mountEditor()
+    await flushPromises()
+    await w.find('#draft-title').setValue('t'.repeat(180))
+    await w.find('#draft-category').setValue('c'.repeat(55))
+    expect(w.find('[data-testid="draft-title-count"]').text()).toContain('180 / 200')
+    expect(w.find('[data-testid="draft-category-count"]').text()).toContain('55 / 60')
+  })
+
+  it('clears the category', async () => {
+    const w = mountEditor()
+    await flushPromises()
+    await w.find('#draft-category').setValue('Community')
+    expect(w.find('[data-testid="draft-category-clear"]').exists()).toBe(true)
+
+    await w.find('[data-testid="draft-category-clear"]').trigger('click')
+    expect((w.find('#draft-category').element as HTMLInputElement).value).toBe('')
+    // The control goes away with nothing to clear.
+    expect(w.find('[data-testid="draft-category-clear"]').exists()).toBe(false)
+  })
+
   it('loads the draft and fills the form', async () => {
     mockApi()
     const w = mountEditor()

--- a/src/web/src/components/editor/DraftEditor.spec.ts
+++ b/src/web/src/components/editor/DraftEditor.spec.ts
@@ -73,6 +73,28 @@ describe('DraftEditor', () => {
     expect(w.find('[data-testid="draft-summary-count"]').text()).toContain('limit reached')
   })
 
+
+  it('counts the body as text the reader sees, not as markup', async () => {
+    // 45,000 visible characters, but far more than that as HTML once every paragraph
+    // wrapper and link href is counted. Charging for markup the reader never sees would
+    // make the figure meaningless — and would stop an author well short of the limit.
+    const visible = 'x'.repeat(45_000)
+    const body = `<p><a href="https://example.com/a/fairly/long/url">${visible}</a></p>`
+    expect(body.length).toBeGreaterThan(45_050)
+
+    mockApi((url, method) => {
+      if (url.startsWith('/drafts/') && method === 'GET') return resp({ ...draftPayload, body })
+      return undefined
+    })
+    const w = mountEditor()
+    await flushPromises()
+
+    const counter = w.find('[data-testid="draft-body-count"]')
+    expect(counter.exists()).toBe(true)
+    expect(counter.text()).toContain('45000 / 50000')
+    expect(counter.text()).not.toContain('limit reached')
+  })
+
   it('counts the title and category too', async () => {
     const w = mountEditor()
     await flushPromises()

--- a/src/web/src/components/editor/DraftEditor.vue
+++ b/src/web/src/components/editor/DraftEditor.vue
@@ -87,11 +87,11 @@ async function save(value: DraftPayload) {
   // for content that arrived over it (an older draft, or a write through the API). Caught
   // here rather than letting the API answer, so the author gets a sentence they can act on
   // instead of "The field Body must be a string with a maximum length of 50000".
-  if (value.body.length > LIMITS.body) {
+  const bodyChars = htmlToText(value.body).length
+  if (bodyChars > LIMITS.body) {
     throw new Error(
-      `This piece is too long to save — ${value.body.length.toLocaleString()} characters of `
-      + `formatting and text, against a limit of ${LIMITS.body.toLocaleString()}. `
-      + 'Shorten it, or split it into two pieces.',
+      `This piece is too long to save — ${bodyChars.toLocaleString()} characters, against a `
+      + `limit of ${LIMITS.body.toLocaleString()}. Shorten it, or split it into two pieces.`,
     )
   }
 
@@ -216,7 +216,11 @@ function counterFor(used: number, max: number) {
 const titleCount    = computed(() => counterFor(draft.value.title.length, LIMITS.title))
 const summaryCount  = computed(() => counterFor(draft.value.summary.length, LIMITS.summary))
 const categoryCount = computed(() => counterFor(draft.value.category.length, LIMITS.category))
-const bodyCount     = computed(() => counterFor(draft.value.body.length, LIMITS.body))
+// Counted as an author reads it, not as it is stored: markup, link hrefs and image
+// URLs do not show on the page, so charging for them would make the number meaningless.
+// The editor blocks input against this same figure, so the count and the stop agree.
+const bodyTextLength = computed(() => htmlToText(draft.value.body).length)
+const bodyCount      = computed(() => counterFor(bodyTextLength.value, LIMITS.body))
 
 const missingToSubmit = computed(() => {
   const missing: string[] = []
@@ -413,6 +417,7 @@ watch(() => draft.value.body, (html) => {
       v-model="draft.body"
       :readonly="readonly"
       :max-length="LIMITS.body"
+      :current-length="bodyTextLength"
       @upload-error="(msg) => uploadError = msg"
     />
     <!-- Only once it starts to matter. Counts HTML, which is what the limit applies to,

--- a/src/web/src/components/editor/DraftEditor.vue
+++ b/src/web/src/components/editor/DraftEditor.vue
@@ -36,6 +36,10 @@ const conflict = ref<ConflictState | null>(null)
 
 // Snapshot of the content as loaded, so callers can tell whether the user
 // actually changed anything (e.g. to discard an untouched revision draft).
+// Field caps, mirroring DraftInput/ArticleInput server-side. Kept here so the counters
+// and the maxlength attributes cannot drift from each other.
+const LIMITS = { title: 200, summary: 500, category: 60, body: 50_000 } as const
+
 const loadedSnapshot = ref('')
 function snapshot(d: DraftPayload): string {
   return JSON.stringify({
@@ -78,6 +82,18 @@ async function loadDraft(id: string) {
 
 async function save(value: DraftPayload) {
   if (props.readonly || switching.value || !value.title.trim()) return
+
+  // A backstop: the editor refuses input at the limit, so this should only be reachable
+  // for content that arrived over it (an older draft, or a write through the API). Caught
+  // here rather than letting the API answer, so the author gets a sentence they can act on
+  // instead of "The field Body must be a string with a maximum length of 50000".
+  if (value.body.length > LIMITS.body) {
+    throw new Error(
+      `This piece is too long to save — ${value.body.length.toLocaleString()} characters of `
+      + `formatting and text, against a limit of ${LIMITS.body.toLocaleString()}. `
+      + 'Shorten it, or split it into two pieces.',
+    )
+  }
 
   const headers: Record<string, string> = {}
   if (currentEtag.value) headers['If-Match'] = currentEtag.value
@@ -190,6 +206,17 @@ function hasBodyContent(html: string): boolean {
   if (/<img\b/i.test(html)) return true
   return htmlToText(html).trim().length > 0
 }
+
+// Show a counter only once it starts to matter — a permanent "3 / 200" under every
+// field is noise. Below the threshold the field looks as it always did.
+function counterFor(used: number, max: number) {
+  if (used < max * 0.8) return null
+  return { text: `${used} / ${max}`, atLimit: used >= max }
+}
+const titleCount    = computed(() => counterFor(draft.value.title.length, LIMITS.title))
+const summaryCount  = computed(() => counterFor(draft.value.summary.length, LIMITS.summary))
+const categoryCount = computed(() => counterFor(draft.value.category.length, LIMITS.category))
+const bodyCount     = computed(() => counterFor(draft.value.body.length, LIMITS.body))
 
 const missingToSubmit = computed(() => {
   const missing: string[] = []
@@ -309,24 +336,51 @@ watch(() => draft.value.body, (html) => {
           class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm read-only:bg-slypn-50 read-only:text-slypn-600 focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
         />
         <p v-if="!readonly && !draft.title.trim()" class="mt-1 text-xs text-slypn-400">Add a title to start saving.</p>
+        <p
+          v-if="!readonly && titleCount"
+          data-testid="draft-title-count"
+          class="mt-1 text-right text-xs"
+          :class="titleCount!.atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
+        >{{ titleCount!.text }}{{ titleCount!.atLimit ? ' — limit reached' : '' }}</p>
       </div>
 
       <div>
         <label for="draft-category" class="block text-sm font-medium text-slypn-800">Category</label>
-        <input
-          id="draft-category"
-          v-model="draft.category"
-          type="text"
-          maxlength="60"
-          :readonly="readonly"
-          list="draft-category-hints"
-          autocomplete="off"
-          placeholder="Pick an existing one or type a new category"
-          class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm read-only:bg-slypn-50 read-only:text-slypn-600 focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
-        />
+        <div class="relative">
+          <input
+            id="draft-category"
+            v-model="draft.category"
+            type="text"
+            maxlength="60"
+            :readonly="readonly"
+            list="draft-category-hints"
+            autocomplete="off"
+            placeholder="Pick an existing one or type a new category"
+            class="mt-1 w-full rounded-md border border-slypn-200 bg-white py-2 pl-3 pr-9 text-sm shadow-sm read-only:bg-slypn-50 read-only:text-slypn-600 focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+          />
+          <button
+            v-if="!readonly && draft.category"
+            type="button"
+            data-testid="draft-category-clear"
+            aria-label="Clear category"
+            title="Clear category"
+            class="absolute inset-y-0 right-0 mt-1 flex items-center rounded-r-md px-2.5 text-slypn-400 transition-colors hover:text-slypn-700"
+            @click="draft.category = ''"
+          >
+            <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+              <path d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        </div>
         <datalist id="draft-category-hints">
           <option v-for="c in categoryHints" :key="c" :value="c" />
         </datalist>
+        <p
+          v-if="!readonly && categoryCount"
+          data-testid="draft-category-count"
+          class="mt-1 text-right text-xs"
+          :class="categoryCount!.atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
+        >{{ categoryCount!.text }}{{ categoryCount!.atLimit ? ' — limit reached' : '' }}</p>
       </div>
 
       <div>
@@ -339,6 +393,12 @@ watch(() => draft.value.body, (html) => {
           :readonly="readonly"
           class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm read-only:bg-slypn-50 read-only:text-slypn-600 focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
         />
+        <p
+          v-if="!readonly && summaryCount"
+          data-testid="draft-summary-count"
+          class="mt-1 text-right text-xs"
+          :class="summaryCount!.atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
+        >{{ summaryCount!.text }}{{ summaryCount!.atLimit ? ' — limit reached' : '' }}</p>
       </div>
 
       <div>
@@ -352,8 +412,19 @@ watch(() => draft.value.body, (html) => {
     <RichTextEditor
       v-model="draft.body"
       :readonly="readonly"
+      :max-length="LIMITS.body"
       @upload-error="(msg) => uploadError = msg"
     />
+    <!-- Only once it starts to matter. Counts HTML, which is what the limit applies to,
+         so it runs ahead of the visible word count on a heavily formatted piece. -->
+    <p
+      v-if="!readonly && bodyCount"
+      data-testid="draft-body-count"
+      class="text-right text-xs"
+      :class="bodyCount!.atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
+    >
+      {{ bodyCount!.text }} characters{{ bodyCount!.atLimit ? ' — limit reached' : '' }}
+    </p>
 
     <p v-if="!readonly && uploadError" data-testid="draft-upload-error" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
       Image upload failed: {{ uploadError }}

--- a/src/web/src/components/editor/RichTextEditor.spec.ts
+++ b/src/web/src/components/editor/RichTextEditor.spec.ts
@@ -15,6 +15,29 @@ const mountEditor = (props: Record<string, unknown> = {}) =>
 beforeEach(() => apiFetch.mockReset())
 
 describe('RichTextEditor', () => {
+  // ── Length limit ───────────────────────────────────────────────────────────
+  // Measured in HTML, which is what the API caps. The handlers that consume this
+  // (handleTextInput / handlePaste / handleDrop) only fire on insertion, so a full
+  // document can always be edited back down.
+
+  it('is not full below the limit', () => {
+    const w = mountEditor({ modelValue: 'x'.repeat(39), maxLength: 40 })
+    expect((w.vm as unknown as { isFull: () => boolean }).isFull()).toBe(false)
+  })
+
+  it('is full at the limit and beyond', () => {
+    const at = mountEditor({ modelValue: 'x'.repeat(40), maxLength: 40 })
+    expect((at.vm as unknown as { isFull: () => boolean }).isFull()).toBe(true)
+
+    const over = mountEditor({ modelValue: 'x'.repeat(60), maxLength: 40 })
+    expect((over.vm as unknown as { isFull: () => boolean }).isFull()).toBe(true)
+  })
+
+  it('has no limit when maxLength is not given', () => {
+    const w = mountEditor({ modelValue: 'x'.repeat(100_000) })
+    expect((w.vm as unknown as { isFull: () => boolean }).isFull()).toBe(false)
+  })
+
   it('renders the formatting toolbar', () => {
     const w = mountEditor()
     const labels = w.findAll('button').map(b => b.text())

--- a/src/web/src/components/editor/RichTextEditor.spec.ts
+++ b/src/web/src/components/editor/RichTextEditor.spec.ts
@@ -16,26 +16,36 @@ beforeEach(() => apiFetch.mockReset())
 
 describe('RichTextEditor', () => {
   // ── Length limit ───────────────────────────────────────────────────────────
-  // Measured in HTML, which is what the API caps. The handlers that consume this
-  // (handleTextInput / handlePaste / handleDrop) only fire on insertion, so a full
-  // document can always be edited back down.
+  // Counted in visible text, not HTML, so the figure matches what the author sees.
+  // The parent measures it once per change and passes it down as currentLength.
+  // The handlers that consume this only fire on insertion, so a full document can
+  // always be edited back down.
+
+  const isFull = (w: ReturnType<typeof mountEditor>) =>
+    (w.vm as unknown as { isFull: () => boolean }).isFull()
 
   it('is not full below the limit', () => {
-    const w = mountEditor({ modelValue: 'x'.repeat(39), maxLength: 40 })
-    expect((w.vm as unknown as { isFull: () => boolean }).isFull()).toBe(false)
+    expect(isFull(mountEditor({ maxLength: 40, currentLength: 39 }))).toBe(false)
   })
 
   it('is full at the limit and beyond', () => {
-    const at = mountEditor({ modelValue: 'x'.repeat(40), maxLength: 40 })
-    expect((at.vm as unknown as { isFull: () => boolean }).isFull()).toBe(true)
-
-    const over = mountEditor({ modelValue: 'x'.repeat(60), maxLength: 40 })
-    expect((over.vm as unknown as { isFull: () => boolean }).isFull()).toBe(true)
+    expect(isFull(mountEditor({ maxLength: 40, currentLength: 40 }))).toBe(true)
+    expect(isFull(mountEditor({ maxLength: 40, currentLength: 60 }))).toBe(true)
   })
 
   it('has no limit when maxLength is not given', () => {
-    const w = mountEditor({ modelValue: 'x'.repeat(100_000) })
-    expect((w.vm as unknown as { isFull: () => boolean }).isFull()).toBe(false)
+    expect(isFull(mountEditor({ currentLength: 100_000 }))).toBe(false)
+  })
+
+  it('counts text, so markup does not eat the allowance', () => {
+    // A short sentence wrapped in a link is long as HTML and short as text. The
+    // parent decides that; this asserts the editor trusts the figure it is given.
+    const w = mountEditor({
+      modelValue: '<p><a href="https://example.com/a/very/long/url">hi</a></p>',
+      maxLength: 40,
+      currentLength: 2,
+    })
+    expect(isFull(w)).toBe(false)
   })
 
   it('renders the formatting toolbar', () => {

--- a/src/web/src/components/editor/RichTextEditor.vue
+++ b/src/web/src/components/editor/RichTextEditor.vue
@@ -11,8 +11,10 @@ const props = defineProps<{
   modelValue: string
   placeholder?: string
   readonly?: boolean
-  /** Hard stop, measured in characters of HTML — the same thing the API limits. */
+  /** Hard stop, in characters of visible text. */
   maxLength?: number
+  /** Current text length, computed by the parent so it is measured once per change. */
+  currentLength?: number
 }>()
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void
@@ -21,10 +23,19 @@ const emit = defineEmits<{
 
 const fileInput = ref<HTMLInputElement | null>(null)
 
-// True once there is no room left. Returning true from a ProseMirror handler marks the
-// event handled, which swallows it — so the keystroke or paste simply does not land.
+// Characters still available. Returning true from a ProseMirror handler marks the event
+// handled, which swallows it — so the keystroke or paste simply does not land.
+function remaining(): number {
+  if (props.maxLength === undefined) return Number.POSITIVE_INFINITY
+  return props.maxLength - (props.currentLength ?? 0)
+}
 function atLimit(): boolean {
-  return props.maxLength !== undefined && props.modelValue.length >= props.maxLength
+  return remaining() <= 0
+}
+
+/** Text a paste would add, so an oversized one is refused rather than overshooting. */
+function pastedLength(slice: { content: { size: number, textBetween: (f: number, t: number, s: string) => string } }): number {
+  return slice.content.textBetween(0, slice.content.size, ' ').length
 }
 const uploading = ref(false)
 
@@ -53,8 +64,8 @@ const editor = new Editor({
     // blocked — these handlers never fire for a deletion — so the author can always get
     // back under the limit. Measured on the HTML, because that is what the API counts:
     // a paragraph of links costs more than the same words in plain text.
-    handleTextInput: () => atLimit(),
-    handlePaste:     () => atLimit(),
+    handleTextInput: (_view, _from, _to, text) => remaining() < text.length,
+    handlePaste:     (_view, _event, slice) => remaining() < pastedLength(slice),
     handleDrop:      () => atLimit(),
   },
   onUpdate: ({ editor }) => emit('update:modelValue', editor.getHTML()),

--- a/src/web/src/components/editor/RichTextEditor.vue
+++ b/src/web/src/components/editor/RichTextEditor.vue
@@ -11,6 +11,8 @@ const props = defineProps<{
   modelValue: string
   placeholder?: string
   readonly?: boolean
+  /** Hard stop, measured in characters of HTML — the same thing the API limits. */
+  maxLength?: number
 }>()
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void
@@ -18,6 +20,12 @@ const emit = defineEmits<{
 }>()
 
 const fileInput = ref<HTMLInputElement | null>(null)
+
+// True once there is no room left. Returning true from a ProseMirror handler marks the
+// event handled, which swallows it — so the keystroke or paste simply does not land.
+function atLimit(): boolean {
+  return props.maxLength !== undefined && props.modelValue.length >= props.maxLength
+}
 const uploading = ref(false)
 
 const editor = new Editor({
@@ -41,9 +49,19 @@ const editor = new Editor({
     attributes: {
       class: 'prose prose-slypn focus:outline-none max-w-none min-h-[20rem] px-4 py-3',
     },
+    // Refuse anything that would add to an already-full document. Only insertions are
+    // blocked — these handlers never fire for a deletion — so the author can always get
+    // back under the limit. Measured on the HTML, because that is what the API counts:
+    // a paragraph of links costs more than the same words in plain text.
+    handleTextInput: () => atLimit(),
+    handlePaste:     () => atLimit(),
+    handleDrop:      () => atLimit(),
   },
   onUpdate: ({ editor }) => emit('update:modelValue', editor.getHTML()),
 })
+
+/** Whether the document has hit maxLength. Exposed so it can be asserted directly. */
+defineExpose({ isFull: atLimit })
 
 // Sync external value changes back into TipTap (e.g. when loading a draft).
 watch(() => props.modelValue, (value) => {

--- a/src/web/src/views/EditorView.spec.ts
+++ b/src/web/src/views/EditorView.spec.ts
@@ -70,17 +70,29 @@ beforeEach(async () => {
 })
 
 describe('EditorView', () => {
-  it('opens the draft named by ?draft= on arrival', async () => {
+  it('opens the draft named by ?item= on arrival', async () => {
     // Arriving from the edit affordance with a revision already in progress.
-    route.query = { draft: 'd1' }
+    route.query = { item: 'd1' }
     mockLists([draftSummary({ id: 'd1' })])
     const w = mountV()
     await flushPromises()
     expect(w.find('.draft-editor-stub').exists()).toBe(true)
   })
 
-  it('ignores a ?draft= that is not one of theirs', async () => {
-    route.query = { draft: 'someone-elses' }
+  it('opens a submission awaiting review read-only when named by ?item=', async () => {
+    // Arriving from the edit affordance on an article whose revision is already in the
+    // approvals queue: there is nothing to edit until an admin has dealt with it.
+    route.query = { item: 'r1' }
+    mockWithPending([], [pendingItem({ id: 'r1' })])
+    const w = mountV()
+    await flushPromises()
+    const editor = w.findComponent(DraftEditorStub)
+    expect(editor.exists()).toBe(true)
+    expect(editor.props('readonly')).toBe(true)
+  })
+
+  it('ignores an ?item= that is not one of theirs', async () => {
+    route.query = { item: 'someone-elses' }
     mockLists([draftSummary({ id: 'd1' })])
     const w = mountV()
     await flushPromises()

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -242,11 +242,14 @@ async function withdraw(id: string) {
 
 onMounted(async () => {
   await Promise.all([loadDraftList(), loadPending()])
-  // Arriving from the edit affordance on a published page with a revision already in
-  // progress: open it directly rather than making them find it in the list.
-  const requested = route.query.draft
-  if (typeof requested === 'string' && allDrafts.value.some(d => d.id === requested)) {
-    openDraft(requested)
+  // Arriving from the edit affordance on a published page that already has work in
+  // progress. Resolved against the merged list so it opens the right way round: a draft
+  // is editable, a submission awaiting review opens read-only. Only ever one of the
+  // caller's own, so a hand-typed id cannot open someone else's.
+  const requested = route.query.item
+  if (typeof requested === 'string') {
+    const entry = entries.value.find(e => e.id === requested)
+    if (entry) onRowClick(entry)
   }
 })
 


### PR DESCRIPTION
The tail of the work from #188. Those three commits landed on the branch after #188 had already been squash-merged, so they never made it into main — cherry-picked onto current main here rather than replaying the merged five.

Three commits, each independently green.

---

## 1. Two competing revisions of one article 🐞

Clicking Edit on published content you had **already submitted a revision for** minted a second revision draft, putting two competing revisions of one article into the approvals queue. There's nothing to edit until an admin has dealt with the first one.

The endpoint now looks for your own in-review revision before minting anything, and hands the submission back with `200` — the same "already on the go, go to the editor" answer as a resumed draft, so the client needed no new branch.

Checked across **both content types**: `ListArticlesAsync` is filtered to articles, so looking there alone would miss a blog revision and mint the competing draft anyway. There's a test pinning exactly that.

It only ever matches your own work — someone else revising the same article neither blocks you nor has their submission handed to you.

**Where Edit takes you now:**

| Situation | Response | Result |
|---|---|---|
| Nothing on the go | `201` | Modal opens in place |
| Revision draft in progress | `200` | → `/editor?item=<id>`, **editable** |
| Revision awaiting review | `200` | → `/editor?item=<id>`, **read-only** |

The editor resolves that id against drafts and submissions together, so it opens the right way round without being told which — and only matches your own work, so a hand-typed id can't open someone else's. The query param is `item` rather than `draft` because it's no longer always a draft.

`/admin/content` is untouched: it already shows these with a "Revision pending" badge and Edit disabled, which is the read-only display we want there.

## 2. Field limits you can see

The caps were invisible until you hit one. Title, Category and Summary each had a bare `maxlength`, so typing silently stopped mid-word — which reads as the app breaking rather than a limit being reached. The body had no client guard at all, so exceeding it surfaced as a **failed autosave, mid-typing**, phrased as:

> The field Body must be a string with a maximum length of 50000.

- **Counters** on all four fields, hidden until 80% of the limit so a normal field looks untouched, then amber and explicit at the cap.
- **The body stops too** — `handleTextInput` / `handlePaste` / `handleDrop` refuse once full. Only insertions are blocked, so a full document can always be edited back down. An oversized paste is measured and rejected rather than landing and overshooting.
- **A clear button on Category**, which had no way back to empty once set.
- The save-time refusal stays as a backstop for content that arrived over the limit, and now reads as a sentence rather than a framework message.

## 3. Counting text, not markup

The counter charged for HTML, so a paragraph of links cost far more than the same words in plain text and the figure bore no relation to what was on the page. It now counts the text itself, reusing the `htmlToText` helper already used for the word count and submit checks.

Counting text means *enforcing* text, or the number shown and the point input stops would disagree. So **50,000 changed role**:

| | Before | Now |
|---|---|---|
| What an author meets | HTML length | **50,000 characters of text** |
| Server cap | 50,000 on HTML | **200,000 on HTML — a transport backstop** |

The backstop has to sit above the text limit: 50,000 characters of text is easily 70–90k of HTML once formatted, and matching them would let the editor reach a limit the API then rejected. Bodies live in blob storage, which doesn't care either way. Text length is measured once per change in `DraftEditor` and passed down, so the parse doesn't happen twice per keystroke.

⚠️ **The judgement call worth a second opinion.** This came from reading "make body 50,000 chars" and "true character count" together, and it's an API change made on that reading. If you'd rather the hard cap stayed at 50,000 HTML and the text limit came down to ~20,000, that's a small change. No test pinned the old 50,000 HTML cap, so nothing was relying on it.

---

## Existing tests that changed meaning

Called out so a reviewer can check these weren't just made green:

- `EditContentButton.spec` returned **200** for what it called a freshly-created revision. Under the new contract that means "resumed", so those fixtures moved to `201` via a `created()` helper named for what it represents.
- `EditorView.spec` had no router, so `useRoute()` came back undefined the moment the view read `route.query`; it now mocks `vue-router` the way `views.misc.spec` does.
- The `RichTextEditor` limit tests asserted against `modelValue` length; they now assert the real contract, which is the `currentLength` the parent measures.

## Verification

- **API**: `dotnet build -warnaserror` → 0 warnings, 0 errors; **371 tests** pass
- **Web**: lint clean; **457 unit tests** pass; `npm run build` (vue-tsc) clean
- Verified after the cherry-pick onto current main, not just on the original branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
