### PR TITLE
fix(web): keep the nav badge counts in step with editor actions

### DIFF
--- a/src/web/src/components/common/PublishedContent.spec.ts
+++ b/src/web/src/components/common/PublishedContent.spec.ts
@@ -12,6 +12,7 @@ vi.mock('@/lib/api', async (importOriginal) => {
 import PublishedContent from './PublishedContent.vue'
 import { useAuthStore } from '@/stores/auth'
 import { DEV_PERSONA_STORAGE_KEY } from '@/lib/devPersonas'
+import { useApprovalsStore } from '@/stores/approvals'
 
 const isDirtyMock = vi.fn(() => false)
 const flushMock = vi.fn().mockResolvedValue(undefined)
@@ -379,5 +380,34 @@ describe('PublishedContent', () => {
     const w = mountC()
     await flushPromises()
     expect(w.text()).toContain('Your published articles')
+  })
+
+  it('refreshes the approvals badge after an admin deletes a published item', async () => {
+    // Deleting clears any pending deletion request with it, so the badge in the
+    // admin menu is wrong until it is asked again.
+    vi.stubGlobal('confirm', vi.fn(() => true))
+    mockLoad([item()])
+    const w = mountC()
+    await flushPromises()
+    const spy = vi.spyOn(useApprovalsStore(pinia), 'refresh').mockResolvedValue(undefined)
+
+    await w.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
+    await flushPromises()
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('does not refresh the approvals badge when the delete fails', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => true))
+    mockLoad([item()])
+    const w = mountC()
+    await flushPromises()
+    const spy = vi.spyOn(useApprovalsStore(pinia), 'refresh').mockResolvedValue(undefined)
+    apiFetch.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('boom') } as unknown as Response)
+
+    await w.findAll('button').find(b => b.text() === 'Delete')!.trigger('click')
+    await flushPromises()
+
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/src/web/src/components/common/PublishedContent.vue
+++ b/src/web/src/components/common/PublishedContent.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { apiErrorMessage, apiFetch } from '@/lib/api'
 import { useAuthStore } from '@/stores/auth'
+import { useApprovalsStore } from '@/stores/approvals'
 import DraftEditor from '@/components/editor/DraftEditor.vue'
 
 interface PublishedItem {
@@ -19,6 +20,7 @@ interface PublishedItem {
 }
 
 const auth = useAuthStore()
+const approvals = useApprovalsStore()
 
 const items     = ref<PublishedItem[]>([])
 const loading   = ref(false)
@@ -170,6 +172,9 @@ async function remove(item: PublishedItem) {
       const idx = items.value.findIndex(x => x.id === item.id)
       if (idx >= 0) items.value.splice(idx, 1, { ...items.value[idx], ...updated })
     }
+    // Either branch moves the approvals count: an admin deleting clears any pending
+    // request, a contributor requesting one adds to it.
+    if (auth.isAdmin) approvals.refresh()
   } catch (err) {
     errors.value = { ...errors.value, [item.id]: err instanceof Error ? err.message : String(err) }
   } finally {

--- a/src/web/src/views/EditorView.spec.ts
+++ b/src/web/src/views/EditorView.spec.ts
@@ -18,6 +18,9 @@ vi.mock('vue-router', async (orig) => {
 
 import EditorView from './EditorView.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useEditorQueueStore } from '@/stores/editorQueue'
+import { useApprovalsStore } from '@/stores/approvals'
+import { DEV_PERSONA_STORAGE_KEY } from '@/lib/devPersonas'
 
 const DraftEditorStub = {
   props: ['draftId', 'readonly', 'initialContent'],
@@ -394,5 +397,95 @@ describe('EditorView', () => {
     await w.findAll('button').find(b => b.text() === 'Save draft')!.trigger('click')
     // The DraftEditorStub emits the same id (d1) which IS in the list — splice replaces it
     expect(w.text()).toContain('Saved title')
+  })
+
+  // ── Nav badge freshness ────────────────────────────────────────────────────
+  // Both badges live in AppNav, which only refreshes them on mount. Every action
+  // here changes a count, so each has to say so or the number in the admin menu
+  // stays at whatever it was when the page loaded.
+
+  function spyOnBadges() {
+    const editorQueue = useEditorQueueStore(pinia)
+    const approvals   = useApprovalsStore(pinia)
+    const editorSpy    = vi.spyOn(editorQueue, 'refresh').mockResolvedValue(undefined)
+    const approvalsSpy = vi.spyOn(approvals, 'refresh').mockResolvedValue(undefined)
+    return { editorSpy, approvalsSpy }
+  }
+
+  it('refreshes the badges after deleting a draft', async () => {
+    mockLists([draftSummary()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountV()
+    await flushPromises()
+    const { editorSpy } = spyOnBadges()
+
+    await w.find('button[title="Delete draft"]').trigger('click')
+    await flushPromises()
+
+    expect(editorSpy).toHaveBeenCalled()
+  })
+
+  it('does not refresh the badges when a delete fails', async () => {
+    // A stale count is wrong; a count refreshed away from a document that is still
+    // there is worse, because it tells the user the delete worked.
+    mockLists([draftSummary()])
+    apiFetch.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('boom') } as unknown as Response)
+    const w = mountV()
+    await flushPromises()
+    const { editorSpy } = spyOnBadges()
+
+    await w.find('button[title="Delete draft"]').trigger('click')
+    await flushPromises()
+
+    expect(editorSpy).not.toHaveBeenCalled()
+  })
+
+  it('refreshes approvals after submitting, since an admin now has one more to review', async () => {
+    mockLists([draftSummary()])
+    const w = mountV()
+    await flushPromises()
+    const { editorSpy, approvalsSpy } = spyOnBadges()
+
+    await w.find('[data-testid="draft-row-open"]').trigger('click')
+    await w.findAll('button').find(b => b.text() === 'Submit draft')!.trigger('click')
+    await flushPromises()
+
+    expect(editorSpy).toHaveBeenCalled()
+    expect(approvalsSpy).toHaveBeenCalled()
+  })
+
+  it('refreshes approvals after withdrawing, since the item leaves the review queue', async () => {
+    // The reported bug: withdraw refreshed only the editor count, so an admin's
+    // Approvals badge kept counting a document that was no longer waiting on them.
+    mockWithPending([], [pendingItem({ id: 'r1' })])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountV()
+    await flushPromises()
+    const { editorSpy, approvalsSpy } = spyOnBadges()
+
+    await w.find('[data-testid="draft-row-withdraw"]').trigger('click')
+    await flushPromises()
+
+    expect(editorSpy).toHaveBeenCalled()
+    expect(approvalsSpy).toHaveBeenCalled()
+  })
+
+  it('leaves approvals alone for a contributor, who has no such badge', async () => {
+    localStorage.setItem(DEV_PERSONA_STORAGE_KEY, 'contributor')
+    pinia = createPinia()
+    setActivePinia(pinia)
+    await useAuthStore().initialize()
+    mockLists([draftSummary()])
+    apiFetch.mockResolvedValue(ok({}))
+    const w = mountV()
+    await flushPromises()
+    const { editorSpy, approvalsSpy } = spyOnBadges()
+
+    await w.find('button[title="Delete draft"]').trigger('click')
+    await flushPromises()
+
+    expect(editorSpy).toHaveBeenCalled()
+    expect(approvalsSpy).not.toHaveBeenCalled()
+    localStorage.clear()
   })
 })

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -7,12 +7,14 @@ import { apiErrorMessage, apiFetch, apiJson } from '@/lib/api'
 import { EMPTY_DRAFT, makeDraftId, type DraftPayload, type DraftSummary } from '@/lib/draft'
 import { useAuthStore } from '@/stores/auth'
 import { useEditorQueueStore } from '@/stores/editorQueue'
+import { useApprovalsStore } from '@/stores/approvals'
 
 const DRAFT_ID_KEY = 'slypn:editor:draft-id'
 
 const auth = useAuthStore()
 const route = useRoute()
 const editorQueue = useEditorQueueStore()
+const approvals   = useApprovalsStore()
 
 // ── Draft list ──────────────────────────────────────────────────────────────
 const allDrafts   = ref<DraftSummary[]>([])
@@ -113,6 +115,16 @@ const entries = computed<DraftEntry[]>(() => {
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 })
 
+// Both nav badges are derived from server state, so anything that moves a document
+// between drafts and review invalidates them. Refreshed together rather than at each
+// call site guessing which one it affected: submitting and withdrawing leave the editor
+// count unchanged while moving the approvals count, which is exactly the pairing that
+// gets missed. Approvals only for an Admin — nobody else has that badge.
+function refreshBadges() {
+  editorQueue.refresh()
+  if (auth.isAdmin) approvals.refresh()
+}
+
 // ── Open draft (DraftEditor owns the editing surface) ────────────────────────
 const draftId         = ref<string>('')
 const editorOpen      = ref(false)
@@ -175,6 +187,7 @@ function onSubmitted(id: string) {
   editorOpen.value = false
   submitMessage.value = 'Submitted for admin review.'
   loadPending()
+  refreshBadges()
 }
 
 // ── New draft dialog ─────────────────────────────────────────────────────────
@@ -202,6 +215,7 @@ async function createDraft() {
   } catch { /* DraftEditor autosave will retry */ }
 
   allDrafts.value.unshift({ id, title, type: newType.value, updatedAt: new Date().toISOString() })
+  refreshBadges()
   showNewDraft.value  = false
   submitMessage.value = null
   draftId.value       = id
@@ -221,6 +235,7 @@ async function deleteDraft(id: string, etag?: string) {
     if (!resp.ok) { deleteError.value = `${resp.status} ${await resp.text().catch(() => '')}`; return }
     allDrafts.value = allDrafts.value.filter(d => d.id !== id)
     if (draftId.value === id) { editorOpen.value = false; localStorage.removeItem(DRAFT_ID_KEY) }
+    refreshBadges()
   } catch (err) {
     deleteError.value = err instanceof Error ? err.message : String(err)
   }
@@ -247,7 +262,7 @@ async function withdraw(id: string) {
     allDrafts.value = [draft, ...allDrafts.value.filter(d => d.id !== draft.id)]
     if (draftId.value === id) { editorOpen.value = false; readonlyContent.value = null }
     submitMessage.value = 'Withdrawn from review — it is back in your drafts.'
-    editorQueue.refresh()
+    refreshBadges()
   } catch (err) {
     withdrawError.value = err instanceof Error ? err.message : String(err)
   } finally {


### PR DESCRIPTION
The Approvals and Editor badges in the admin menu are derived from server state, but only `AppNav`'s `onMounted` and the approvals page itself ever refreshed them. Anything done elsewhere left them showing whatever the counts were when the page loaded.

## What was stale, and when

| Action | Editor badge | Approvals badge | Refreshed before |
|---|---|---|---|
| Delete a draft | −1 | — | **nothing** |
| Create a draft | +1 | — | **nothing** |
| Submit for review | net 0 | **+1** | nothing |
| Withdraw a submission | net 0 | **−1** | editor queue only |
| Request deletion | — | **+1** | nothing |

Delete is the reported symptom: the row was removed locally and nothing told the badge, so the Editor count kept counting a document that was gone.

The approvals half is subtler, and is the "approvals included in wrong count" case. Submit and withdraw leave the *Editor* count unchanged — the badge counts drafts plus own in-review, and the document simply moves between the two — while moving the *Approvals* count by one. `withdraw()` refreshed only the editor queue, the one count it could not change, and not approvals, the one it did. An admin withdrawing their own submission was left with an Approvals badge still counting a document no longer waiting on them.

## The fix

Both badges are refreshed together by one helper, after the action succeeds. Call sites should not have to work out which of the two a given transition moves — that reasoning is exactly what was wrong here, and it was wrong in the non-obvious direction. Approvals is fetched only for an Admin, who is the only one with that badge.

Refreshing only on success is deliberate: a stale count is wrong, but a count refreshed away from a document that is still there is worse, because it tells the user a failed delete worked. There is a test for that.

## Tests

Five in `EditorView.spec` (delete, submit, withdraw, the failed-delete guard, and a contributor who must not trigger an approvals fetch) and two in `PublishedContent.spec`.

Verified falsifiable rather than assumed: reverting each component and re-running fails the four positive EditorView cases and the PublishedContent one. The two guard tests pass either way by design.

`npm run lint`, `test:unit` (476 passing) and `build` all green.