### PR TITLE
fix(e2e): make the suite runnable locally

### DIFF
--- a/src/web/e2e/support/backend.ts
+++ b/src/web/e2e/support/backend.ts
@@ -9,6 +9,7 @@
  * failure path here throws.
  */
 import { spawn, type ChildProcess } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { copyFileSync, createWriteStream, existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { createConnection } from 'node:net'
 import os from 'node:os'
@@ -132,6 +133,17 @@ async function waitForPort(port: number, timeoutMs: number): Promise<boolean> {
 // ── azurite ──────────────────────────────────────────────────────────────────
 
 /**
+ * Absolute path to azurite's CLI entry. It is a direct devDependency, so this resolves
+ * from the web package rather than relying on PATH or on npx's resolution order.
+ */
+function azuriteEntryPoint(): string {
+  const require = createRequire(import.meta.url)
+  const pkgPath = require.resolve('azurite/package.json')
+  const bin = (require('azurite/package.json') as { bin: Record<string, string> }).bin.azurite
+  return path.resolve(path.dirname(pkgPath), bin)
+}
+
+/**
  * Start Azurite unless something is already listening — which covers the
  * `slypn-azurite` Docker container that scripts/startLocal.ps1 runs.
  *
@@ -147,9 +159,14 @@ export async function startAzurite(): Promise<ChildProcess | null> {
 
   const child = spawnLogged(
     'azurite',
-    isWindows() ? 'npx.cmd' : 'npx',
+    // Run azurite's own entry point under this Node rather than going through npx.
+    // Node refuses to spawn a .cmd without a shell (CVE-2024-27980's fix, 18.20.2+),
+    // so `npx.cmd` died with a bare EINVAL on Windows — before any test ran, and with
+    // nothing in the message to say which of the two spawns had failed. Resolving the
+    // bin directly sidesteps the shim on every platform, and skips npx's lookup.
+    process.execPath,
     [
-      'azurite',
+      azuriteEntryPoint(),
       '--silent',
       '--location', location,
       '--blobHost', '127.0.0.1', '--blobPort', String(AZURITE_BLOB_PORT),

--- a/src/web/playwright.config.ts
+++ b/src/web/playwright.config.ts
@@ -21,8 +21,13 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  // One Functions host serves every worker, so more workers mostly queue.
-  workers: process.env.CI ? 2 : 4,
+  // One Functions host serves every worker, so more workers mostly queue — and locally
+  // they also race a Vite dev server that compiles on demand, where CI navigates a warm
+  // one. At four workers the first navigations pile onto an uncompiled server and blow
+  // the 30s navigationTimeout, so a local run failed while CI passed on the same commit.
+  // Flat 2 rather than a local/CI split: the point of running it locally is to predict
+  // what CI will say, which it cannot do from a different concurrency.
+  workers: 2,
   timeout: 60_000,
   expect: { timeout: 10_000 },
 


### PR DESCRIPTION
The e2e suite could not run at all on Windows. `global-setup` died before a single test executed:

```
Error: spawn EINVAL
  at support/backend.ts:102
```

## The cause

Node refuses to spawn a `.cmd` without a shell — the fix for CVE-2024-27980, from Node 18.20.2 onwards. `spawnLogged` passes `npx.cmd` with `shell: false`.

The message is the worst part: it names neither `npx` nor which of the two spawns failed, so it reads like a broken harness rather than a one-line incompatibility. The other spawn is `dotnet.exe`, which was never affected — only the `.cmd` shim is.

## The fix

`azurite` is a direct devDependency, so its CLI entry can be resolved and run under this Node directly:

```ts
spawn(process.execPath, [azuriteEntryPoint(), '--silent', …])
```

Chosen over `shell: isWindows()` because it sidesteps the shim on **every** platform rather than special-casing one, avoids the quoting hazards a shell would introduce for the `--location` path, and skips npx's resolution while it's at it.

## Why it matters beyond Windows

This has been quietly costing us. Every e2e spec written in the recent run of PRs went to CI **unrun**, because the only way to exercise one locally was to push and wait — so each of those PRs carried a "specs typecheck and lint; CI is the first real run" caveat. That caveat is now removable.

## Verification

Ran the `anon` suite locally for the first time on this machine. Azurite, the Functions host and the seed all come up, and the API-level assertions pass — including `expect(published.length, 'demo seed should have published articles')`, which proves the backend is genuinely live rather than the browser rendering mock data.

## The second half: local ran more parallel than CI

Fixing the spawn revealed the next problem. 6 of 13 anon tests failed locally on `page.goto()` — **after** the API assertions in the same tests passed — while the identical commit was green in CI.

Cause: `workers: process.env.CI ? 2 : 4`. Local had *more* concurrency than CI, against a Vite dev server that compiles on demand where CI navigates a warm one. Four workers pile onto an uncompiled server and the first navigations blow the 30s `navigationTimeout`.

Now a flat `2`. The point of running the suite locally is to predict what CI will say, and it cannot do that from a different concurrency. The file's own comment already argued for fewer workers — *"One Functions host serves every worker, so more workers mostly queue"* — which makes the local number the odd one out rather than a deliberate speed-up.

**It is not a trade:**

| | Result |
|---|---|
| 4 workers (old local default) | 7 passed, **6 failed** |
| 1 worker | 13 passed, 2.3m |
| **2 workers (new default)** | **13 passed, 1.6m** |

Four was pure contention — two workers is both correct *and* faster than serial.

## Verification

Both projects now pass locally, for the first time on this machine:

- `anon/public-browsing` — **13/13** in 1.6m
- `app/permissions` — **19/19** in 37s

That second one matters most: it is the file enumerating the whole API-path/role matrix, and the best regression net in the repo. It has been unrunnable locally until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
