### PR TITLE
feat: field limits for newsletters and resources, and a missing topics cap

### DIFF
--- a/src/api/Slypn.Api.Tests/InputValidationTests.cs
+++ b/src/api/Slypn.Api.Tests/InputValidationTests.cs
@@ -111,4 +111,53 @@ public class InputValidationTests
         Assert.True(Validate(new SubscribeInput { Email = "a@b.com" }).Ok);
         Assert.False(Validate(new SubscribeInput { Email = "bad" }).Ok);
     }
+
+    // ── Newsletter topics ───────────────────────────────────────────────────────
+    // DataAnnotations validates the property, not its elements, so [StringLength] on a
+    // List<string> checks nothing. Topics were unbounded per item until ItemLength.
+
+    private static NewsletterInput NewsletterWith(params string[] topics) => new()
+    {
+        Title = "An issue",
+        IssueDate = new DateOnly(2026, 5, 1),
+        Summary = "A summary long enough to pass.",
+        Topics = topics.ToList(),
+    };
+
+    [Fact]
+    public void Newsletter_accepts_topics_within_the_per_item_limit()
+    {
+        Assert.True(Validate(NewsletterWith("Research", new string('x', 60))).Ok);
+    }
+
+    [Fact]
+    public void Newsletter_rejects_a_topic_that_is_too_long()
+    {
+        var (ok, errors) = Validate(NewsletterWith("Research", new string('x', 61)));
+        Assert.False(ok);
+        Assert.Contains(errors, e => e.ErrorMessage!.Contains("characters or fewer"));
+    }
+
+    [Fact]
+    public void Newsletter_rejects_too_many_topics()
+    {
+        var (ok, errors) = Validate(NewsletterWith(Enumerable.Range(0, 21).Select(i => $"t{i}").ToArray()));
+        Assert.False(ok);
+        Assert.Contains(errors, e => e.ErrorMessage!.Contains("at most 20 topics"));
+    }
+
+    [Fact]
+    public void ItemLength_ignores_a_collection_it_does_not_understand()
+    {
+        // Shape is another rule's problem; this one only has an opinion on string length.
+        Assert.True(new ItemLengthAttribute(5).IsValid(new List<int> { 1, 2, 3 }));
+        Assert.True(new ItemLengthAttribute(5).IsValid(null));
+    }
+
+    [Fact]
+    public void ItemLength_tolerates_a_null_entry()
+    {
+        Assert.True(new ItemLengthAttribute(5).IsValid(new List<string?> { null, "ok" }));
+    }
+
 }

--- a/src/api/Slypn.Api/Models/Inputs/ItemLengthAttribute.cs
+++ b/src/api/Slypn.Api/Models/Inputs/ItemLengthAttribute.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Slypn.Api.Models.Inputs;
+
+/// <summary>
+/// Caps the length of each string in a collection. DataAnnotations validates the property,
+/// not its elements, so [StringLength] on a List&lt;string&gt; checks nothing — this fills that
+/// gap for free-text lists that would otherwise be unbounded per item.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class ItemLengthAttribute(int maximumLength) : ValidationAttribute
+{
+    public int MaximumLength { get; } = maximumLength;
+
+    public override bool IsValid(object? value)
+    {
+        if (value is not IEnumerable<string?> items) return true; // wrong shape is another rule's problem
+        return items.All(item => (item?.Length ?? 0) <= MaximumLength);
+    }
+
+    public override string FormatErrorMessage(string name)
+        => $"Each entry in {name} must be {MaximumLength} characters or fewer.";
+}

--- a/src/api/Slypn.Api/Models/Inputs/NewsletterInput.cs
+++ b/src/api/Slypn.Api/Models/Inputs/NewsletterInput.cs
@@ -13,5 +13,10 @@ public sealed class NewsletterInput
     [Required, StringLength(1_000, MinimumLength = 10)]
     public string Summary { get; set; } = "";
 
+    /// <summary>Free-text tags, entered as one comma-separated field and split client-side.
+    /// Capped per topic and in number: unbounded here would let a single issue carry
+    /// arbitrarily large strings, and nothing downstream truncates them.</summary>
+    [MaxLength(20, ErrorMessage = "An issue can carry at most 20 topics.")]
+    [ItemLength(60)]
     public List<string> Topics { get; set; } = new();
 }

--- a/src/web/src/components/common/ClearFieldButton.vue
+++ b/src/web/src/components/common/ClearFieldButton.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+withDefaults(defineProps<{
+  /** Names the field in the accessible label, e.g. "category". */
+  field: string
+  testid?: string
+}>(), { testid: 'field-clear' })
+
+defineEmits<{ (e: 'clear'): void }>()
+</script>
+
+<template>
+  <!--
+    Sits inside a `relative` wrapper, over the right-hand end of the input — so the input
+    needs padding there (pr-9) or the text runs underneath. Rendered by the caller only
+    when there is something to clear, so it never offers a no-op.
+  -->
+  <button
+    type="button"
+    :data-testid="testid"
+    :aria-label="`Clear ${field}`"
+    :title="`Clear ${field}`"
+    class="absolute inset-y-0 right-0 mt-1 flex items-center rounded-r-md px-2.5 text-slypn-400 transition-colors hover:text-slypn-700"
+    @click="$emit('clear')"
+  >
+    <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+      <path d="M6 6l12 12M18 6L6 18" />
+    </svg>
+  </button>
+</template>

--- a/src/web/src/components/common/FieldCounter.spec.ts
+++ b/src/web/src/components/common/FieldCounter.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FieldCounter from './FieldCounter.vue'
+import ClearFieldButton from './ClearFieldButton.vue'
+
+const counter = (props: { used: number; max?: number; showFrom?: number; testid?: string }) =>
+  mount(FieldCounter, { props: { max: 100, ...props } })
+
+describe('FieldCounter', () => {
+  it('stays hidden until the limit is close', () => {
+    // A permanent "3 / 200" under every field is noise, and trains people to ignore it.
+    expect(counter({ used: 0 }).find('[data-testid="field-counter"]').exists()).toBe(false)
+    expect(counter({ used: 79 }).find('[data-testid="field-counter"]').exists()).toBe(false)
+  })
+
+  it('appears at the threshold and shows the figures', () => {
+    const w = counter({ used: 80 })
+    expect(w.text()).toContain('80 / 100')
+    expect(w.text()).not.toContain('limit reached')
+  })
+
+  it('says so at the limit, and stays said beyond it', () => {
+    expect(counter({ used: 100 }).text()).toContain('limit reached')
+    expect(counter({ used: 140 }).text()).toContain('limit reached')
+  })
+
+  it('honours a custom threshold', () => {
+    expect(counter({ used: 50, showFrom: 0.5 }).exists()).toBe(true)
+    expect(counter({ used: 49, showFrom: 0.5 }).find('[data-testid="field-counter"]').exists()).toBe(false)
+  })
+
+  it('takes a testid so each field can be addressed on its own', () => {
+    const w = counter({ used: 90, testid: 'summary-count' })
+    expect(w.find('[data-testid="summary-count"]').exists()).toBe(true)
+  })
+})
+
+describe('ClearFieldButton', () => {
+  it('emits clear, and names the field for screen readers', async () => {
+    const w = mount(ClearFieldButton, { props: { field: 'category' } })
+    const btn = w.find('[data-testid="field-clear"]')
+    expect(btn.attributes('aria-label')).toBe('Clear category')
+    expect(btn.attributes('title')).toBe('Clear category')
+
+    await btn.trigger('click')
+    expect(w.emitted('clear')).toHaveLength(1)
+  })
+})

--- a/src/web/src/components/common/FieldCounter.vue
+++ b/src/web/src/components/common/FieldCounter.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
+  /** Characters used. Pass a length, not the value, so callers can count what they mean —
+      text rather than markup, for instance. */
+  used: number
+  max: number
+  /** Fraction of the limit to stay hidden below. */
+  showFrom?: number
+  /** Overridden so each field's counter can be addressed on its own in tests. */
+  testid?: string
+}>(), { showFrom: 0.8, testid: 'field-counter' })
+
+// A permanent "3 / 200" under every field is noise, and trains people to ignore it. It
+// appears only once the limit is close enough to be worth knowing about.
+const visible = computed(() => props.used >= props.max * props.showFrom)
+const atLimit = computed(() => props.used >= props.max)
+</script>
+
+<template>
+  <p
+    v-if="visible"
+    :data-testid="testid"
+    class="mt-1 text-right text-xs"
+    :class="atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
+  >
+    {{ used }} / {{ max }}<span v-if="atLimit"> — limit reached</span>
+  </p>
+</template>

--- a/src/web/src/components/editor/DraftEditor.vue
+++ b/src/web/src/components/editor/DraftEditor.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import RichTextEditor from '@/components/editor/RichTextEditor.vue'
+import FieldCounter from '@/components/common/FieldCounter.vue'
+import ClearFieldButton from '@/components/common/ClearFieldButton.vue'
 import SaveIndicator from '@/components/editor/SaveIndicator.vue'
 import { useAutoSave } from '@/composables/useAutoSave'
 import { useBeforeUnload } from '@/composables/useBeforeUnload'
@@ -207,20 +209,10 @@ function hasBodyContent(html: string): boolean {
   return htmlToText(html).trim().length > 0
 }
 
-// Show a counter only once it starts to matter — a permanent "3 / 200" under every
-// field is noise. Below the threshold the field looks as it always did.
-function counterFor(used: number, max: number) {
-  if (used < max * 0.8) return null
-  return { text: `${used} / ${max}`, atLimit: used >= max }
-}
-const titleCount    = computed(() => counterFor(draft.value.title.length, LIMITS.title))
-const summaryCount  = computed(() => counterFor(draft.value.summary.length, LIMITS.summary))
-const categoryCount = computed(() => counterFor(draft.value.category.length, LIMITS.category))
 // Counted as an author reads it, not as it is stored: markup, link hrefs and image
 // URLs do not show on the page, so charging for them would make the number meaningless.
 // The editor blocks input against this same figure, so the count and the stop agree.
 const bodyTextLength = computed(() => htmlToText(draft.value.body).length)
-const bodyCount      = computed(() => counterFor(bodyTextLength.value, LIMITS.body))
 
 const missingToSubmit = computed(() => {
   const missing: string[] = []
@@ -340,12 +332,7 @@ watch(() => draft.value.body, (html) => {
           class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm read-only:bg-slypn-50 read-only:text-slypn-600 focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
         />
         <p v-if="!readonly && !draft.title.trim()" class="mt-1 text-xs text-slypn-400">Add a title to start saving.</p>
-        <p
-          v-if="!readonly && titleCount"
-          data-testid="draft-title-count"
-          class="mt-1 text-right text-xs"
-          :class="titleCount!.atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
-        >{{ titleCount!.text }}{{ titleCount!.atLimit ? ' — limit reached' : '' }}</p>
+        <FieldCounter v-if="!readonly" :used="draft.title.length" :max="LIMITS.title" testid="draft-title-count" />
       </div>
 
       <div>
@@ -362,29 +349,17 @@ watch(() => draft.value.body, (html) => {
             placeholder="Pick an existing one or type a new category"
             class="mt-1 w-full rounded-md border border-slypn-200 bg-white py-2 pl-3 pr-9 text-sm shadow-sm read-only:bg-slypn-50 read-only:text-slypn-600 focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
           />
-          <button
+          <ClearFieldButton
             v-if="!readonly && draft.category"
-            type="button"
-            data-testid="draft-category-clear"
-            aria-label="Clear category"
-            title="Clear category"
-            class="absolute inset-y-0 right-0 mt-1 flex items-center rounded-r-md px-2.5 text-slypn-400 transition-colors hover:text-slypn-700"
-            @click="draft.category = ''"
-          >
-            <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
-              <path d="M6 6l12 12M18 6L6 18" />
-            </svg>
-          </button>
+            field="category"
+            testid="draft-category-clear"
+            @clear="draft.category = ''"
+          />
         </div>
         <datalist id="draft-category-hints">
           <option v-for="c in categoryHints" :key="c" :value="c" />
         </datalist>
-        <p
-          v-if="!readonly && categoryCount"
-          data-testid="draft-category-count"
-          class="mt-1 text-right text-xs"
-          :class="categoryCount!.atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
-        >{{ categoryCount!.text }}{{ categoryCount!.atLimit ? ' — limit reached' : '' }}</p>
+        <FieldCounter v-if="!readonly" :used="draft.category.length" :max="LIMITS.category" testid="draft-category-count" />
       </div>
 
       <div>
@@ -397,12 +372,7 @@ watch(() => draft.value.body, (html) => {
           :readonly="readonly"
           class="mt-1 w-full rounded-md border border-slypn-200 bg-white px-3 py-2 text-sm shadow-sm read-only:bg-slypn-50 read-only:text-slypn-600 focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
         />
-        <p
-          v-if="!readonly && summaryCount"
-          data-testid="draft-summary-count"
-          class="mt-1 text-right text-xs"
-          :class="summaryCount!.atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
-        >{{ summaryCount!.text }}{{ summaryCount!.atLimit ? ' — limit reached' : '' }}</p>
+        <FieldCounter v-if="!readonly" :used="draft.summary.length" :max="LIMITS.summary" testid="draft-summary-count" />
       </div>
 
       <div>
@@ -422,14 +392,7 @@ watch(() => draft.value.body, (html) => {
     />
     <!-- Only once it starts to matter. Counts HTML, which is what the limit applies to,
          so it runs ahead of the visible word count on a heavily formatted piece. -->
-    <p
-      v-if="!readonly && bodyCount"
-      data-testid="draft-body-count"
-      class="text-right text-xs"
-      :class="bodyCount!.atLimit ? 'font-semibold text-amber-600' : 'text-slypn-400'"
-    >
-      {{ bodyCount!.text }} characters{{ bodyCount!.atLimit ? ' — limit reached' : '' }}
-    </p>
+    <FieldCounter v-if="!readonly" :used="bodyTextLength" :max="LIMITS.body" testid="draft-body-count" />
 
     <p v-if="!readonly && uploadError" data-testid="draft-upload-error" class="rounded-md bg-rose-50 px-4 py-2 text-sm text-rose-700">
       Image upload failed: {{ uploadError }}

--- a/src/web/src/views/NewsletterManagementView.spec.ts
+++ b/src/web/src/views/NewsletterManagementView.spec.ts
@@ -38,6 +38,33 @@ beforeEach(async () => {
 })
 
 describe('NewsletterManagementView', () => {
+  it('counts the fields as they fill', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Add newsletter'))!.trigger('click')
+
+    expect(w.find('[data-testid="newsletter-summary-count"]').exists()).toBe(false)
+
+    await w.find('textarea').setValue('s'.repeat(900))
+    expect(w.find('[data-testid="newsletter-summary-count"]').text()).toContain('900 / 1000')
+
+    await w.find('textarea').setValue('s'.repeat(1000))
+    expect(w.find('[data-testid="newsletter-summary-count"]').text()).toContain('limit reached')
+  })
+
+  it('caps the topics field, which had no limit at all', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Add newsletter'))!.trigger('click')
+
+    const topics = w.find('#newsletter-topics')
+    expect(topics.attributes('maxlength')).toBe('600')
+    await topics.setValue('t'.repeat(600))
+    expect(w.find('[data-testid="newsletter-topics-count"]').text()).toContain('limit reached')
+  })
+
   it('lists newsletters', async () => {
     apiJson.mockResolvedValue([newsletter()])
     const w = mountC()

--- a/src/web/src/views/NewsletterManagementView.vue
+++ b/src/web/src/views/NewsletterManagementView.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import { apiFetch, apiJson, apiErrorMessage } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
+import FieldCounter from '@/components/common/FieldCounter.vue'
 
 interface Newsletter {
   id: string
@@ -24,6 +25,11 @@ const formatDate = (iso: string) =>
 // ── Add / edit dialog ────────────────────────────────────────────────────────
 const showForm  = ref(false)
 const editing   = ref<Newsletter | null>(null)
+// Field caps, mirroring NewsletterInput server-side, so the counters and the maxlength
+// attributes cannot drift from it. `topics` is the raw comma-separated input; the server
+// caps each topic it is split into.
+const LIMITS = { title: 200, summary: 1_000, topic: 60, topics: 600 } as const
+
 const form      = ref({ title: '', issueDate: '', summary: '', topics: '' })
 const file      = ref<File | null>(null)
 const fileInput = ref<HTMLInputElement | null>(null)
@@ -232,6 +238,7 @@ async function remove(n: Newsletter) {
               required
               class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
             />
+            <FieldCounter :used="form.title.length" :max="LIMITS.title" testid="newsletter-title-count" />
           </div>
           <div>
             <label for="newsletter-issue-date" class="block text-sm font-medium text-slypn-800">Issue date</label>
@@ -253,6 +260,7 @@ async function remove(n: Newsletter) {
               required
               class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
             />
+            <FieldCounter :used="form.summary.length" :max="LIMITS.summary" testid="newsletter-summary-count" />
           </div>
           <div>
             <label for="newsletter-topics" class="block text-sm font-medium text-slypn-800">Topics</label>
@@ -260,9 +268,11 @@ async function remove(n: Newsletter) {
               id="newsletter-topics"
               v-model="form.topics"
               type="text"
+              :maxlength="LIMITS.topics"
               placeholder="Comma-separated, e.g. Research, Events"
               class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
             />
+            <FieldCounter :used="form.topics.length" :max="LIMITS.topics" testid="newsletter-topics-count" />
           </div>
           <div>
             <label for="newsletter-file" class="block text-sm font-medium text-slypn-800">

--- a/src/web/src/views/ResourceManagementView.vue
+++ b/src/web/src/views/ResourceManagementView.vue
@@ -3,6 +3,8 @@ import { computed, ref } from 'vue'
 import HeroBanner from '@/components/common/HeroBanner.vue'
 import { apiFetch, apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
+import FieldCounter from '@/components/common/FieldCounter.vue'
+import ClearFieldButton from '@/components/common/ClearFieldButton.vue'
 
 interface Resource {
   id: string
@@ -38,6 +40,10 @@ const categoryHints = computed(() => {
 // ── Add / edit dialog ────────────────────────────────────────────────────────
 const showForm  = ref(false)
 const editing   = ref<Resource | null>(null)
+// Field caps, mirroring ResourceInput server-side, so the counters and the maxlength
+// attributes cannot drift from it.
+const LIMITS = { title: 200, description: 500, url: 500, category: 60 } as const
+
 const form      = ref({ title: '', description: '', url: '', category: '' })
 const saving    = ref(false)
 const formError = ref<string | null>(null)
@@ -214,6 +220,7 @@ async function remove(r: Resource) {
               required
               class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
             />
+            <FieldCounter :used="form.title.length" :max="LIMITS.title" testid="resource-title-count" />
           </div>
           <div>
             <label for="resource-description" class="block text-sm font-medium text-slypn-800">Description</label>
@@ -225,6 +232,7 @@ async function remove(r: Resource) {
               required
               class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
             />
+            <FieldCounter :used="form.description.length" :max="LIMITS.description" testid="resource-description-count" />
           </div>
           <div>
             <label for="resource-url" class="block text-sm font-medium text-slypn-800">URL</label>
@@ -237,20 +245,30 @@ async function remove(r: Resource) {
               placeholder="https://…"
               class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
             />
+            <FieldCounter :used="form.url.length" :max="LIMITS.url" testid="resource-url-count" />
           </div>
           <div>
             <label for="resource-category" class="block text-sm font-medium text-slypn-800">Category</label>
+            <div class="relative">
             <input
-              id="resource-category"
-              v-model="form.category"
-              type="text"
-              maxlength="60"
-              list="resource-category-hints"
-              autocomplete="off"
-              required
-              placeholder="Pick an existing one or type a new category"
-              class="mt-1 w-full rounded-md border border-slypn-200 px-3 py-2 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
-            />
+                id="resource-category"
+                v-model="form.category"
+                type="text"
+                maxlength="60"
+                list="resource-category-hints"
+                autocomplete="off"
+                required
+                placeholder="Pick an existing one or type a new category"
+                class="mt-1 w-full rounded-md border border-slypn-200 py-2 pl-3 pr-9 text-sm shadow-sm focus:border-slypn-600 focus:outline-none focus:ring-1 focus:ring-slypn-600"
+              />
+              <ClearFieldButton
+                v-if="form.category"
+                field="category"
+                testid="resource-category-clear"
+                @clear="form.category = ''"
+              />
+            </div>
+            <FieldCounter :used="form.category.length" :max="LIMITS.category" testid="resource-category-count" />
             <datalist id="resource-category-hints">
               <option v-for="c in categoryHints" :key="c" :value="c" />
             </datalist>

--- a/src/web/src/views/views.admin.spec.ts
+++ b/src/web/src/views/views.admin.spec.ts
@@ -355,6 +355,31 @@ describe('ApprovalsQueue', () => {
 })
 
 describe('ResourceManagementView', () => {
+  it('counts the fields as they fill, and clears the category', async () => {
+    apiJson.mockResolvedValue([])
+    const w = mountC(ResourceManagementView)
+    await flushPromises()
+    await w.findAll('button').find(b => b.text()?.includes('Add resource'))!.trigger('click')
+
+    // Hidden while there is nothing to warn about.
+    expect(w.find('[data-testid="resource-description-count"]').exists()).toBe(false)
+
+    await w.find('textarea').setValue('d'.repeat(450))
+    expect(w.find('[data-testid="resource-description-count"]').text()).toContain('450 / 500')
+
+    await w.find('textarea').setValue('d'.repeat(500))
+    expect(w.find('[data-testid="resource-description-count"]').text()).toContain('limit reached')
+
+    // Category had no way back to empty once set.
+    const catInput = w.findAll('input').find(i => i.attributes('list') === 'resource-category-hints')!
+    await catInput.setValue('Local')
+    await w.find('[data-testid="resource-category-clear"]').trigger('click')
+    // Re-query: the wrapper captured before the re-render is stale.
+    const cleared = w.findAll('input').find(i => i.attributes('list') === 'resource-category-hints')!
+    expect((cleared.element as HTMLInputElement).value).toBe('')
+    expect(w.find('[data-testid="resource-category-clear"]').exists()).toBe(false)
+  })
+
   const resource = (over = {}) => ({ id: 'r1', title: 'Helpline', description: 'd', url: 'https://x.org/a', category: 'NHS', _etag: 'e1', ...over })
 
   it('renders resources grouped by category', async () => {


### PR DESCRIPTION
Newsletters and resources now behave like the editor. Both forms *already* had `maxlength` attributes matching their server caps, so typing stopped — but **silently, mid-word**, exactly as the editor did before #189. That's the gap this closes.

## Counters

| Form | Fields |
|---|---|
| Newsletter | title (200), summary (1,000), topics (600) |
| Resource | title (200), description (500), url (500), category (60) |

Hidden until 80% of the limit, so a normal field looks untouched, then amber and explicit at the cap.

## Clear button on the resource category

It had no way back to empty once set — same affordance the editor's category got.

## Two shared components

The counter and clear affordances were about to have three call sites each, so they're extracted:

- `FieldCounter.vue`
- `ClearFieldButton.vue`

`DraftEditor` is refactored onto both, so there's one implementation rather than three copies drifting apart.

Both take an optional `testid`. Without it every `draft-*-count` selector in the existing specs would have collapsed onto a single `field-counter`, making the counters individually unaddressable — so the existing tests keep working unchanged.

## 🐞 Newsletter topics had no cap anywhere

The input had no `maxlength`, and:

```csharp
public List<string> Topics { get; set; } = new();
```

`[StringLength]` **does not reach list elements** — DataAnnotations validates the property, not its items. So a single issue could carry arbitrarily long topic strings, and nothing downstream truncates them.

Fixed with a small `ItemLengthAttribute`:

```csharp
[MaxLength(20, ErrorMessage = "An issue can carry at most 20 topics.")]
[ItemLength(60)]
public List<string> Topics { get; set; } = new();
```

Plus a 600-character cap on the comma-separated input it's typed into. The attribute deliberately ignores collections it doesn't understand and tolerates null entries — shape is another rule's problem; this one only has an opinion on string length. Both cases are tested.

## Test note

One existing-style trap worth mentioning: the resource clear test initially asserted against an input wrapper captured *before* the click. That wrapper is stale after the re-render, so it read the old value — it now re-queries, as the equivalent `DraftEditor` test does.

## Verification

- **API**: `dotnet build -warnaserror` → 0 warnings, 0 errors; **376 tests** (was 371)
- **Web**: lint clean; **466 unit tests** (was 457); `npm run build` (vue-tsc) clean

`vue-tsc` earned its keep here — it caught an untyped test helper that vitest ran happily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
