### PR TITLE
fix(web): show a half-submitted document once, not twice

### DIFF
--- a/src/web/src/stores/editorQueue.spec.ts
+++ b/src/web/src/stores/editorQueue.spec.ts
@@ -34,6 +34,20 @@ beforeEach(() => {
 })
 
 describe('editorQueue store', () => {
+  it('counts a half-submitted item once', async () => {
+    // Submitting is not atomic, so an interruption leaves the same id in both lists.
+    // Counting both would badge one document as two.
+    await useAuthStore().initialize()
+    mockQueues([{ id: 'x1' }, { id: 'd2' }], [{ id: 'x1', authorId: adminOid }], [])
+
+    const store = useEditorQueueStore()
+    await store.refresh()
+
+    expect(store.draftCount).toBe(1)      // d2 only; x1 is already in review
+    expect(store.inReviewCount).toBe(1)
+    expect(store.openCount).toBe(2)       // not 3
+  })
+
   it('counts open drafts plus the caller’s own submissions', async () => {
     await useAuthStore().initialize() // dev-skip admin
     mockQueues([{ id: 'd1' }, { id: 'd2' }], [{ authorId: adminOid }], [{ authorId: adminOid }])

--- a/src/web/src/stores/editorQueue.ts
+++ b/src/web/src/stores/editorQueue.ts
@@ -32,14 +32,20 @@ export const useEditorQueueStore = defineStore('editorQueue', () => {
       if (!dr.ok || !ar.ok || !br.ok) return
 
       const [drafts, articles, blogs] = await Promise.all([
-        dr.json() as Promise<unknown[]>,
-        ar.json() as Promise<{ authorId?: string | null }[]>,
-        br.json() as Promise<{ authorId?: string | null }[]>,
+        dr.json() as Promise<{ id: string }[]>,
+        ar.json() as Promise<{ id: string; authorId?: string | null }[]>,
+        br.json() as Promise<{ id: string; authorId?: string | null }[]>,
       ])
 
-      draftCount.value = drafts.length
-      inReviewCount.value = [...articles, ...blogs]
-        .filter(x => auth.oid && x.authorId === auth.oid).length
+      const mine = [...articles, ...blogs].filter(x => auth.oid && x.authorId === auth.oid)
+
+      // An interrupted submit leaves the item in both lists for a moment — see the note in
+      // EditorView's `entries`. The submitted article reuses the draft's id, so counting
+      // both would report one document as two.
+      const submitted = new Set(mine.map(x => x.id))
+
+      draftCount.value = drafts.filter(d => !submitted.has(d.id)).length
+      inReviewCount.value = mine.length
       openCount.value = draftCount.value + inReviewCount.value
     } catch {
       // non-fatal — the badge just stays at its last known value

--- a/src/web/src/views/EditorView.spec.ts
+++ b/src/web/src/views/EditorView.spec.ts
@@ -56,7 +56,11 @@ function mockLists(drafts: unknown[]) {
 function mockWithPending(drafts: unknown[], pending: unknown[]) {
   apiJson.mockImplementation((path: string) => {
     if (path === '/drafts') return Promise.resolve(drafts)
-    return Promise.resolve(pending)
+    // Only the articles queue: returning `pending` for both review endpoints served
+    // every item twice, so a one-item fixture produced two rows and any assertion
+    // about how many rows there are was measuring the mock.
+    if (path === '/review/articles') return Promise.resolve(pending)
+    return Promise.resolve([])
   })
 }
 
@@ -70,6 +74,35 @@ beforeEach(async () => {
 })
 
 describe('EditorView', () => {
+  // ── The interrupted-submit window ──────────────────────────────────────────
+  // Submitting crosses a table and a partition boundary, so it cannot be atomic.
+  // The article is written before the draft is deleted, so an interruption leaves
+  // the same id in both lists rather than losing the work.
+
+  it('shows a half-submitted item once, as in-review', async () => {
+    // Same id in both lists: the article reuses the draft's id on submit.
+    mockWithPending([draftSummary({ id: 'x1', title: 'Caught mid-submit' })],
+                    [pendingItem({ id: 'x1', title: 'Caught mid-submit' })])
+    const w = mountV()
+    await flushPromises()
+
+    const rows = w.findAll('[data-testid="draft-row"]')
+    expect(rows).toHaveLength(1)
+    // The in-review side wins: it is the one that is true.
+    expect(rows[0].attributes('data-state')).toBe('in-review')
+  })
+
+  it('still lists a draft that has not been submitted', async () => {
+    mockWithPending([draftSummary({ id: 'd1' })], [pendingItem({ id: 'r1' })])
+    const w = mountV()
+    await flushPromises()
+
+    const states = w.findAll('[data-testid="draft-row"]').map(r => r.attributes('data-state'))
+    expect(states).toHaveLength(2)
+    expect(states).toContain('draft')
+    expect(states).toContain('in-review')
+  })
+
   it('opens the draft named by ?item= on arrival', async () => {
     // Arriving from the edit affordance with a revision already in progress.
     route.query = { item: 'd1' }

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -87,13 +87,28 @@ interface DraftEntry {
 }
 
 const entries = computed<DraftEntry[]>(() => {
-  const drafts: DraftEntry[] = allDrafts.value.map(d => ({
-    id: d.id, title: d.title, type: d.type, date: d.updatedAt, state: 'draft', etag: d._etag,
-  }))
   const pending: DraftEntry[] = pendingItems.value.map(p => ({
     id: p.id, title: p.title, type: p.type, date: p.publishedAt,
     state: 'in-review', isRevision: !!p.replacesArticleId,
   }))
+
+  // Submitting cannot be atomic: it crosses both a table and a partition boundary
+  // (drafts are keyed by author, articles by status), and Table Storage transactions
+  // are single-table, single-partition. The repository writes the article before
+  // deleting the draft, so an interrupted submit leaves a duplicate rather than losing
+  // the work — but until it is retried the same item is in both lists.
+  //
+  // The submitted article reuses the draft's id, so an id in both lists means exactly
+  // one thing: it is already submitted. The in-review entry wins, which makes the only
+  // visible symptom of that window impossible, and it resolves itself when the draft
+  // row finally goes.
+  const submitted = new Set(pending.map(p => p.id))
+  const drafts: DraftEntry[] = allDrafts.value
+    .filter(d => !submitted.has(d.id))
+    .map(d => ({
+      id: d.id, title: d.title, type: d.type, date: d.updatedAt, state: 'draft', etag: d._etag,
+    }))
+
   return [...drafts, ...pending].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 })


### PR DESCRIPTION
Follows a question about whether draft → content could be made atomic. It can't — but the one symptom of that was visible, and needn't be.

## Why atomicity is off the table

Submitting crosses **both** a table boundary and a partition boundary:

```
drafts (partition = authorId)  ──▶  articles (partition = status)
```

Table Storage's only transaction is an Entity Group Transaction: one table, one partition key. Cosmos would not help either — its transactional batch is also single-partition-key within a container. Plus two blob operations, which share no transaction with tables at all.

Collapsing the two tables is the only route to a real transaction, and **both partition keys are load-bearing for opposite reasons**: drafts key on `authorId` so privacy is *structural* (you physically cannot read another author's draft — no ownership check needed), articles key on `status` so the published read is one cheap single-partition query. Merging sacrifices one or the other.

## What the repository already gets right

```csharp
await body.PutAsync(ArticleBodyPrefix, article.Id, draftBody, ct);   // target
await store.Articles.UpsertEntityAsync(...);                          // target
await store.Drafts.DeleteEntityAsync(authorId, draft.Id, ...);        // source
await body.DeleteAsync(DraftBodyPrefix, draft.Id, ct);                // source
```

**Target first, source last** — an interruption leaves a duplicate, never a loss. And the article reuses the draft's id, so a retry is an idempotent upsert onto the same row rather than a second article.

| Crash point | Result |
|---|---|
| after article blob, before article row | orphan blob; draft intact; retry fixes |
| **after article row, before draft delete** | **visible in both lists** |
| after draft row, before draft blob | orphan blob; harmless litter |

Only the middle one reaches a user.

## The fix

`EditorView` merged both lists without deduping, so during that window one document rendered **twice** — once as a draft, once as In review — and the Editor badge counted it as two.

A shared id means exactly one thing: already submitted. So the in-review entry wins. That makes the only visible symptom impossible, and it clears itself when the draft row finally goes. Applied in both places that merge the lists: `EditorView.entries` and the `editorQueue` badge store.

No storage change, no API change.

## 🐞 And a harness bug it exposed

`mockWithPending` returned the same list for **both** `/review/articles` and `/review/blog`:

```ts
if (path === '/drafts') return Promise.resolve(drafts)
return Promise.resolve(pending)          // ← served to both review endpoints
```

So every pending fixture was served twice, and any assertion about how many rows the view rendered was measuring the mock rather than the view. Fixed to serve the articles queue only. This is the second harness bug of this kind found recently — after `DraftEditor.spec`'s `resp()` helper, whose `text()` ignored the body and made plain-text response assertions unfalsifiable.

## Verification

lint clean; **469 unit tests** pass (was 466); `npm run build` (vue-tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM8HhK2R4ynxw91TLuvfBe
