### PR TITLE
fix(web): refresh the editor count after acting on a submission

### DIFF
--- a/src/web/src/components/common/ApprovalsQueue.vue
+++ b/src/web/src/components/common/ApprovalsQueue.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { apiErrorMessage, apiFetch } from '@/lib/api'
 import { useApprovalsStore } from '@/stores/approvals'
+import { useEditorQueueStore } from '@/stores/editorQueue'
 
 interface PendingArticle {
   id: string
@@ -21,6 +22,7 @@ interface PendingArticle {
 }
 
 const approvalsStore = useApprovalsStore()
+const editorQueue    = useEditorQueueStore()
 
 const articles  = ref<PendingArticle[]>([])
 const deletions = ref<PendingArticle[]>([])
@@ -32,6 +34,16 @@ const errors    = ref<Record<string, string | null>>({})
 
 function syncPendingCount() {
   approvalsStore.pendingCount = articles.value.length + deletions.value.length
+}
+
+// Acting on a submission also moves it out of its author's editor queue, and when the admin
+// reviewing it is the author — the usual case on a small site — that is this same session's
+// Editor badge. Approving used to leave it counting an item that was already published.
+// Refreshed rather than adjusted locally: the count is the caller's own drafts plus their own
+// submissions, which this component does not track. Called for revise too, which only nets to
+// zero because the draft goes back to the same author; the call site should not depend on that.
+function refreshEditorQueue() {
+  editorQueue.refresh()
 }
 
 const reviseDialog = ref<{ show: boolean; article: PendingArticle | null; feedback: string }>({
@@ -94,6 +106,7 @@ async function publish(article: PendingArticle) {
     if (!resp.ok) throw new Error(await apiErrorMessage(resp))
     articles.value = articles.value.filter(a => a.id !== article.id)
     syncPendingCount()
+    refreshEditorQueue()
   } catch (err) {
     errors.value = { ...errors.value, [article.id]: err instanceof Error ? err.message : String(err) }
   } finally {
@@ -155,6 +168,7 @@ async function confirmRevise() {
     if (!resp.ok) throw new Error(await apiErrorMessage(resp))
     articles.value = articles.value.filter(a => a.id !== article.id)
     syncPendingCount()
+    refreshEditorQueue()
   } catch (err) {
     errors.value = { ...errors.value, [article.id]: err instanceof Error ? err.message : String(err) }
   } finally {

--- a/src/web/src/components/common/ApprovalsQueue.vue
+++ b/src/web/src/components/common/ApprovalsQueue.vue
@@ -36,14 +36,34 @@ function syncPendingCount() {
   approvalsStore.pendingCount = articles.value.length + deletions.value.length
 }
 
-// Acting on a submission also moves it out of its author's editor queue, and when the admin
-// reviewing it is the author — the usual case on a small site — that is this same session's
-// Editor badge. Approving used to leave it counting an item that was already published.
-// Refreshed rather than adjusted locally: the count is the caller's own drafts plus their own
-// submissions, which this component does not track. Called for revise too, which only nets to
-// zero because the draft goes back to the same author; the call site should not depend on that.
-function refreshEditorQueue() {
-  editorQueue.refresh()
+/// Approving and sending back differ only in the call they make: both then drop the item from
+/// the queue, resync the badges, and report a failure against that row. Shared so the two
+/// cannot drift, and so the editor-count refresh is stated once.
+///
+/// Acting on a submission also moves it out of its author's editor queue, and when the admin
+/// reviewing it is the author — the usual case on a small site — that is this same session's
+/// Editor badge, which used to go on counting an item that was already published. The count is
+/// the caller's own drafts plus their own submissions, which this component does not track, so
+/// it is refetched rather than adjusted here. Revise only nets to zero because the draft goes
+/// back to the same author; that is a coincidence, not something to depend on.
+async function resolveSubmission(
+  article: PendingArticle,
+  state: 'publishing' | 'revising',
+  call: () => Promise<Response>,
+) {
+  busy.value = { ...busy.value, [article.id]: state }
+  errors.value = { ...errors.value, [article.id]: null }
+  try {
+    const resp = await call()
+    if (!resp.ok) throw new Error(await apiErrorMessage(resp))
+    articles.value = articles.value.filter(a => a.id !== article.id)
+    syncPendingCount()
+    editorQueue.refresh()
+  } catch (err) {
+    errors.value = { ...errors.value, [article.id]: err instanceof Error ? err.message : String(err) }
+  } finally {
+    busy.value = { ...busy.value, [article.id]: null }
+  }
 }
 
 const reviseDialog = ref<{ show: boolean; article: PendingArticle | null; feedback: string }>({
@@ -98,20 +118,9 @@ async function load() {
   }
 }
 
-async function publish(article: PendingArticle) {
-  busy.value = { ...busy.value, [article.id]: 'publishing' }
-  errors.value = { ...errors.value, [article.id]: null }
-  try {
-    const resp = await apiFetch(`/content/${article.id}/publish`, { method: 'POST' })
-    if (!resp.ok) throw new Error(await apiErrorMessage(resp))
-    articles.value = articles.value.filter(a => a.id !== article.id)
-    syncPendingCount()
-    refreshEditorQueue()
-  } catch (err) {
-    errors.value = { ...errors.value, [article.id]: err instanceof Error ? err.message : String(err) }
-  } finally {
-    busy.value = { ...busy.value, [article.id]: null }
-  }
+function publish(article: PendingArticle) {
+  return resolveSubmission(article, 'publishing',
+    () => apiFetch(`/content/${article.id}/publish`, { method: 'POST' }))
 }
 
 // ── Deletion requests ────────────────────────────────────────────────────────
@@ -158,22 +167,11 @@ async function confirmRevise() {
     return
   }
   reviseDialog.value.show = false
-  busy.value = { ...busy.value, [article.id]: 'revising' }
-  errors.value = { ...errors.value, [article.id]: null }
-  try {
-    const resp = await apiFetch(`/content/${article.id}/revise`, {
+  await resolveSubmission(article, 'revising',
+    () => apiFetch(`/content/${article.id}/revise`, {
       method: 'POST',
       body: JSON.stringify({ feedback: feedback.trim() }),
-    })
-    if (!resp.ok) throw new Error(await apiErrorMessage(resp))
-    articles.value = articles.value.filter(a => a.id !== article.id)
-    syncPendingCount()
-    refreshEditorQueue()
-  } catch (err) {
-    errors.value = { ...errors.value, [article.id]: err instanceof Error ? err.message : String(err) }
-  } finally {
-    busy.value = { ...busy.value, [article.id]: null }
-  }
+    }))
 }
 
 function toggle(id: string) {

--- a/src/web/src/views/views.admin.spec.ts
+++ b/src/web/src/views/views.admin.spec.ts
@@ -82,31 +82,31 @@ describe('ApprovalsQueue', () => {
   // the author — the usual case here — that is this same session's badge, which used to go
   // on counting an item that was already published.
 
-  it('refreshes the editor count after approving', async () => {
+  /// Approve one pending item and report whether the editor count was asked to refresh.
+  /// Both cases mount and click the same way; only the API's answer to the publish differs.
+  async function approveAndWatchEditorCount(publishSucceeds: boolean) {
     mockLoad([pending()])
     const w = mountC(ApprovalsQueue)
     await flushPromises()
     const spy = vi.spyOn(useEditorQueueStore(pinia), 'refresh').mockResolvedValue(undefined)
+    if (!publishSucceeds) {
+      apiFetch.mockResolvedValue(
+        { ok: false, status: 500, text: () => Promise.resolve('boom') } as unknown as Response)
+    }
 
     await w.findAll('button').find(b => b.text() === 'Approve')!.trigger('click')
     await flushPromises()
+    return spy
+  }
 
-    expect(spy).toHaveBeenCalled()
+  it('refreshes the editor count after approving', async () => {
+    expect(await approveAndWatchEditorCount(true)).toHaveBeenCalled()
   })
 
   it('does not refresh the editor count when approving fails', async () => {
     // A count refreshed away from an item still sitting in review would say the approval
     // worked.
-    mockLoad([pending()])
-    const w = mountC(ApprovalsQueue)
-    await flushPromises()
-    const spy = vi.spyOn(useEditorQueueStore(pinia), 'refresh').mockResolvedValue(undefined)
-    apiFetch.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('boom') } as unknown as Response)
-
-    await w.findAll('button').find(b => b.text() === 'Approve')!.trigger('click')
-    await flushPromises()
-
-    expect(spy).not.toHaveBeenCalled()
+    expect(await approveAndWatchEditorCount(false)).not.toHaveBeenCalled()
   })
 
   it('toggles the article body open', async () => {

--- a/src/web/src/views/views.admin.spec.ts
+++ b/src/web/src/views/views.admin.spec.ts
@@ -13,6 +13,7 @@ vi.mock('vue-router', async (orig) => {
 })
 
 import ApprovalsQueue from '@/components/common/ApprovalsQueue.vue'
+import { useEditorQueueStore } from '@/stores/editorQueue'
 import ResourceManagementView from './ResourceManagementView.vue'
 import ApprovalsView from './ApprovalsView.vue'
 import ManageContentView from './ManageContentView.vue'
@@ -74,6 +75,38 @@ describe('ApprovalsQueue', () => {
     await flushPromises()
     expect(apiFetch).toHaveBeenCalledWith('/content/p1/publish', { method: 'POST' })
     expect(w.text()).not.toContain('Pending piece')
+  })
+
+// ── The Editor badge after acting on a submission ──────────────────────────
+  // Approving moves the item out of its author's editor queue. When the reviewing admin is
+  // the author — the usual case here — that is this same session's badge, which used to go
+  // on counting an item that was already published.
+
+  it('refreshes the editor count after approving', async () => {
+    mockLoad([pending()])
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    const spy = vi.spyOn(useEditorQueueStore(pinia), 'refresh').mockResolvedValue(undefined)
+
+    await w.findAll('button').find(b => b.text() === 'Approve')!.trigger('click')
+    await flushPromises()
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('does not refresh the editor count when approving fails', async () => {
+    // A count refreshed away from an item still sitting in review would say the approval
+    // worked.
+    mockLoad([pending()])
+    const w = mountC(ApprovalsQueue)
+    await flushPromises()
+    const spy = vi.spyOn(useEditorQueueStore(pinia), 'refresh').mockResolvedValue(undefined)
+    apiFetch.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('boom') } as unknown as Response)
+
+    await w.findAll('button').find(b => b.text() === 'Approve')!.trigger('click')
+    await flushPromises()
+
+    expect(spy).not.toHaveBeenCalled()
   })
 
   it('toggles the article body open', async () => {


### PR DESCRIPTION
## Approving left the Editor badge stale

`publish()` removed the item from the approvals list and called `syncPendingCount()`, but never touched the editor queue. The editor count is *the caller's own drafts plus their own submissions awaiting review*, so when the admin approving something is also its author — the usual case on a small site — the Editor badge kept counting an item that was already published.

The approvals side was already right on this page: `syncPendingCount()` runs on every action, and it's exact rather than a refetch because the component owns both lists. Only the editor count needed asking again, since nothing here tracks the caller's drafts.

## What changed

| Action | Editor count | Now |
|---|---|---|
| Approve | −1 for the author | **refreshed** |
| Send back for revision | net 0 | refreshed anyway |
| Approve deletion | — | unchanged |
| Keep (decline deletion) | — | unchanged |

Revision currently nets to zero — the draft goes back to the same author, so one item leaves review as another arrives in drafts — but the call site shouldn't depend on that coincidence. That's the same reasoning as #196, where a transition that looked net-zero for one badge turned out to move the other.

The two deletion actions are deliberately left alone: they act on **published** items, which are never in anyone's editor queue.

Refreshing only on success is deliberate and tested — a count refreshed away from an item still sitting in review would report that the approval worked.

## Withdraw — checked, already correct

`EditorView.withdraw()` calls `refreshBadges()`, which refreshes approvals when the user is an Admin, so the Approvals count does drop on withdraw. That landed in #196 along with a test asserting it; I re-ran it rather than just reading the code. No change needed.

## Tests

Two in `views.admin.spec.ts` — the refresh happens on approve, and does *not* happen when the approve call fails. Verified falsifiable: reverting the component fails the first.

Lint, 478 unit tests and `build` all green.