### PR TITLE
fix: lock content type once an article row exists

### DIFF
--- a/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
+++ b/src/api/Slypn.Api.Tests/AdminFunctionsTests.cs
@@ -151,6 +151,87 @@ public class AdminFunctionsTests
         Assert.Contains((int)submit.StatusCode, new[] { 200, 201 });
     }
 
+
+    // ── Content type is fixed once an Article row exists ────────────────────
+    // A revision draft is a copy of a published article, and that article's type picks the
+    // public URL prefix. Letting the type change here moved the live item from /articles to
+    // /blog on approval and 404'd the original URL.
+
+    private static Draft RevisionDraft(string type) => new(
+        Id: "d1", AuthorId: "oid-1", AuthorName: "Author", Type: type,
+        Title: "T", Slug: "s", Summary: "Sum", Body: "<p>hi</p>", Category: "Community",
+        ReadingMinutes: 3, CreatedAt: DateTime.UtcNow, UpdatedAt: DateTime.UtcNow,
+        ReplacesArticleId: "a1");
+
+    private static object DraftBody(string type) => new
+    {
+        type, title = "T", slug = "s", summary = "Sum",
+        body = "<p>hi</p>", category = "Community", readingMinutes = 3,
+    };
+
+    [Theory]
+    [InlineData("article", "blog")]
+    [InlineData("blog", "article")]
+    public async Task Revision_draft_refuses_a_type_change(string stored, string attempted)
+    {
+        // Both directions: a check written one way round passes for the wrong reason.
+        var repo = new FakeContentRepository { DraftById = RevisionDraft(stored) };
+        var fn = DraftsFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
+
+        var resp = (TestHttpResponseData)await fn.Upsert(
+            TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/d1", DraftBody(attempted)), ctx, "d1", Ct);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var text = resp.ReadBodyAsString();
+        Assert.Contains(stored, text);      // says what it is
+        Assert.Contains(attempted, text);   // and what was asked for
+    }
+
+    [Fact]
+    public async Task Revision_draft_allows_a_save_that_keeps_its_type()
+    {
+        // The guard must not block ordinary editing of a revision.
+        var repo = new FakeContentRepository { DraftById = RevisionDraft("blog") };
+        var fn = DraftsFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
+
+        var resp = (TestHttpResponseData)await fn.Upsert(
+            TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/d1", DraftBody("blog")), ctx, "d1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Plain_draft_may_still_change_its_type()
+    {
+        // Nothing is published yet, so there is no URL to break. Miscategorisation stays
+        // fixable right up to submission, which is the whole reason the lock starts later.
+        var repo = new FakeContentRepository { DraftById = RevisionDraft("article") with { ReplacesArticleId = null } };
+        var fn = DraftsFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
+
+        var resp = (TestHttpResponseData)await fn.Upsert(
+            TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/d1", DraftBody("blog")), ctx, "d1", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_brand_new_draft_may_pick_either_type()
+    {
+        // No stored row at all: the guard reads existing?.ReplacesArticleId, so a null
+        // existing must not trip it.
+        var repo = new FakeContentRepository { DraftById = null };
+        var fn = DraftsFn(repo);
+        var ctx = new TestFunctionContext().WithUser("oid-1", "Author", "Contributor");
+
+        var resp = (TestHttpResponseData)await fn.Upsert(
+            TestHttp.Json(ctx, "PUT", "http://localhost/api/drafts/dnew", DraftBody("blog")), ctx, "dnew", Ct);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
     // ── Media ──────────────────────────────────────────────────────────────
     [Fact]
     public async Task Media_503_when_unconfigured()

--- a/src/api/Slypn.Api.Tests/ContentRepositoryWriteTests.cs
+++ b/src/api/Slypn.Api.Tests/ContentRepositoryWriteTests.cs
@@ -105,4 +105,67 @@ public class ContentRepositoryWriteTests
         Assert.Equal("some future field's worth of state",
             ContentRepository.ApplyInput(stored, Hostile()).RejectionReason);
     }
+
+    // ── Approving a revision ───────────────────────────────────────────────────
+    // ApplyRevision lays a reviewed item over the published article it replaces. The type is
+    // deliberately not among the fields it carries across: a revision that disagreed used to
+    // flip the live item between /articles and /blog, keeping the slug but changing the URL
+    // prefix, so the address it was published under started 404ing.
+
+    /// <summary>An in-review revision whose every field differs from its target, including type.</summary>
+    private static Article Review(string type) => new(
+        "r1", "review-slug", "Reviewed title", "Reviewed summary", "<p>Reviewed body</p>",
+        "Bob", new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc), 2, "Treatment", "in-review")
+    {
+        Type = type,
+        AuthorId = "oid-bob",
+        ReplacesArticleId = "a1",
+    };
+
+    [Theory]
+    [InlineData("blog", "article")]
+    [InlineData("article", "blog")]
+    public async Task Approving_a_revision_keeps_the_published_type(string published, string reviewed)
+    {
+        // Both directions, and the mismatch is built directly rather than through the editor:
+        // with the save-time guard in place nothing normally reaches here, which is exactly
+        // why this needs testing on its own.
+        await Task.CompletedTask;
+        var target = Stored() with { Type = published };
+
+        var result = ContentRepository.ApplyRevision(target, Review(reviewed));
+
+        Assert.Equal(published, result.Type);
+    }
+
+    [Fact]
+    public async Task Approving_a_revision_keeps_the_public_URL_and_takes_the_new_content()
+    {
+        // The reason the type matters: id, slug and publish date are preserved precisely so the
+        // URL survives a revision. A type change would move the item to the other prefix and
+        // undo that, which is why it is excluded rather than merely discouraged.
+        await Task.CompletedTask;
+        var target = Stored() with { Type = "blog" };
+
+        var result = ContentRepository.ApplyRevision(target, Review("article"));
+
+        Assert.Equal(target.Id, result.Id);
+        Assert.Equal(target.Slug, result.Slug);
+        Assert.Equal(target.PublishedAt, result.PublishedAt);
+        Assert.Equal(target.AuthorId, result.AuthorId);
+        Assert.Equal("blog", result.Type);
+
+        // The content itself must still come from the review, or the revision did nothing.
+        Assert.Equal("Reviewed title", result.Title);
+        Assert.Equal("Reviewed summary", result.Summary);
+        Assert.Equal("Treatment", result.Category);
+        Assert.Equal(2, result.ReadingMinutes);
+
+        // And the workflow state is cleared, so the item lands clean.
+        Assert.Equal("published", result.Status);
+        Assert.Null(result.ReplacesArticleId);
+        Assert.Null(result.RejectionReason);
+        Assert.Null(result.DeletionRequestedBy);
+        Assert.Null(result.DeletionRequestedAt);
+    }
 }

--- a/src/api/Slypn.Api/Functions/DraftsFunctions.cs
+++ b/src/api/Slypn.Api/Functions/DraftsFunctions.cs
@@ -97,6 +97,18 @@ public sealed class DraftsFunctions(IContentRepository repo, IHtmlSanitizer sani
         try { existing = await repo.GetDraftAsync(id, authorId, ct); }
         catch (RequestFailedException ex) { return await MapStorageException(req, ex, log); }
 
+        // A revision draft is a copy of a published article, and that article's type decides
+        // which public URL prefix serves it. Changing the type here would move the live item
+        // from /articles/{slug} to /blog/{slug} on approval, leaving the original URL a 404.
+        // Refused rather than quietly pinned to the stored type: silently discarding a stated
+        // type is how blog posts became articles in the first place (#192).
+        if (existing?.ReplacesArticleId is not null
+            && !string.Equals(input!.Type, existing.Type, StringComparison.OrdinalIgnoreCase))
+            return await BadRequest(req,
+                $"This revision is for a {existing.Type}, so it cannot be saved as a "
+                + $"{input.Type}. The type is fixed once an item is published, because its "
+                + "public URL depends on it.");
+
         var draft = new Draft(
             Id:               id,
             AuthorId:         authorId,

--- a/src/api/Slypn.Api/Services/ContentRepository.cs
+++ b/src/api/Slypn.Api/Services/ContentRepository.cs
@@ -170,6 +170,35 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
     /// which the revision path deliberately does not do. That inconsistency predates this method
     /// and is left alone rather than fixed in passing.
     /// </summary>
+    /// <summary>
+    /// The merge behind approving a revision: the reviewed content is laid over the published
+    /// article it replaces, which keeps its id, slug and original publish date so the public
+    /// URL never changes.
+    ///
+    /// <para><b>Type is not in the list.</b> `target with` preserves it, matching the "stored
+    /// row always wins" rule on <see cref="ApplyInput"/>. Carrying the review's type across was
+    /// how a revision could flip a published item between /articles and /blog: the item keeps
+    /// its slug but changes URL prefix, so the address it was published under starts 404ing.
+    /// Structural rather than a guard, so it holds however the in-review row got its type.</para>
+    ///
+    /// Pure and static for the same reason ApplyInput is: the repository's write path has no
+    /// test seam, so the merge is tested directly.
+    /// </summary>
+    internal static Article ApplyRevision(Article target, Article review) =>
+        target with
+        {
+            Title          = review.Title,
+            Summary        = review.Summary,
+            Category       = review.Category,
+            ReadingMinutes = review.ReadingMinutes,
+            Status         = PublishedStatus,
+            RejectionReason     = null,
+            ReplacesArticleId   = null,
+            DeletionRequestedBy = null,
+            DeletionRequestedAt = null,
+            Etag           = null,
+        };
+
     internal static Article ApplyInput(Article existing, ArticleInput input) =>
         existing with
         {
@@ -646,6 +675,16 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
                 throw new ContentUnchangedException(
                     "This revision is identical to the published version, so there is nothing "
                     + "to review. Make a change first, or close the editor to discard it.");
+
+            // Saving the draft refuses a type change, so this only catches one stored before
+            // that guard existed. Approval would preserve the target's type regardless — this
+            // says so plainly instead of accepting a submission that quietly would not apply.
+            if (target is not null
+                && !string.Equals(NormalizeType(draft.Type), target.Type, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException(
+                    $"This revision is for a {target.Type}, so it cannot be submitted as a "
+                    + $"{NormalizeType(draft.Type)}. The type is fixed once an item is published, "
+                    + "because its public URL depends on it.");
         }
 
         var article = new Article(
@@ -745,20 +784,7 @@ public sealed class ContentRepository(ITableStore store, IContentBodyStore body,
         var target = await GetArticleAsync(review.ReplacesArticleId, PublishedStatus, ct)
             ?? throw new InvalidOperationException($"Target published article {review.ReplacesArticleId} not found.");
 
-        var replacement = target with
-        {
-            Title          = review.Title,
-            Summary        = review.Summary,
-            Category       = review.Category,
-            ReadingMinutes = review.ReadingMinutes,
-            Type           = review.Type,
-            Status         = PublishedStatus,
-            RejectionReason     = null,
-            ReplacesArticleId   = null,
-            DeletionRequestedBy = null,
-            DeletionRequestedAt = null,
-            Etag           = null,
-        };
+        var replacement = ApplyRevision(target, review);
 
         await body.PutAsync(ArticleBodyPrefix, target.Id, review.Body, ct);
         var saved = await store.Articles.UpsertEntityAsync(ArticleEntity(replacement), TableUpdateMode.Replace, ct);

--- a/src/web/e2e/app/content-revision.spec.ts
+++ b/src/web/e2e/app/content-revision.spec.ts
@@ -116,6 +116,34 @@ test.describe('revision workflow', () => {
     expect((await api.post(`/drafts/${revision.id}/submit`)).ok()).toBeTruthy()
   })
 
+  test('a revision cannot change the content type', async ({ api, adminApi, cleanup, uid }) => {
+    // A revision keeps the published article's id and slug so its URL survives. The type
+    // picks the URL prefix, so changing it would move the live item from /articles/{slug}
+    // to /blog/{slug} and 404 the address it was published under.
+    const article = await publishAuthoredArticle(api, adminApi, cleanup, {
+      title: titleFor(uid, 'Type is fixed'),
+    })
+
+    const revision = await (await api.post(`/content/${article.id}/edit`)).json() as { id: string }
+    const draft = await (await api.get(`/drafts/${revision.id}`)).json() as Record<string, unknown>
+    expect(draft.replacesArticleId).toBe(article.id)
+    expect(draft.type).toBe('article')
+
+    const refused = await api.put(`/drafts/${revision.id}`, { ...draft, type: 'blog' })
+    expect(refused.status()).toBe(400)
+    const message = await refused.text()
+    expect(message).toContain('article')
+    expect(message).toContain('blog')
+
+    // Not a blanket block: the same revision still saves when the type is left alone.
+    const saved = await api.put(`/drafts/${revision.id}`, { ...draft, summary: 'Genuinely revised.' })
+    expect(saved.ok()).toBeTruthy()
+
+    // And the published article is untouched by the refused attempt.
+    const live = await (await api.get(`/articles/${article.slug}`)).json() as { type?: string }
+    expect(live.type ?? 'article').toBe('article')
+  })
+
   test('editing published content creates a revision, and approving it updates the live copy',
     async ({ page, browser, api, adminApi, cleanup, uid }) => {
       const original = await publishAuthoredArticle(api, adminApi, cleanup, {

--- a/src/web/src/components/editor/DraftEditor.spec.ts
+++ b/src/web/src/components/editor/DraftEditor.spec.ts
@@ -230,4 +230,42 @@ describe('DraftEditor', () => {
     expect(w.find('[data-testid="draft-submit-notice"]').exists()).toBe(false)
   })
 
+  // ── Content type is fixed once an item is published ────────────────────────
+  // A revision keeps the article's id and slug so the URL survives, but the type picks the
+  // URL prefix. Offering the toggle invited a change the API refuses on save and on submit.
+
+  it('shows the type as fixed on a revision draft, with no toggle', async () => {
+    mockApi((url, method) =>
+      url.startsWith('/drafts/') && method === 'GET'
+        ? resp({ ...draftPayload, type: 'blog', replacesArticleId: 'a1' })
+        : undefined)
+    const w = mountEditor()
+    await flushPromises()
+
+    expect(w.find('[data-testid="draft-type-article"]').exists()).toBe(false)
+    expect(w.find('[data-testid="draft-type-blog"]').exists()).toBe(false)
+    // Still legible: the author can see what the item is, just not change it.
+    expect(w.find('[data-testid="draft-type-locked"]').text()).toContain('Blog post')
+  })
+
+  it('still offers the toggle on a draft that replaces nothing', async () => {
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+
+    expect(w.find('[data-testid="draft-type-article"]').exists()).toBe(true)
+    expect(w.find('[data-testid="draft-type-blog"]').exists()).toBe(true)
+    expect(w.find('[data-testid="draft-type-locked"]').exists()).toBe(false)
+  })
+
+  it('lets a plain draft still switch type', async () => {
+    // The lock must not leak into ordinary drafts — miscategorisation stays fixable until
+    // the item is published.
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+
+    await w.find('[data-testid="draft-type-blog"]').trigger('click')
+    expect(w.find('[data-testid="draft-type-blog"]').classes().join(' ')).toContain('bg-slypn-600')
+  })
 })

--- a/src/web/src/components/editor/DraftEditor.vue
+++ b/src/web/src/components/editor/DraftEditor.vue
@@ -23,6 +23,11 @@ const emit = defineEmits<{
 }>()
 
 const draft       = ref<DraftPayload>({ ...EMPTY_DRAFT })
+
+// A revision draft may not change type: the article it replaces is already published under a
+// type-specific URL. Enforced by the API on save and again on submit; this keeps the control
+// from offering a choice that would be refused.
+const typeLocked  = computed(() => !!draft.value.replacesArticleId)
 const currentEtag = ref<string | null>(null)
 const switching   = ref(false)
 const uploadError = ref<string | null>(null)
@@ -304,7 +309,21 @@ watch(() => draft.value.body, (html) => {
     <div class="space-y-4 rounded-xl border border-slypn-100 bg-white p-6 shadow-sm">
       <fieldset>
         <legend class="text-sm font-medium text-slypn-800">Type</legend>
-        <div class="mt-2 inline-flex rounded-md border border-slypn-200 bg-white p-1">
+
+        <!-- A revision keeps the published item's id and slug so its URL survives, but the
+             type picks the URL prefix — flipping it would move the item to the other prefix
+             and 404 the address it was published under. Shown as a fact rather than hidden,
+             so the type is still visible while editing. -->
+        <p
+          v-if="typeLocked"
+          data-testid="draft-type-locked"
+          class="mt-2 text-sm text-slypn-700"
+        >
+          {{ draft.type === 'blog' ? 'Blog post' : 'Article' }}
+          <span class="text-slypn-900/60">— fixed once published</span>
+        </p>
+
+        <div v-else class="mt-2 inline-flex rounded-md border border-slypn-200 bg-white p-1">
           <button
             v-for="t in (['article', 'blog'] as const)"
             :key="t"

--- a/src/web/src/lib/draft.ts
+++ b/src/web/src/lib/draft.ts
@@ -9,6 +9,11 @@ export interface DraftPayload {
   category: string
   readingMinutes: number
   revisionFeedback?: string | null
+  /// Set when this draft revises a published article. Server-owned: it is not a DraftInput
+  /// field, and the API takes it from the stored row, so sending it back on save is inert.
+  /// Present here because the type is fixed once an item is published — the published URL
+  /// prefix depends on it — and the editor needs to know not to offer the choice.
+  replacesArticleId?: string | null
 }
 
 export interface DraftSummary {


### PR DESCRIPTION
The editor offers a type toggle on any draft that isn't readonly, and on a revision draft **it works** — it was never a UI control the API refused. The refusal in `ReplaceArticleAsync` (`ContentRepository.cs:238`) only guards `PUT /content/{id}`, a path the SPA barely uses. The revision route goes around it:

```
/edit copies the published article into a draft carrying ReplacesArticleId
  -> the toggle flips draft.type; UpsertDraftAsync had no guard
  -> SubmitDraftAsync builds the in-review row with Type = draft.Type
  -> PublishArticleAsync applied Type = review.Type to the target
```

The published item keeps its id and slug but changes URL prefix, so `/articles/{slug}` starts 404ing — `WithNeighboursAsync` filters to a type *before* matching the slug. That's exactly the breakage the existing refusal exists to prevent, reachable through the door the UI actually points at.

## The rule

**A draft with `ReplacesArticleId` set may not change type.** Everything else stays editable:

- A new draft — nothing published, no URL to break.
- A rejected *first* submission — `ReviseArticleAsync` deletes the in-review row and its body blob, so it's a plain draft again.
- A rejected *revision* keeps `ReplacesArticleId`, so the same rule locks it. No special case.

## Enforced in three places, each for a different reason

| Where | Why |
|---|---|
| Draft save (`DraftsFunctions.cs`) | Earliest point; stops a wrong type ever being stored. **400**, naming both types. |
| Revision approval (`ApplyRevision`) | Structural backstop — holds however the in-review row got its type, including drafts saved before this ships. |
| Submit (`SubmitDraftAsync`) | A draft stored before this change gets a clear message instead of a submission that quietly wouldn't apply. |

The save guard **refuses** rather than quietly pinning the type the way `ReplacesArticleId` is pinned — silently discarding a stated type is how blog posts became articles in the first place (#192).

The approval merge is now a pure static, `ApplyRevision`, following the precedent `ApplyInput` set when that same class of bug was fixed: the repository write path has no test seam, so the merge is extracted to be tested directly. `Type` is simply absent from it — `target with` preserves it, which is what the documented "stored row always wins" rule at `:158` already claimed.

## UI

The toggle becomes a static `Blog post — fixed once published` label when `replacesArticleId` is set, so the type stays visible while editing rather than the control silently vanishing. Plain drafts keep the toggle; the new-draft picker is untouched.

`DraftPayload` gains `replacesArticleId`. The API already sends it and `DraftEditor` spreads the response wholesale, so only the type declaration was missing. Sending it back on save is inert — it isn't a `DraftInput` field, and the server takes it from the stored row.

## Tests

Four in `AdminFunctionsTests` (both directions as a `[Theory]`, plus a same-type save, a plain draft and a brand-new draft, so the guard isn't blanket), three for `ApplyRevision`, three in `DraftEditor.spec`, one e2e against a live API.

Verified falsifiable rather than assumed: reverting each change fails its tests, and reintroducing `Type = review.Type` fails three of them.

**One honest gap** — the submit-time guard has no automated coverage. With the save guard in place, no public path can create the state it catches, so there's nothing to drive it from a test. It's a backstop for pre-existing data, and `ApplyRevision` makes that data safe regardless.

API **405** passing, web **479**, e2e **124**.