### PR TITLE
fix(web): autosave only when the content actually changed

### DIFF
--- a/src/web/src/components/editor/DraftEditor.spec.ts
+++ b/src/web/src/components/editor/DraftEditor.spec.ts
@@ -268,4 +268,82 @@ describe('DraftEditor', () => {
     await w.find('[data-testid="draft-type-blog"]').trigger('click')
     expect(w.find('[data-testid="draft-type-blog"]').classes().join(' ')).toContain('bg-slypn-600')
   })
+
+  // ── Autosave writes only what changed ──────────────────────────────────────
+  // The debounce watcher fires on any change to the draft object, which is not the same as
+  // the content differing from what is stored. Loading a draft replaces the object wholesale,
+  // so opening a second draft used to PUT the freshly loaded content straight back.
+
+  const puts = () => apiFetch.mock.calls.filter(c => c[1]?.method === 'PUT')
+
+  it('does not save after switching drafts with no typing', async () => {
+    vi.useFakeTimers()
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+    await w.setProps({ draftId: 'd2' })
+    await flushPromises()
+    apiFetch.mockClear()
+
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+
+    expect(puts()).toHaveLength(0)
+    vi.useRealTimers()
+  })
+
+  it('does not save a change that was undone inside the debounce window', async () => {
+    vi.useFakeTimers()
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+    apiFetch.mockClear()
+
+    await w.find('#draft-title').setValue('My draft edited')
+    await vi.advanceTimersByTimeAsync(500)      // still within the 1.5s
+    await w.find('#draft-title').setValue('My draft')  // back to what was loaded
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+
+    expect(puts()).toHaveLength(0)
+    vi.useRealTimers()
+  })
+
+  it('still saves a real change', async () => {
+    vi.useFakeTimers()
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+    apiFetch.mockClear()
+
+    await w.find('#draft-title').setValue('Genuinely different')
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+
+    expect(puts()).toHaveLength(1)
+    vi.useRealTimers()
+  })
+
+  it('saves an undo that comes after a save, rather than leaving the server ahead', async () => {
+    // The trap in comparing against what was loaded: once an edit is written, going back to
+    // the original is itself a change the server has not seen. The snapshot moves on every
+    // successful save so this stays dirty.
+    vi.useFakeTimers()
+    mockApi()
+    const w = mountEditor()
+    await flushPromises()
+    apiFetch.mockClear()
+
+    await w.find('#draft-title').setValue('Edited')
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+    expect(puts()).toHaveLength(1)
+
+    await w.find('#draft-title').setValue('My draft')  // back to the originally loaded title
+    await vi.advanceTimersByTimeAsync(2000)
+    await flushPromises()
+
+    expect(puts()).toHaveLength(2)   // the undo is persisted too
+    vi.useRealTimers()
+  })
 })

--- a/src/web/src/components/editor/DraftEditor.vue
+++ b/src/web/src/components/editor/DraftEditor.vue
@@ -87,8 +87,22 @@ async function loadDraft(id: string) {
   }
 }
 
-async function save(value: DraftPayload) {
+/// `force` writes even when nothing changed. Submitting uses it: the PUT is also the ETag
+/// check, and it is how a draft edited in another tab surfaces as a 412 rather than being
+/// submitted over silently. The autosave and the flush-before-close have no such need.
+async function save(value: DraftPayload, { force = false } = {}) {
   if (props.readonly || switching.value || !value.title.trim()) return
+
+  // Nothing to write. The autosave watcher fires on any change to the draft object, which is
+  // not the same as the content differing from what is stored: loadDraft replaces the object
+  // wholesale, so opening a second draft used to PUT the freshly loaded content straight back
+  // a second and a half later, and a keystroke undone inside one debounce window wrote a copy
+  // of what was already there.
+  //
+  // Compared against the last thing loaded *or written*, not just loaded — the snapshot moves
+  // on every successful save below. Without that, typing, saving, then undoing would look
+  // clean and quietly leave the server holding the edit the author had just taken back.
+  if (!force && snapshot(value) === loadedSnapshot.value) return
 
   // A backstop: the editor refuses input at the limit, so this should only be reachable
   // for content that arrived over it (an older draft, or a write through the API). Caught
@@ -121,6 +135,10 @@ async function save(value: DraftPayload) {
   }
   if (!resp.ok) throw new Error(await apiErrorMessage(resp))
   currentEtag.value = resp.headers.get('ETag') ?? currentEtag.value
+  // What the server now holds. Taken from the payload that was sent rather than draft.value,
+  // which may have moved on during the request — if it did, the watcher has already scheduled
+  // the next save, and it will compare against this and find itself dirty.
+  loadedSnapshot.value = snapshot(value)
   emit('saved', {
     id: props.draftId,
     title: value.title,
@@ -142,7 +160,7 @@ async function submitForReview() {
   submitNotice.value = null
   submitting.value  = true
   try {
-    await save(draft.value)
+    await save(draft.value, { force: true })
     const resp = await apiFetch(`/drafts/${props.draftId}/submit`, { method: 'POST' })
     if (resp.status === 409) {
       submitNotice.value = await resp.text()


### PR DESCRIPTION
Answering "does autosave only fire on a real change?" — it didn't. The debounce watcher fires on any change to the draft *object*, which isn't the same as the content differing from what's stored.

Two consequences, both confirmed by probe rather than by reading:

- **Switching drafts wrote the loaded content straight back.** `loadDraft` replaces `draft.value` wholesale, which the deep watcher counts as a change. `skipInitial` only suppresses the very first fire ever (`firstFire` is a one-shot flag), and `switching` couldn't help — it's cleared in a `finally`, long before the 1.5s timer runs. Opening a second draft and not typing produced exactly one PUT, same as typing once.
- **A keystroke undone inside the window still wrote.** Type a character, delete it, and 1.5s later you got a PUT of content identical to what was already there.

## The fix

`save()` compares a snapshot of the payload against the last thing loaded *or written*, reusing the `snapshot`/`isDirty` pair the close paths already rely on.

The "or written" half matters. The snapshot advances on every successful save, so an undo that comes *after* a save is still dirty and still persists. Comparing only against the load would make it look clean and quietly leave the server holding an edit the author had just taken back. There's a test named for that case.

## Submit deliberately still writes

Gating `save()` broke two existing tests, and they were right to fail. The PUT before a submit is also the **ETag check** — it's how a draft edited in another tab surfaces as a 412 conflict banner instead of being submitted over in silence. So `submitForReview` passes an explicit `force` flag.

`flush()` stays gated, and that's deliberate: `EditorView` flushes unconditionally before switching drafts, which is where the redundant write came from.

| Path | Writes when unchanged? |
|---|---|
| Autosave (1.5s debounce) | no |
| `flush()` before switch/close | no |
| Submit for review | **yes** — the PUT is the conflict check |

## Tests

Four in `DraftEditor.spec`: no save after switching drafts, none for a change undone in the window, a real change still saves, and the undo-after-save case. The two negative ones are verified falsifiable against the ungated component; the two positive ones pass either way by design, guarding against over-correcting into "never saves".

491 unit tests, lint and build green, plus the revision and lifecycle e2e specs (14 tests) against a live API.