### PR TITLE
fix(web): update the editor badge when an edit dialog closes

### DIFF
--- a/src/web/src/components/common/EditContentButton.spec.ts
+++ b/src/web/src/components/common/EditContentButton.spec.ts
@@ -16,6 +16,8 @@ vi.mock('vue-router', async (orig) => {
 
 import EditContentButton from './EditContentButton.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useEditorQueueStore } from '@/stores/editorQueue'
+import { useApprovalsStore } from '@/stores/approvals'
 
 let pinia: Pinia
 
@@ -125,5 +127,45 @@ describe('EditContentButton', () => {
     await w.findComponent({ name: 'DraftEditor' }).vm.$emit('close')
     await flushPromises()
     expect(apiFetch).not.toHaveBeenCalledWith('/drafts/draft-9', { method: 'DELETE' })
+  })
+
+  // ── The Editor badge after editing from the page itself ────────────────────
+  // Same modal as the content manager: opening mints a revision draft, and both ways of
+  // closing move the editor count.
+
+  /// Open the modal on a published page, close it, and report whether the badge refreshed.
+  async function editThenClose(dirty: boolean) {
+    apiFetch.mockResolvedValue(created({ id: 'draft-9' }))
+    const w = mountBtn({}, { DraftEditor: dirtyEditor(dirty) })
+    await w.find('button').trigger('click')
+    await flushPromises()
+    const spy = vi.spyOn(useEditorQueueStore(pinia), 'refresh').mockResolvedValue(undefined)
+
+    await w.findComponent({ name: 'DraftEditor' }).vm.$emit('close')
+    await flushPromises()
+    return spy
+  }
+
+  it('refreshes the editor count when a changed edit is closed', async () => {
+    expect(await editThenClose(true)).toHaveBeenCalled()
+  })
+
+  it('refreshes the editor count when an untouched edit is closed', async () => {
+    expect(await editThenClose(false)).toHaveBeenCalled()
+  })
+
+  it('refreshes the badges when the revision is submitted', async () => {
+    apiFetch.mockResolvedValue(created({ id: 'draft-9' }))
+    const w = mountBtn({}, { DraftEditor: dirtyEditor(true) })
+    await w.find('button').trigger('click')
+    await flushPromises()
+    const editorSpy    = vi.spyOn(useEditorQueueStore(pinia), 'refresh').mockResolvedValue(undefined)
+    const approvalsSpy = vi.spyOn(useApprovalsStore(pinia), 'refresh').mockResolvedValue(undefined)
+
+    await w.findComponent({ name: 'DraftEditor' }).vm.$emit('submitted')
+    await flushPromises()
+
+    expect(editorSpy).toHaveBeenCalled()
+    expect(approvalsSpy).toHaveBeenCalled()
   })
 })

--- a/src/web/src/components/common/EditContentButton.vue
+++ b/src/web/src/components/common/EditContentButton.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { apiFetch, apiErrorMessage } from '@/lib/api'
 import { useAuthStore } from '@/stores/auth'
+import { useContentBadges } from '@/composables/useContentBadges'
 import DraftEditor from '@/components/editor/DraftEditor.vue'
 
 const props = withDefaults(defineProps<{
@@ -16,6 +17,7 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{ (e: 'submitted'): void }>()
 
 const auth = useAuthStore()
+const { refreshContentBadges } = useContentBadges()
 const router = useRouter()
 
 const editDraftId  = ref<string | null>(null)
@@ -60,12 +62,17 @@ async function closeEdit() {
     else try { await apiFetch(`/drafts/${id}`, { method: 'DELETE' }) } catch { /* best-effort */ }
   }
   editDraftId.value = null
+  // A flushed edit leaves a revision draft in the author's queue; the untouched case
+  // removes the one that opening this minted. Either way the Editor badge has moved.
+  refreshContentBadges()
 }
 
 // Submit consumes the draft server-side (it becomes an in-review revision), so
 // there is nothing to clean up.
 function submittedEdit() {
   editDraftId.value = null
+  // Consumed server-side into an in-review revision: out of the editor queue, into approvals.
+  refreshContentBadges()
   emit('submitted')
 }
 </script>

--- a/src/web/src/components/common/PublishedContent.spec.ts
+++ b/src/web/src/components/common/PublishedContent.spec.ts
@@ -13,6 +13,7 @@ import PublishedContent from './PublishedContent.vue'
 import { useAuthStore } from '@/stores/auth'
 import { DEV_PERSONA_STORAGE_KEY } from '@/lib/devPersonas'
 import { useApprovalsStore } from '@/stores/approvals'
+import { useEditorQueueStore } from '@/stores/editorQueue'
 
 const isDirtyMock = vi.fn(() => false)
 const flushMock = vi.fn().mockResolvedValue(undefined)
@@ -409,5 +410,65 @@ describe('PublishedContent', () => {
     await flushPromises()
 
     expect(spy).not.toHaveBeenCalled()
+  })
+
+  // ── The Editor badge after editing published content ───────────────────────
+  // Opening the editor mints a revision draft. Closing it either keeps that draft (there
+  // were changes to flush) or deletes it (there were not) — both move the editor count,
+  // and neither used to say so.
+
+  /// Open the edit dialog on one published item, close it, and report whether the badge
+  /// was asked to refresh. `dirty` picks which of the two close paths runs.
+  async function editThenClose(dirty: boolean) {
+    apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (url.endsWith('/edit') && method === 'POST') return Promise.resolve(ok({ id: 'draft-2' }))
+      if (method === 'GET') return Promise.resolve(ok([item()]))
+      return Promise.resolve(ok({}))
+    })
+    isDirtyMock.mockReturnValue(dirty)
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Edit')!.trigger('click')
+    await flushPromises()
+    const spy = vi.spyOn(useEditorQueueStore(pinia), 'refresh').mockResolvedValue(undefined)
+
+    await w.findComponent(DraftEditorStub).vm.$emit('close')
+    await flushPromises()
+    return spy
+  }
+
+  it('refreshes the editor count when a changed edit is closed', async () => {
+    // The reported case: the flushed draft stays in the queue, so the count went up and
+    // the badge did not.
+    expect(await editThenClose(true)).toHaveBeenCalled()
+  })
+
+  it('refreshes the editor count when an untouched edit is closed', async () => {
+    // The other branch deletes the draft that opening the editor minted, which moves the
+    // count back down.
+    expect(await editThenClose(false)).toHaveBeenCalled()
+  })
+
+  it('refreshes the badges when a revision is submitted from the content manager', async () => {
+    apiFetch.mockImplementation((url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      if (url.endsWith('/edit') && method === 'POST') return Promise.resolve(ok({ id: 'draft-2' }))
+      if (method === 'GET') return Promise.resolve(ok([item()]))
+      return Promise.resolve(ok({}))
+    })
+    const w = mountC()
+    await flushPromises()
+    await w.findAll('button').find(b => b.text() === 'Edit')!.trigger('click')
+    await flushPromises()
+    const editorSpy    = vi.spyOn(useEditorQueueStore(pinia), 'refresh').mockResolvedValue(undefined)
+    const approvalsSpy = vi.spyOn(useApprovalsStore(pinia), 'refresh').mockResolvedValue(undefined)
+
+    await w.findComponent(DraftEditorStub).vm.$emit('submitted')
+    await flushPromises()
+
+    // The draft became an in-review revision: out of one queue, into the other.
+    expect(editorSpy).toHaveBeenCalled()
+    expect(approvalsSpy).toHaveBeenCalled()
   })
 })

--- a/src/web/src/components/common/PublishedContent.vue
+++ b/src/web/src/components/common/PublishedContent.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { apiErrorMessage, apiFetch } from '@/lib/api'
 import { useAuthStore } from '@/stores/auth'
-import { useApprovalsStore } from '@/stores/approvals'
+import { useContentBadges } from '@/composables/useContentBadges'
 import DraftEditor from '@/components/editor/DraftEditor.vue'
 
 interface PublishedItem {
@@ -20,7 +20,7 @@ interface PublishedItem {
 }
 
 const auth = useAuthStore()
-const approvals = useApprovalsStore()
+const { refreshContentBadges } = useContentBadges()
 
 const items     = ref<PublishedItem[]>([])
 const loading   = ref(false)
@@ -138,6 +138,9 @@ async function closeEdit() {
     }
   }
   editDraftId.value = null
+  // Either branch moved the editor queue: a flushed edit leaves a revision draft behind,
+  // and the untouched case deletes the one that opening the editor minted.
+  refreshContentBadges()
   await load()
 }
 
@@ -145,6 +148,9 @@ async function closeEdit() {
 // just close and refresh — no draft to clean up.
 async function submittedEdit() {
   editDraftId.value = null
+  // The draft became an in-review revision, so it left the editor queue and joined the
+  // approvals one.
+  refreshContentBadges()
   await load()
 }
 
@@ -174,7 +180,7 @@ async function remove(item: PublishedItem) {
     }
     // Either branch moves the approvals count: an admin deleting clears any pending
     // request, a contributor requesting one adds to it.
-    if (auth.isAdmin) approvals.refresh()
+    refreshContentBadges()
   } catch (err) {
     errors.value = { ...errors.value, [item.id]: err instanceof Error ? err.message : String(err) }
   } finally {

--- a/src/web/src/composables/useContentBadges.ts
+++ b/src/web/src/composables/useContentBadges.ts
@@ -1,0 +1,34 @@
+import { useAuthStore } from '@/stores/auth'
+import { useEditorQueueStore } from '@/stores/editorQueue'
+import { useApprovalsStore } from '@/stores/approvals'
+
+/**
+ * The two nav badges — Editor and Approvals — are derived from server state, and AppNav only
+ * fetches them when it mounts. Anything that moves a document between drafts, review and
+ * published therefore has to say so, or the numbers in the account menu keep describing the
+ * moment the page loaded.
+ *
+ * Both are refreshed together on purpose. Deciding per call site which of the two a given
+ * transition moves has been wrong three times now, and wrong in the non-obvious direction:
+ * submitting and withdrawing leave the Editor count unchanged — the document just moves
+ * between drafts and review, and it counts both — while moving the Approvals count by one.
+ * Editing a published item is the mirror image: it mints a revision draft, so the Editor
+ * count moves and Approvals does not.
+ *
+ * Call this after the action has succeeded, never before. A stale count is wrong, but a count
+ * refreshed away from a document that is still there tells the user a failed action worked.
+ *
+ * Approvals is fetched only for an Admin, who is the only one with that badge.
+ */
+export function useContentBadges() {
+  const auth        = useAuthStore()
+  const editorQueue = useEditorQueueStore()
+  const approvals   = useApprovalsStore()
+
+  function refreshContentBadges() {
+    editorQueue.refresh()
+    if (auth.isAdmin) approvals.refresh()
+  }
+
+  return { refreshContentBadges }
+}

--- a/src/web/src/views/EditorView.vue
+++ b/src/web/src/views/EditorView.vue
@@ -6,15 +6,13 @@ import DraftEditor from '@/components/editor/DraftEditor.vue'
 import { apiErrorMessage, apiFetch, apiJson } from '@/lib/api'
 import { EMPTY_DRAFT, makeDraftId, type DraftPayload, type DraftSummary } from '@/lib/draft'
 import { useAuthStore } from '@/stores/auth'
-import { useEditorQueueStore } from '@/stores/editorQueue'
-import { useApprovalsStore } from '@/stores/approvals'
+import { useContentBadges } from '@/composables/useContentBadges'
 
 const DRAFT_ID_KEY = 'slypn:editor:draft-id'
 
 const auth = useAuthStore()
 const route = useRoute()
-const editorQueue = useEditorQueueStore()
-const approvals   = useApprovalsStore()
+const { refreshContentBadges } = useContentBadges()
 
 // ── Draft list ──────────────────────────────────────────────────────────────
 const allDrafts   = ref<DraftSummary[]>([])
@@ -115,16 +113,6 @@ const entries = computed<DraftEntry[]>(() => {
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 })
 
-// Both nav badges are derived from server state, so anything that moves a document
-// between drafts and review invalidates them. Refreshed together rather than at each
-// call site guessing which one it affected: submitting and withdrawing leave the editor
-// count unchanged while moving the approvals count, which is exactly the pairing that
-// gets missed. Approvals only for an Admin — nobody else has that badge.
-function refreshBadges() {
-  editorQueue.refresh()
-  if (auth.isAdmin) approvals.refresh()
-}
-
 // ── Open draft (DraftEditor owns the editing surface) ────────────────────────
 const draftId         = ref<string>('')
 const editorOpen      = ref(false)
@@ -187,7 +175,7 @@ function onSubmitted(id: string) {
   editorOpen.value = false
   submitMessage.value = 'Submitted for admin review.'
   loadPending()
-  refreshBadges()
+  refreshContentBadges()
 }
 
 // ── New draft dialog ─────────────────────────────────────────────────────────
@@ -215,7 +203,7 @@ async function createDraft() {
   } catch { /* DraftEditor autosave will retry */ }
 
   allDrafts.value.unshift({ id, title, type: newType.value, updatedAt: new Date().toISOString() })
-  refreshBadges()
+  refreshContentBadges()
   showNewDraft.value  = false
   submitMessage.value = null
   draftId.value       = id
@@ -235,7 +223,7 @@ async function deleteDraft(id: string, etag?: string) {
     if (!resp.ok) { deleteError.value = `${resp.status} ${await resp.text().catch(() => '')}`; return }
     allDrafts.value = allDrafts.value.filter(d => d.id !== id)
     if (draftId.value === id) { editorOpen.value = false; localStorage.removeItem(DRAFT_ID_KEY) }
-    refreshBadges()
+    refreshContentBadges()
   } catch (err) {
     deleteError.value = err instanceof Error ? err.message : String(err)
   }
@@ -262,7 +250,7 @@ async function withdraw(id: string) {
     allDrafts.value = [draft, ...allDrafts.value.filter(d => d.id !== draft.id)]
     if (draftId.value === id) { editorOpen.value = false; readonlyContent.value = null }
     submitMessage.value = 'Withdrawn from review — it is back in your drafts.'
-    refreshBadges()
+    refreshContentBadges()
   } catch (err) {
     withdrawError.value = err instanceof Error ? err.message : String(err)
   } finally {


### PR DESCRIPTION
Editing a published item — from the content manager or the edit affordance on the page itself — mints a revision draft up front. Closing the dialog then either **keeps** that draft (there were changes to flush) or **deletes** it (there were none). Both move the editor count, and neither said so, so the badge kept showing whatever it was before the edit.

Submitting from either dialog was wrong in the other direction: the draft is consumed server-side into an in-review revision, so it leaves the editor queue and joins the approvals one — and neither badge was told.

| Path | Moves | Refreshed before |
|---|---|---|
| Close a changed edit | Editor +1 | nothing |
| Close an untouched edit | Editor −1 (the minted draft is deleted) | nothing |
| Submit the revision | Editor −1, Approvals +1 | nothing |

Four call sites across two components, both entry points the report named.

## One rule, one place

This is the third round of a call site forgetting a badge (#196, #199, this), so the rule now lives in `useContentBadges` rather than being restated per component. It refreshes both together and records *why* guessing per site keeps going wrong:

> submitting and withdrawing leave the Editor count unchanged — the document just moves between drafts and review, and it counts both — while moving Approvals by one. Editing a published item is the mirror image.

`EditorView` and `PublishedContent` now use it in place of their own copies of that logic, so this also removes duplication rather than adding more.

## What I deliberately did not do

I first added a refresh to `EditorView`'s `onMounted` and it broke two existing tests that assert `apiFetch` is never called on a no-op. They were right to fail: navigation to `/editor` from the edit affordance happens only on a **200**, which means work already existed and was already counted — and the page fetches the same three endpoints the store does, so a mount refresh would duplicate every request for no gain. Removed. That's what those guard tests are for.

## Tests

Three in `PublishedContent.spec` and three in `EditContentButton.spec`, covering both close paths and submit on each. **All six verified falsifiable** against the pre-fix components — I committed first this time so the revert couldn't clobber uncommitted work.

487 passing, lint and build clean.