### PR TITLE
fix(ci): let the Pages workflow enable Pages itself

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,8 +40,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # enablement: true turns Pages on if it is off, rather than failing with
+      # "Get Pages site failed". Without it the first run on a repo (or a fork)
+      # needs someone to flip Settings -> Pages -> Source: GitHub Actions by
+      # hand, which is exactly what broke run 33825190324.
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+        with:
+          enablement: true
 
       # Only presentation/ is uploaded, so index.html lands at the site root.
       - name: Upload deck


### PR DESCRIPTION
The first Pages publish on `main` after #203 failed at **Configure Pages**:

```
Get Pages site failed. Please verify that the repository has Pages enabled
and configured to build using GitHub Actions...
HttpError: Not Found
```

`actions/configure-pages` does not enable Pages by default, so the very first run needs someone to flip **Settings → Pages → Source: GitHub Actions** manually. Setting `enablement: true` lets the workflow provision the site itself.

Two reasons that's better than leaving it manual:

- A fork or a fresh clone gets a working Pages deploy with no out-of-band setup step.
- The failure mode is silent-ish — the deck simply never publishes, while every other check on the PR is green.

The existing `permissions: pages: write` is sufficient; no permission change needed.

I've also enabled Pages on this repo directly and re-run the failed job, so the deck is publishing at <https://sinclapa.github.io/slypn/> without waiting for this to merge. This change is about stopping it happening again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
