### PR TITLE
refactor(api)!: POST /newsletter/subscribe becomes POST /subscribers

### DIFF
--- a/src/api/Slypn.Api.Tests/AuthExtensionFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AuthExtensionFunctionsTests.cs
@@ -229,7 +229,7 @@ public class AuthExtensionFunctionsTests
     // ── SEC-1: subscribing is not an invitation ─────────────────────────────
     // The members table used to double as the newsletter subscriber list, and the gate
     // allowed any address with a row. Anyone could POST to the anonymous
-    // /api/newsletter/subscribe and then sign up through CIAM. Subscribers have their own
+    // /api/subscribers and then sign up through CIAM. Subscribers have their own
     // table since SEC-5, so these rows are now legacy shapes — the gate must still reject
     // them, and anything else that learns to write a role-less member row.
 

--- a/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentFunctionsTests.cs
@@ -371,20 +371,20 @@ public class ContentFunctionsTests
     }
 
     [Fact]
-    public async Task Newsletters_subscribe_412_when_lookup_fails_and_412_when_upsert_fails()
+    public async Task Subscribers_create_412_when_lookup_fails_and_412_when_upsert_fails()
     {
         var ctx = new TestFunctionContext();
-        var payload = TestHttp.Json(ctx, "POST", "http://localhost/api/newsletter/subscribe", new { email = "me@example.com" });
+        var payload = TestHttp.Json(ctx, "POST", "http://localhost/api/subscribers", new { email = "me@example.com" });
 
         // GetSubscriberByEmailAsync throws
         var repo1 = new FakeContentRepository { ThrowOnSubscriberLookup = new RequestFailedException(500, "Lookup failed") };
-        var err1 = (TestHttpResponseData)await NewslettersFn(repo1).Subscribe(payload, Ct);
+        var err1 = (TestHttpResponseData)await SubscribersFn(repo1).Subscribe(payload, Ct);
         Assert.Equal(HttpStatusCode.InternalServerError, err1.StatusCode);
 
         // UpsertSubscriberAsync throws
         var repo2 = new FakeContentRepository { ThrowOnWrite = new RequestFailedException(412, "Precondition failed") };
-        var err2 = (TestHttpResponseData)await NewslettersFn(repo2).Subscribe(
-            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe", new { email = "me@example.com" }), Ct);
+        var err2 = (TestHttpResponseData)await SubscribersFn(repo2).Subscribe(
+            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/subscribers", new { email = "me@example.com" }), Ct);
         Assert.Equal(HttpStatusCode.PreconditionFailed, err2.StatusCode);
     }
 
@@ -402,7 +402,7 @@ public class ContentFunctionsTests
         var created = (TestHttpResponseData)await fn.Create(TestHttp.Json(ctx, "POST", "http://localhost/api/newsletters", valid), Ct);
         Assert.Contains((int)created.StatusCode, new[] { 200, 201 });
 
-        var sub = (TestHttpResponseData)await fn.Subscribe(TestHttp.Json(ctx, "POST", "http://localhost/api/newsletter/subscribe", new { email = "me@example.com" }), Ct);
+        var sub = (TestHttpResponseData)await SubscribersFn(repo).Subscribe(TestHttp.Json(ctx, "POST", "http://localhost/api/subscribers", new { email = "me@example.com" }), Ct);
         Assert.Contains((int)sub.StatusCode, new[] { 200, 201 });
     }
 
@@ -967,22 +967,22 @@ public class ContentFunctionsTests
     }
 
     [Fact]
-    public async Task Newsletters_subscribe_503_when_writes_disabled()
+    public async Task Subscribers_create_503_when_writes_disabled()
     {
-        var fn = NewslettersFn(new FakeContentRepository { Writes = false });
+        var fn = SubscribersFn(new FakeContentRepository { Writes = false });
         var resp = (TestHttpResponseData)await fn.Subscribe(
-            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe",
+            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/subscribers",
                 new { email = "me@example.com" }), Ct);
         Assert.Equal(HttpStatusCode.ServiceUnavailable, resp.StatusCode);
     }
 
     [Fact]
-    public async Task Newsletters_subscribe_400_on_invalid_input()
+    public async Task Subscribers_create_400_on_invalid_input()
     {
-        var fn = NewslettersFn(new FakeContentRepository());
+        var fn = SubscribersFn(new FakeContentRepository());
         // Empty object → email field fails [Required, EmailAddress] validation
         var resp = (TestHttpResponseData)await fn.Subscribe(
-            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe",
+            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/subscribers",
                 new { }), Ct);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
@@ -990,13 +990,13 @@ public class ContentFunctionsTests
     // SEC-5: subscribing must never touch the members table. That conflation is what let an
     // anonymous subscribe buy its way past the CIAM sign-up gate (SEC-1).
     [Fact]
-    public async Task Newsletters_subscribe_writes_a_subscriber_and_never_a_member()
+    public async Task Subscribers_create_writes_a_subscriber_and_never_a_member()
     {
         var repo = new FakeContentRepository();
-        var fn = NewslettersFn(repo);
+        var fn = SubscribersFn(repo);
 
         var resp = (TestHttpResponseData)await fn.Subscribe(
-            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe",
+            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/subscribers",
                 new { email = "  New@Example.com  " }), Ct);
 
         Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
@@ -1010,16 +1010,16 @@ public class ContentFunctionsTests
     }
 
     [Fact]
-    public async Task Newsletters_subscribe_is_idempotent_and_keeps_the_original_date()
+    public async Task Subscribers_create_is_idempotent_and_keeps_the_original_date()
     {
         // The row key is derived from the address, so a repeat subscribe upserts the same row.
         var firstSeen = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
         var existing = new Subscriber(Subscriber.KeyFor("sub@example.com"), "sub@example.com", "Old Display", firstSeen);
         var repo = new FakeContentRepository { SubscriberByEmail = existing };
-        var fn = NewslettersFn(repo);
+        var fn = SubscribersFn(repo);
 
         var resp = (TestHttpResponseData)await fn.Subscribe(
-            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe",
+            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/subscribers",
                 new { email = "sub@example.com" }), Ct);
 
         Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });
@@ -1030,14 +1030,14 @@ public class ContentFunctionsTests
     }
 
     [Fact]
-    public async Task Newsletters_subscribe_applies_a_supplied_display_name()
+    public async Task Subscribers_create_applies_a_supplied_display_name()
     {
         var existing = new Subscriber(Subscriber.KeyFor("sub@example.com"), "sub@example.com", "Old Display", DateTime.UtcNow);
         var repo = new FakeContentRepository { SubscriberByEmail = existing };
-        var fn = NewslettersFn(repo);
+        var fn = SubscribersFn(repo);
 
         var resp = (TestHttpResponseData)await fn.Subscribe(
-            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/newsletter/subscribe",
+            TestHttp.Json(new TestFunctionContext(), "POST", "http://localhost/api/subscribers",
                 new { email = "sub@example.com", displayName = "  New Display  " }), Ct);
 
         Assert.Contains((int)resp.StatusCode, new[] { 200, 201 });

--- a/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/NewslettersFunctions.cs
@@ -206,45 +206,4 @@ public sealed class NewslettersFunctions(
         }
         catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
     }
-
-    /// <summary>
-    /// Public anonymous newsletter subscribe. Writes to the <c>subscribers</c> table, which is
-    /// separate from <c>members</c> on purpose: subscribing is anonymous, so a subscriber row must
-    /// never be mistaken for evidence that someone was invited. Dedupe comes from the row key being
-    /// derived from the email, so repeat subscribes upsert the same row.
-    /// </summary>
-    [Function("SubscribeToNewsletter")]
-    [OpenApiOperation(operationId: "newsletter.subscribe", tags: new[] { "newsletters" }, Summary = "Subscribe to newsletter", Description = "Subscribes an email address to the newsletter.")]
-    [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(SubscribeInput), Required = true, Description = "Subscription payload.")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(object), Description = "Subscription result")]
-    public async Task<HttpResponseData> Subscribe(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "newsletter/subscribe")] HttpRequestData req,
-        CancellationToken ct)
-    {
-        if (!repo.SupportsWrites) return await WritesDisabled(req);
-
-        var (input, err) = await ReadValidatedAsync<SubscribeInput>(req, ct);
-        if (err is not null) return err;
-
-        var email = input!.Email.Trim().ToLowerInvariant();
-
-        Subscriber? existing;
-        try { existing = await repo.GetSubscriberByEmailAsync(email, ct); }
-        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
-
-        var displayName = input.DisplayName?.Trim();
-        var record = new Subscriber(
-            Id:           Subscriber.KeyFor(email),
-            Email:        email,
-            DisplayName:  string.IsNullOrWhiteSpace(displayName) ? existing?.DisplayName ?? email : displayName,
-            // Keep the date they first signed up rather than resetting it on every resubmit.
-            SubscribedAt: existing?.SubscribedAt ?? DateTime.UtcNow);
-
-        try
-        {
-            var saved = await repo.UpsertSubscriberAsync(record, existing?.Etag, ct);
-            return await Created(req, new { saved.Email });
-        }
-        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
-    }
 }

--- a/src/api/Slypn.Api/Functions/SubscribersFunctions.cs
+++ b/src/api/Slypn.Api/Functions/SubscribersFunctions.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Azure;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -7,6 +8,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 using Slypn.Api.Infrastructure;
 using Slypn.Api.Models;
+using Slypn.Api.Models.Inputs;
 using Slypn.Api.Services;
 using static Slypn.Api.Functions.FunctionHelpers;
 
@@ -45,4 +47,50 @@ public sealed class SubscribersFunctions(
             await repo.DeleteSubscriberAsync(id, IfMatch(req), ct);
             return NoContent(req);
         });
+
+    /// <summary>
+    /// Public anonymous newsletter subscribe. It creates a subscriber, so it sits on
+    /// POST /subscribers beside the admin list and delete rather than under a verb of its
+    /// own. An anonymous POST next to an Admin-gated GET on one path is deliberate: the
+    /// auth belongs to the operation, not to the resource.
+    ///
+    /// Writes to the <c>subscribers</c> table, which is separate from <c>members</c> on
+    /// purpose: subscribing is anonymous, so a subscriber row must never be mistaken for
+    /// evidence that someone was invited. Dedupe comes from the row key being derived from
+    /// the email, so repeat subscribes upsert the same row.
+    /// </summary>
+    [Function("SubscribeToNewsletter")]
+    [OpenApiOperation(operationId: "subscribers.create", tags: new[] { "subscribers" }, Summary = "Subscribe to newsletter", Description = "Subscribes an email address to the newsletter.")]
+    [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(SubscribeInput), Required = true, Description = "Subscription payload.")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Created, contentType: "application/json", bodyType: typeof(object), Description = "Subscription result")]
+    public async Task<HttpResponseData> Subscribe(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "subscribers")] HttpRequestData req,
+        CancellationToken ct)
+    {
+        if (!repo.SupportsWrites) return await WritesDisabled(req);
+
+        var (input, err) = await ReadValidatedAsync<SubscribeInput>(req, ct);
+        if (err is not null) return err;
+
+        var email = input!.Email.Trim().ToLowerInvariant();
+
+        Subscriber? existing;
+        try { existing = await repo.GetSubscriberByEmailAsync(email, ct); }
+        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
+
+        var displayName = input.DisplayName?.Trim();
+        var record = new Subscriber(
+            Id:           Subscriber.KeyFor(email),
+            Email:        email,
+            DisplayName:  string.IsNullOrWhiteSpace(displayName) ? existing?.DisplayName ?? email : displayName,
+            // Keep the date they first signed up rather than resetting it on every resubmit.
+            SubscribedAt: existing?.SubscribedAt ?? DateTime.UtcNow);
+
+        try
+        {
+            var saved = await repo.UpsertSubscriberAsync(record, existing?.Etag, ct);
+            return await Created(req, new { saved.Email });
+        }
+        catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
+    }
 }

--- a/src/api/Slypn.Seed/MigrateSubscribers.cs
+++ b/src/api/Slypn.Seed/MigrateSubscribers.cs
@@ -10,9 +10,10 @@ namespace Slypn.Seed;
 /// One-off SEC-5 migration: moves legacy newsletter subscribers out of the <c>members</c> table
 /// into <c>subscribers</c>.
 ///
-/// Before SEC-5, POST /api/newsletter/subscribe stored each address as a members row with
-/// Status="subscribed", so subscribers and invited members shared one table. Subscribers have
-/// their own table now; these rows have to follow.
+/// Before SEC-5, the subscribe endpoint — then POST /api/newsletter/subscribe, now POST
+/// /api/subscribers — stored each address as a members row with Status="subscribed", so
+/// subscribers and invited members shared one table. Subscribers have their own table now;
+/// these rows have to follow.
 ///
 /// Idempotent and re-runnable: the destination row key is derived from the address, so a repeat
 /// run rewrites the same rows, and rows already migrated no longer match the source filter.

--- a/src/web/e2e/anon/public-browsing.spec.ts
+++ b/src/web/e2e/anon/public-browsing.spec.ts
@@ -157,7 +157,7 @@ test.describe('public browsing', () => {
     await page.getByLabel('Email address').fill(email)
 
     const [response] = await Promise.all([
-      page.waitForResponse((r) => r.url().includes('/api/newsletter/subscribe')),
+      page.waitForResponse((r) => r.url().includes('/api/subscribers')),
       page.getByTestId('subscribe-submit').click(),
     ])
     // 2xx, not 201: FunctionHelpers.Created() builds a 201 but the following

--- a/src/web/src/views/NewsletterView.vue
+++ b/src/web/src/views/NewsletterView.vue
@@ -25,7 +25,7 @@ async function subscribe() {
   submitting.value = true
   submitError.value = null
   try {
-    const resp = await apiFetch('/newsletter/subscribe', {
+    const resp = await apiFetch('/subscribers', {
       method: 'POST',
       body: JSON.stringify({ email: email.value.trim() }),
     })

--- a/src/web/src/views/views.public.spec.ts
+++ b/src/web/src/views/views.public.spec.ts
@@ -256,7 +256,7 @@ describe('NewsletterView', () => {
     await w.find('input[type="email"]').setValue('me@example.com')
     await w.find('form').trigger('submit')
     await flushPromises()
-    expect(apiFetch).toHaveBeenCalledWith('/newsletter/subscribe', expect.objectContaining({ method: 'POST' }))
+    expect(apiFetch).toHaveBeenCalledWith('/subscribers', expect.objectContaining({ method: 'POST' }))
     expect(w.text()).toContain('you’re on the list')
   })
 


### PR DESCRIPTION
`POST /newsletter/subscribe` → `POST /subscribers`, with the handler moved to `SubscribersFunctions`.

## Why

It was the odd one out three ways:

| | Every other route | This one |
|---|---|---|
| Noun | `newsletters` (plural) | `newsletter` — the only **singular** path |
| Shape | resource-oriented | `/subscribe` — the only **verb** |
| Home | creation sits with its resource | in `NewslettersFunctions`, but creates a **Subscriber** |

That last one is the real tell. The other two operations on the same resource were already where you'd expect:

```
GET    /subscribers        SubscribersFunctions   (admin)
DELETE /subscribers/{id}   SubscribersFunctions   (admin)
POST   /newsletter/subscribe   NewslettersFunctions   ← creation, elsewhere
```

Moving it completes the triad on one path. **The move is the point** — renaming the route alone would have left the creation of a subscriber filed under newsletters.

An anonymous `POST` beside an Admin-gated `GET` on one path is deliberate, and now says so in the handler's docs: the auth belongs to the operation, not to the resource.

## ⚠️ Breaking, and not aliased

The old route is **gone**, not kept as an alias. It's public, anonymous and unversioned, so an external caller would break.

The only caller in the repo is the site's own form (`NewsletterView.vue`). I chose no alias because a permanent one to cover a hypothetical is how an API ends up with two paths forever — but **that's the one thing I can't verify from here**, so it's worth a moment's thought before merging if anything outside this repo posts to it.

If you'd rather be cautious, the alternative is to add the new route, point the form at it, and leave the old one with a deprecation note to remove after a release. Say the word and I'll rework it.

## Deliberately unchanged

The Function name stays `SubscribeToNewsletter`. It's the identifier traces and dashboards are keyed on, and renaming it would break that continuity for no user-facing gain — the route is what callers see.

## Also swept up

Test names move `Newsletters_subscribe_*` → `Subscribers_create_*`, since they describe subscriber creation rather than a newsletter operation. And two comments citing the endpoint by name were stale after the move: the SEC-5 migration note in `MigrateSubscribers.cs` and the CIAM sign-up-gate note in `AuthExtensionFunctionsTests.cs`.

I grepped for the old path across `.cs`, `.ts`, `.vue`, `.md` and `.json` to confirm nothing else references it. The only surviving mention is the migration comment, which cites it deliberately as history.

## Note for #165

SEC-12's acceptance criteria reference `POST /api/newsletter/subscribe`. That text is now stale — worth updating when that work starts, along with the confirm endpoint it plans to add as a sibling.

## Verification

- **API**: `dotnet build -warnaserror` → 0 warnings, 0 errors; **376 tests** pass
- **Web**: lint clean; **466 unit tests** pass; `npm run build` (vue-tsc) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
