### PR TITLE
feat(web): report which article is being read, not just that one was

### DIFF
--- a/src/web/src/composables/useContentView.test.ts
+++ b/src/web/src/composables/useContentView.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { defineComponent, ref, h, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+
+const { getFaro } = vi.hoisted(() => ({ getFaro: vi.fn() }))
+vi.mock('@/lib/faro', () => ({ getFaro }))
+
+import { useContentView, type TrackedContent } from './useContentView'
+
+const pushEvent = vi.fn()
+
+/** Mount a component that tracks the ref it is handed, so watchers run in a real scope. */
+function track(item: ReturnType<typeof ref<TrackedContent | null>>) {
+  return mount(defineComponent({
+    setup() {
+      useContentView(item, 'article')
+      return () => h('div')
+    },
+  }))
+}
+
+beforeEach(() => {
+  pushEvent.mockReset()
+  getFaro.mockReturnValue({ api: { pushEvent } })
+})
+
+describe('useContentView', () => {
+  it('reports the slug, title and category of the item on screen', async () => {
+    track(ref<TrackedContent | null>({ slug: 'a-slug', title: 'A Title', category: 'Community' }))
+    await nextTick()
+
+    expect(pushEvent).toHaveBeenCalledWith('content_viewed', expect.objectContaining({
+      content_slug: 'a-slug',
+      content_title: 'A Title',
+      content_category: 'Community',
+    }))
+  })
+
+  it('reports a new view when prev/next swaps the item in place', async () => {
+    // The detail views refresh without remounting, so a mount-time hook would report the
+    // first article of a series and nothing after it.
+    const item = ref<TrackedContent | null>({ slug: 'first' })
+    track(item)
+    await nextTick()
+
+    item.value = { slug: 'second' }
+    await nextTick()
+
+    expect(pushEvent).toHaveBeenCalledTimes(2)
+    expect(pushEvent.mock.calls[1][1]).toMatchObject({ content_slug: 'second' })
+  })
+
+  it('does not report the same item twice when it is re-fetched', async () => {
+    const item = ref<TrackedContent | null>({ slug: 'same', title: 'Same' })
+    track(item)
+    await nextTick()
+
+    item.value = { slug: 'same', title: 'Same' }   // a retry or manual refresh
+    await nextTick()
+
+    expect(pushEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('says nothing while the item is still loading', async () => {
+    track(ref<TrackedContent | null>(null))
+    await nextTick()
+    expect(pushEvent).not.toHaveBeenCalled()
+  })
+
+  it('prefers the item’s own type, so a mirrored blog post is not filed as an article', async () => {
+    track(ref<TrackedContent | null>({ slug: 's', type: 'blog' }))
+    await nextTick()
+
+    expect(pushEvent.mock.calls[0][1]).toMatchObject({ content_kind: 'blog' })
+  })
+
+  it('is inert without telemetry consent', async () => {
+    // getFaro() stays null until the cookie banner is accepted.
+    getFaro.mockReturnValue(null)
+    track(ref<TrackedContent | null>({ slug: 'a-slug' }))
+    await nextTick()
+
+    expect(pushEvent).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/src/composables/useContentView.ts
+++ b/src/web/src/composables/useContentView.ts
@@ -1,0 +1,57 @@
+import { watch, type Ref } from 'vue'
+import { getFaro } from '@/lib/faro'
+
+/**
+ * The fields a tracked item may carry. Every one is optional because the four content types
+ * do not share a shape — a newsletter has no slug, an event has no category — and a missing
+ * dimension should narrow the reporting rather than drop the event.
+ */
+export interface TrackedContent {
+  id?: string
+  slug?: string
+  title?: string
+  type?: string
+  category?: string
+}
+
+/**
+ * Report *which* piece of content is on screen, not just that a detail page was opened.
+ *
+ * Faro's own view tracking is keyed on the route name, so every article arrives as
+ * `view_name=article-detail`. The identity is technically recoverable from `page_url`, but
+ * only by parsing a slug out of a URL — and prod currently serves from more than one
+ * hostname, so the same article splits across several `page_url` values and has to be
+ * stitched back together in every query. This emits the slug and title as their own
+ * dimensions instead, which is both cheaper to query and stable across hostnames.
+ *
+ * Keyed on the item rather than on mount, deliberately. The detail views refresh in place
+ * when the prev/next links change the route param, so the component is not re-created and a
+ * mount-time hook would miss every step through a series.
+ *
+ * Inert without telemetry consent: getFaro() returns null until the visitor accepts the
+ * cookie banner, so this reports nothing and costs nothing until then.
+ */
+export function useContentView(
+  item: Ref<TrackedContent | null | undefined>,
+  kind: 'article' | 'blog' | 'newsletter' | 'event',
+) {
+  // One event per distinct item. Without this, any re-fetch of the same content — a manual
+  // refresh, a retry after an error — would report a second view nobody made.
+  let lastReported = ''
+
+  watch(item, (value) => {
+    if (!value) return
+    const key = value.slug || value.id
+    if (!key || key === lastReported) return
+    lastReported = key
+
+    getFaro()?.api.pushEvent('content_viewed', {
+      // The item's own type where it has one: a blog post is an article row with
+      // type="blog", so trusting the calling view would mislabel a mirrored item.
+      content_kind:     value.type || kind,
+      content_slug:     key,
+      content_title:    value.title ?? '',
+      content_category: value.category ?? '',
+    })
+  }, { immediate: true })
+}

--- a/src/web/src/views/ArticleDetailView.vue
+++ b/src/web/src/views/ArticleDetailView.vue
@@ -3,6 +3,7 @@ import { computed, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { apiFetch } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
+import { useContentView } from '@/composables/useContentView'
 import type { Article } from '@/types/content'
 import EditContentButton from '@/components/common/EditContentButton.vue'
 
@@ -24,6 +25,9 @@ const { data: article, loading, error, refresh } = useAsyncData(async () => {
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`)
   return resp.json() as Promise<Article>
 })
+
+// Which piece of content, not just that a detail page was opened.
+useContentView(article, 'article')
 
 watch(slug, refresh)
 

--- a/src/web/src/views/BlogDetailView.vue
+++ b/src/web/src/views/BlogDetailView.vue
@@ -3,6 +3,7 @@ import { computed, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { apiFetch } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
+import { useContentView } from '@/composables/useContentView'
 import type { Article } from '@/types/content'
 import EditContentButton from '@/components/common/EditContentButton.vue'
 
@@ -24,6 +25,9 @@ const { data: post, loading, error, refresh } = useAsyncData(async () => {
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`)
   return resp.json() as Promise<Article>
 })
+
+// Which piece of content, not just that a detail page was opened.
+useContentView(post, 'blog')
 
 watch(slug, refresh)
 

--- a/src/web/src/views/EventDetailView.vue
+++ b/src/web/src/views/EventDetailView.vue
@@ -3,6 +3,7 @@ import { computed, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
+import { useContentView } from '@/composables/useContentView'
 import type { CommunityEvent } from '@/types/content'
 
 const route  = useRoute()
@@ -23,6 +24,9 @@ function backToEvents() {
 const { data: event, loading, error, refresh } = useAsyncData(
   () => apiJson<CommunityEvent>(`/events/${route.params.id}`),
 )
+
+// Which piece of content, not just that a detail page was opened.
+useContentView(event, 'event')
 
 watch(() => route.params.id, refresh)
 

--- a/src/web/src/views/NewsletterDetailView.vue
+++ b/src/web/src/views/NewsletterDetailView.vue
@@ -4,6 +4,7 @@ import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { renderAsync } from 'docx-preview'
 import { apiFetch, apiJson } from '@/lib/api'
 import { useAsyncData } from '@/composables/useAsyncData'
+import { useContentView } from '@/composables/useContentView'
 import type { Newsletter } from '@/types/content'
 
 const route = useRoute()
@@ -40,6 +41,9 @@ const { data: newsletter, loading, error, refresh: refreshMeta } = useAsyncData(
   const list = await apiJson<Newsletter[]>('/newsletters')
   return list.find(n => n.id === route.params.id) ?? null
 }, { lazy: true })
+
+// Which piece of content, not just that a detail page was opened.
+useContentView(newsletter, 'newsletter')
 
 type FileKind = 'pdf' | 'docx' | 'unsupported'
 


### PR DESCRIPTION
Faro's view tracking is keyed on the route name, so every article arrives as `view_name=article-detail`. The reporting can say how many article pages were opened, but not which articles.

## Why not just parse the URL

The identity is *already* in the data â€” `page_url` carries the slug. But recovering it means parsing a slug out of a URL, and prod currently serves from **three hostnames**:

- `slypn.cookingcode.com`
- `orange-hill-0f65dde03.7.azurestaticapps.net`
- `thankful-tree-090006c03.7.azurestaticapps.net`

So one article splits across several `page_url` values and has to be stitched back together in every query â€” "telling-your-employer" is currently 54 + 5 + 3 across three hosts. Emitting the slug and title as their own dimensions is cheaper to query and stable across hostnames.

## What this adds

`useContentView` pushes a `content_viewed` event carrying `content_slug`, `content_title`, `content_kind` and `content_category`, wired into the article, blog, newsletter and event detail views. One composable rather than four near-identical watchers.

Two design points that aren't obvious:

**Keyed on the item, not on mount.** The detail views refresh in place when the prev/next links change the route param â€” `ArticleDetailView` does `watch(slug, refresh)` and is never re-created. A mount-time hook would report the first item of a series and nothing after it.

**De-duplicated.** A retry after an error, or a manual refresh, re-resolves the same content; without a guard that would report a view nobody made.

## Privacy

Inert without consent â€” `getFaro()` returns null until the visitor accepts the cookie banner, so this reports nothing and costs nothing until then. Only public content fields are sent: no identifiers, no PII.

## Querying it afterwards

```logql
topk(10, sum by (content_title) (count_over_time(
  {service_name="slypn-web", deployment_environment="prod", kind="event"}
  | logfmt | event_name="content_viewed" [30d])))
```

## Tests

Six in `useContentView.test.ts`: the reported dimensions, the prev/next swap, the re-fetch de-duplication, the still-loading case, a mirrored blog post keeping its own `type` rather than the calling view's, and the no-consent case.

497 passing, lint and build clean.

---

**Separately, on the three hostnames — I checked, and my first reading was wrong.**

There is only **one** slypn Static Web App: `swa-slypn-prod` in `rg-slypn-prod`, default host `orange-hill-0f65dde03.7.azurestaticapps.net`, with `slypn.cookingcode.com` bound to it (status Ready). Two of the three hostnames are that same app — its default host and its custom domain — so nothing is misconfigured.

`thankful-tree-090006c03.7.azurestaticapps.net` is a **retired** app: it is not in the subscription, and it has sent no telemetry in the last 14 days. Its rows are historical, from before the current SWA.

So this is not several apps taking production deploys. It is one app reachable under two names, which is normal — and that still argues for this PR, since a single article legitimately splits across both.
